### PR TITLE
Mark a check as completed

### DIFF
--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -1,0 +1,21 @@
+# The step including this concern will mark the record as `completed`.
+# Some operations can't be done or differ on `completed` records as
+# opposite to records with status `in_progress`.
+#
+module CompletionStep
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :mark_completed, unless: :completed?
+  end
+
+  private
+
+  def completed?
+    current_disclosure_check.completed?
+  end
+
+  def mark_completed
+    current_disclosure_check.completed!
+  end
+end

--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -6,6 +6,8 @@ module ErrorHandling
       case exception
       when Errors::InvalidSession, ActionController::InvalidAuthenticityToken
         redirect_to invalid_session_errors_path
+      when Errors::CheckCompleted
+        redirect_to check_completed_errors_path
       else
         raise if Rails.application.config.consider_all_requests_local
 
@@ -19,5 +21,9 @@ module ErrorHandling
 
   def check_disclosure_check_presence
     raise Errors::InvalidSession unless current_disclosure_check
+  end
+
+  def check_disclosure_check_not_completed
+    raise Errors::CheckCompleted if current_disclosure_check.completed?
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -9,6 +9,10 @@ class ErrorsController < ApplicationController
     respond_with_status(:not_found)
   end
 
+  def check_completed
+    respond_with_status(:unprocessable_entity)
+  end
+
   def unhandled
     respond_with_status(:internal_server_error)
   end

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -1,5 +1,6 @@
 class StepController < ApplicationController
   before_action :check_disclosure_check_presence
+  before_action :check_disclosure_check_not_completed, except: [:show]
   before_action :update_navigation_stack, only: [:show, :edit]
 
   private

--- a/app/controllers/steps/caution/result_controller.rb
+++ b/app/controllers/steps/caution/result_controller.rb
@@ -1,13 +1,9 @@
 module Steps
   module Caution
     class ResultController < Steps::CautionStepController
-      before_action :set_presenter
+      include CompletionStep
 
-      def show; end
-
-      private
-
-      def set_presenter
+      def show
         @presenter = CautionResultPresenter.new(current_disclosure_check)
       end
     end

--- a/app/errors/errors.rb
+++ b/app/errors/errors.rb
@@ -1,3 +1,4 @@
 module Errors
   class InvalidSession < StandardError; end
+  class CheckCompleted < StandardError; end
 end

--- a/app/views/errors/check_completed.html.erb
+++ b/app/views/errors/check_completed.html.erb
@@ -1,0 +1,21 @@
+<% title t('.page_title') %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+        <p class="govuk-body"><%=t '.lead_text' %></p>
+        <p class="govuk-body"><%= link_to t('.results_page'), steps_caution_result_path %></p>
+
+        <div class="form-submit">
+          <%= link_to t('.start_again'), root_path, class: 'govuk-button' %>
+        </div>
+
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/app/views/steps/caution/result/show.html.erb
+++ b/app/views/steps/caution/result/show.html.erb
@@ -35,7 +35,8 @@
         </dl>
 
         <p class="govuk-body">
-          If you need to change any information, or if you have another caution or conviction you’d like to check, <a href="/">use the service again</a>.
+          If you need to change any information, or if you have another caution or conviction you’d like to
+          check, <%= link_to 'use the service again', root_path %>.
         </p>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,12 @@ en:
         inclusion: Select under 18 or over 18
       caution_type:
         inclusion: Select caution type
+    check_completed:
+      page_title: Check completed
+      heading: You have already completed this check
+      lead_text: If you want to make changes you will need to start a new check.
+      results_page: Go to results page
+      start_again: New check
 
   helpers:
     submit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
     get :invalid_session
     get :unhandled
     get :not_found
+    get :check_completed
   end
 
   # Health and ping endpoints (`status` and `health` are alias)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ApplicationController do
   controller do
     def my_url; true; end
     def invalid_session; raise Errors::InvalidSession; end
+    def check_completed; raise Errors::CheckCompleted; end
     def another_exception; raise Exception; end
   end
 
@@ -21,6 +22,17 @@ RSpec.describe ApplicationController do
 
         get :invalid_session
         expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'Errors::CheckCompleted' do
+      it 'should not report the exception, and redirect to the error page' do
+        routes.draw { get 'check_completed' => 'anonymous#check_completed' }
+
+        expect(Raven).not_to receive(:capture_exception)
+
+        get :check_completed
+        expect(response).to redirect_to(check_completed_errors_path)
       end
     end
 

--- a/spec/controllers/steps/caution/result_controller_spec.rb
+++ b/spec/controllers/steps/caution/result_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Caution::ResultController, type: :controller do
+  it_behaves_like 'a completion step controller'
 
   describe '#show' do
     let(:disclosure_check) { build(:disclosure_check) }
@@ -17,6 +18,5 @@ RSpec.describe Steps::Caution::ResultController, type: :controller do
       expect(response).to render_template(:show)
       expect(assigns[:presenter]).to eq(caution_result_presenter)
     end
-
   end
 end

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -180,3 +180,48 @@ RSpec.shared_examples 'a show step controller' do
     end
   end
 end
+
+RSpec.shared_examples 'a completion step controller' do
+  describe '#show' do
+    let(:disclosure_disclosure_check) {
+      build(:disclosure_check, status: status, navigation_stack: %w(/not /empty))
+    }
+    let(:status) { :in_progress }
+
+    context 'when no case exists in the session' do
+      before do
+        # Needed because some specs that include these examples stub current_disclosure_check,
+        # which is undesirable for this particular test
+        allow(controller).to receive(:current_disclosure_check).and_return(nil)
+      end
+
+      it 'redirects to the invalid session error page' do
+        get :show
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    describe 'marking as completed' do
+      before do
+        allow(controller).to receive(:current_disclosure_check).and_return(disclosure_disclosure_check)
+      end
+
+      context 'when the check is not already marked as `completed`' do
+        it 'changes the status to `completed`' do
+          expect {
+            get :show, session: { disclosure_check_id: '123' }
+          }.to change { disclosure_disclosure_check.status }.from('in_progress').to('completed')
+        end
+      end
+
+      context 'when the check is already marked as `completed`' do
+        let(:status) { :completed }
+
+        it 'does not call the `mark_completed` method' do
+          expect(controller).not_to receive(:mark_completed)
+          get :show, session: { disclosure_check_id: '123' }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164861902

In order to know when a check has been completed, we change their `status` attribute from `in_progress` to `completed`.

This also allow us to handle errors when trying to modify a completed check, and in the future will let us know which checks we can purge from the database, among other functionality we might want to introduce.

Note: the copy in the views is temporary until we have the final sign-off.