### PR TITLE
Add a date step generator

### DIFF
--- a/lib/generators/step/USAGE
+++ b/lib/generators/step/USAGE
@@ -13,6 +13,7 @@ Description:
 Examples:
     rails generate step Appeal DisputeType
     rails generate step Petition Protection --type=question
+    rails generate step Petition OrderDate --type=date
     rails generate step Screener Done --type=show
 
     This will create:

--- a/lib/generators/step/step_generator.rb
+++ b/lib/generators/step/step_generator.rb
@@ -8,7 +8,8 @@ class StepGenerator < Rails::Generators::Base
   TYPE_TEMPLATES = {
     show: 'show.html.erb',
     edit: 'edit.html.erb',
-    question: 'edit.html.erb'
+    question: 'edit.html.erb',
+    date: 'edit.html.erb',
   }.freeze
 
   def validate_options!
@@ -35,7 +36,7 @@ class StepGenerator < Rails::Generators::Base
     case type
     when :show
       add_to_routes("show_step :#{step_name.underscore}")
-    when :edit, :question
+    else
       add_to_routes("edit_step :#{step_name.underscore}")
     end
   end

--- a/lib/generators/step/templates/date/controller.rb
+++ b/lib/generators/step/templates/date/controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module <%= task_name.camelize %>
+    class <%= step_name.camelize %>Controller < Steps::<%= task_name.camelize %>StepController
+      def edit
+        @form_object = <%= step_name.camelize %>Form.new(
+          disclosure_check: current_disclosure_check,
+          <%= step_name.underscore  %>: current_disclosure_check.<%= step_name.underscore %>
+        )
+      end
+
+      def update
+        update_and_advance(<%= step_name.camelize %>Form, as: :<%= step_name.underscore.to_sym %>)
+      end
+    end
+  end
+end

--- a/lib/generators/step/templates/date/controller_spec.rb
+++ b/lib/generators/step/templates/date/controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::<%= task_name.camelize %>::<%= step_name.camelize %>Controller, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::<%= task_name.camelize %>::<%= step_name.camelize %>Form, <%= task_name.camelize %>DecisionTree
+end

--- a/lib/generators/step/templates/date/edit.html.erb
+++ b/lib/generators/step/templates/date/edit.html.erb
@@ -1,0 +1,17 @@
+<%% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%%= step_header %>
+
+    <h1 class="heading-xlarge gv-u-heading-xxlarge"><%%=t '.heading' %></h1>
+
+    <p class="lede gv-u-text-lede"><%%=t '.lead_text' %></p>
+
+    <%%= step_form @form_object do |f| %>
+      <%%= f.gov_uk_date_field :<%= step_name.underscore %>, placeholders: true %>
+
+      <%%= f.continue_button %>
+    <%% end %>
+  </div>
+</div>

--- a/lib/generators/step/templates/date/form.rb
+++ b/lib/generators/step/templates/date/form.rb
@@ -1,0 +1,23 @@
+module Steps
+  module <%= task_name.camelize %>
+    class <%= step_name.camelize %>Form < BaseForm
+      include GovUkDateFields::ActsAsGovUkDate
+
+      attribute :<%= step_name.underscore %>, Date
+
+      acts_as_gov_uk_date :<%= step_name.underscore %>
+
+      validates_presence_of :<%= step_name.underscore %>
+
+      private
+
+      def persist!
+        raise DisclosureCheckNotFound unless disclosure_check
+
+        disclosure_check.update(
+          <%= step_name.underscore %>: <%= step_name.underscore %>
+        )
+      end
+    end
+  end
+end

--- a/lib/generators/step/templates/date/form_spec.rb
+++ b/lib/generators/step/templates/date/form_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe Steps::<%= task_name.camelize %>::<%= step_name.camelize %>Form do
+  let(:arguments) { {
+    disclosure_check: disclosure_check,
+    <%= step_name.underscore %>: <%= step_name.underscore %>
+  } }
+  let(:disclosure_check) { instance_double(DisclosureCheck) }
+  let(:<%= step_name.underscore %>) { 3.months.ago.to_date } # Change accordingly!
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    it { should validate_presence_of(:<%= step_name.underscore %>) }
+
+    context 'when no disclosure_check is associated with the form' do
+      let(:disclosure_check) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::DisclosureCheckNotFound)
+      end
+    end
+
+    context 'date validation' do
+      context 'when date is not given' do
+        let(:<%= step_name.underscore %>) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:<%= step_name.underscore %>, :blank)).to eq(true)
+        end
+      end
+
+      xcontext 'when date is invalid' do
+        # Implement as needed
+      end
+
+      xcontext 'when date is in the future' do
+        # Implement as needed
+      end
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(disclosure_check).to receive(:update).with(
+          <%= step_name.underscore %>: 3.months.ago.to_date
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In a similar way to the other steps generators, this will generate a
form prepared to take a date input.