### PR TITLE
add caution result page

### DIFF
--- a/app/controllers/steps/caution/result_controller.rb
+++ b/app/controllers/steps/caution/result_controller.rb
@@ -1,0 +1,15 @@
+module Steps
+  module Caution
+    class ResultController < Steps::CautionStepController
+      before_action :set_presenter
+
+      def show; end
+
+      private
+
+      def set_presenter
+        @presenter = CautionResultPresenter.new(current_disclosure_check)
+      end
+    end
+  end
+end

--- a/app/presenters/caution_result_presenter.rb
+++ b/app/presenters/caution_result_presenter.rb
@@ -1,0 +1,24 @@
+class CautionResultPresenter
+  attr_reader :disclosure_check
+  QuestionAnswerRow = Struct.new(:question, :value)
+
+  def initialize(disclosure_check)
+    @disclosure_check = disclosure_check
+  end
+
+  def summary
+    caution_questions.map do |item|
+      next if disclosure_check[item].nil?
+
+      QuestionAnswerRow.new(item, disclosure_check[item])
+    end
+  end
+
+  def expiry_date
+    ExpiryDateCalculator.new(disclosure_check: disclosure_check).expiry_date
+  end
+
+  def caution_questions
+    [:kind, :caution_date, :under_age, :caution_date].freeze
+  end
+end

--- a/app/services/caution_decision_tree.rb
+++ b/app/services/caution_decision_tree.rb
@@ -26,7 +26,11 @@ class CautionDecisionTree < BaseDecisionTree
   def after_caution_type
     return edit(:conditional_end_date) if CautionType.new(disclosure_check.caution_type).conditional?
 
-    home
+    result
+  end
+
+  def result
+    show(:result)
   end
 
   def home

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -69,6 +69,8 @@
           </li>
         </ul>
       </div>
+
+
     </div>
   </main>
 </div>

--- a/app/views/steps/caution/result/shared/_row.html.erb
+++ b/app/views/steps/caution/result/shared/_row.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    <%=t "caution_results_html.#{row.question}.question" %>
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <%=t "caution_results_html.#{row.question}.answers.#{row.value}", default: row.value %>
+  </dd>
+</div>

--- a/app/views/steps/caution/result/show.html.erb
+++ b/app/views/steps/caution/result/show.html.erb
@@ -1,0 +1,44 @@
+<% title 'Check when your criminal record expires' %>
+
+<div class="govuk-width-container">
+  <%= step_header %>
+
+  <main class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <div class="govuk-panel govuk-panel--confirmation">
+          <h1 class="govuk-panel__title">
+            Your caution expired on <%=  l(@presenter.expiry_date) %>
+          </h1>
+          <div class="govuk-panel__body">
+            You do not need to tell anyone about the caution unless an <a class="govuk-link" href="https://www.gov.uk/exoffenders-and-employment?#when-employers-still-need-to-know-about-your-conviction">exception applies</a>.
+          </div>
+        </div>
+
+        <h2 class="govuk-heading-m">How this date has been worked out</h2>
+
+        <p class="govuk-body">The expiry date of your caution is based on:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>the information you’ve provided</li>
+          <li>the current law on when cautions and convictions expire</li>
+        </ul>
+
+        <p class="govuk-body">
+          This table shows the information you provided, which was used to work out the expiry date. If you entered any incorrect information, the expiry date will be incorrect.
+        </p>
+
+        <dl class="govuk-summary-list">
+          <%= render partial: 'steps/caution/result/shared/row',
+                     collection: @presenter.summary, as: :row %>
+        </dl>
+
+        <p class="govuk-body">
+          If you need to change any information, or if you have another caution or conviction you’d like to check, <a href="/">use the service again</a>.
+        </p>
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,11 @@ en:
   shared:
     back_link: Back
 
+  date:
+    formats:
+      default: '%d %B %Y'
+      long: '%d %B %y'
+
   errors:
     format: "%{message}"
     page_title_prefix: 'Error: '
@@ -72,7 +77,7 @@ en:
       steps_caution_caution_type_form:
         caution_type: What type of caution did you get?
       steps_caution_condition_complied_form:
-        condition_complied: Did you stick to the conditions of the caution? 
+        condition_complied: Did you stick to the conditions of the caution?
 
     label:
       steps_check_kind_form:
@@ -152,12 +157,34 @@ en:
       caution_type:
         edit:
           page_title: Caution types
-      condition_complied: 
+      condition_complied:
         edit:
           page_title: Conditions complied
           heading: Did you stick to the conditions of the caution?
           inset_text_heading: If no is selected
