### PR TITLE
Update `gov_uk_date_fields` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.6.1'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'govuk_elements_form_builder', '~> 1.3.0'
-gem 'gov_uk_date_fields', git: 'git@github.com:ministryofjustice/gov_uk_date_fields.git', branch: 'govuk-frontend-v4'
+gem 'gov_uk_date_fields', '~> 4.0.0'
 gem 'jquery-rails'
 gem 'pg', '~> 1.0.0'
 gem 'puma', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: git@github.com:ministryofjustice/gov_uk_date_fields.git
-  revision: 153f60aae23feb42ead432639f4259a1bc1410c0
-  branch: govuk-frontend-v4
-  specs:
-    gov_uk_date_fields (4.0.0)
-      rails (>= 5.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -127,6 +119,8 @@ GEM
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gov_uk_date_fields (4.0.0)
+      rails (>= 5.0)
     govuk_elements_form_builder (1.3.0)
       govuk_elements_rails (>= 3.0.0)
       govuk_frontend_toolkit (>= 6.0.0)
@@ -345,7 +339,7 @@ DEPENDENCIES
   cucumber
   cucumber-rails
   dotenv-rails
-  gov_uk_date_fields!
+  gov_uk_date_fields (~> 4.0.0)
   govuk_elements_form_builder (~> 1.3.0)
   i18n-debug
   jquery-rails


### PR DESCRIPTION
The version 4.0.0 of the `gov_uk_date_fields` gem has been published, with support for the new design system.

https://github.com/ministryofjustice/gov_uk_date_fields/releases/tag/v4.0.0

We can use Rubygems instead of pointing directly to the repository.