-          inset_text_paragraph_one: Breaking the conditions of a caution usually leads to prosecution. 
+          inset_text_paragraph_one: Breaking the conditions of a caution usually leads to prosecution.
           inset_text_paragraph_two: If you were convicted of an offence after breaking the conditions of your caution, you’ll need to start again and select conviction instead of caution.
 
-
+  caution_results_html:
+    kind:
+      question: Criminal record type
+      answers:
+        caution: Caution
+        conviction: Conviction
+    caution_date:
+      question: 'Date caution given:'
+      answers:
+        caution: Caution
+        conviction: Conviction
+    under_age:
+      question: 'Age at time of caution:'
+      answers:
+       'yes': Under 18
+       'no': 18 or over
+    caution_type:
+      question: 'Type of caution:'
+      answers:
+        simple_caution: Simple caution
+        conditional_caution: Conditional caution
+        youth_simple_caution: Youth Simple caution
+        youth_conditional_caution: Youth Conditional caution

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
       edit_step :caution_type
       edit_step :conditional_end_date
       edit_step :condition_complied
+      show_step :result
     end
 
     namespace :conviction do

--- a/spec/controllers/steps/caution/result_controller_spec.rb
+++ b/spec/controllers/steps/caution/result_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Caution::ResultController, type: :controller do
+
+  describe '#show' do
+    let(:disclosure_check) { build(:disclosure_check) }
+    let(:caution_result_presenter) { CautionResultPresenter.new(disclosure_check) }
+
+    before do
+      allow(controller).to receive(:current_disclosure_check).and_return(disclosure_check)
+    end
+
+    it 'assigns the presenter' do
+      allow(CautionResultPresenter).to receive(:new).with(disclosure_check).and_return(caution_result_presenter)
+
+      get :show
+      expect(response).to render_template(:show)
+      expect(assigns[:presenter]).to eq(caution_result_presenter)
+    end
+
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -116,12 +116,12 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context 'for a blank value' do
       let(:value) { '' }
-      it { expect(title).to eq('Disclosure Checker - GOV.UK') }
+      it { expect(title).to eq('Check if you need to disclose your criminal record - GOV.UK') }
     end
 
     context 'for a provided value' do
       let(:value) { 'Test page' }
-      it { expect(title).to eq('Test page - Disclosure Checker - GOV.UK') }
+      it { expect(title).to eq('Test page - Check if you need to disclose your criminal record - GOV.UK') }
     end
   end
 

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe CautionResultPresenter do
+  subject { described_class.new(disclosure_check) }
+
+  let(:disclosure_check) { build(:disclosure_check) }
+
+  describe '#caution_questions' do
+    it { expect(subject.caution_questions).to eq( [:kind, :caution_date, :under_age, :caution_date]) }
+  end
+
+  describe '#summary' do
+    let(:summary) { subject.summary }
+
+    it 'return array of objects' do
+      expect(summary.size).to eq(4)
+
+      expect(summary[0].question).to eql(:kind)
+      expect(summary[0].value).to eql(disclosure_check.kind)
+    end
+  end
+
+  describe '#expiry_date' do
+    let(:expiry_date) { subject.expiry_date }
+
+    it 'return formatted expiry_date' do
+      expect(expiry_date).to eql(disclosure_check.caution_date )
+    end
+  end
+end

--- a/spec/services/caution_decision_tree_spec.rb
+++ b/spec/services/caution_decision_tree_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe CautionDecisionTree do
 
   context 'when the step is `caution_type` does not equal conditional' do
     let(:caution_type)  { CautionType::SIMPLE_CAUTION }
-    let(:step_params) { { caution_type: 'anything' } }
-    it { is_expected.to have_destination('/home', :index) }
+    let(:step_params) { { caution_type: caution_type } }
+    it { is_expected.to have_destination(:result, :show) }
   end
 
   context 'when the step is `caution_type` is equal to conditional' do


### PR DESCRIPTION
[Link to story](https://www.pivotaltracker.com/n/projects/2311302/stories/164006866)

Add the the following:

- caution result page
- CautionResultPresenter to present the questions and answers for simple caution journey
 
Result page in the [prototype](http://localhost:3000/steps/caution/result), i have updated it to use gov.uk design system

<img width="1247" alt="Screen Shot 2019-03-14 at 10 47 01" src="https://user-images.githubusercontent.com/22822829/54351558-a23c6480-4647-11e9-9539-d47ccb9030f1.png">
