### PR TITLE
Split locale file  into several smaller files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'i18n-tasks', '~> 0.9.28'
 
   # Available in dev env for generators
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,10 +140,21 @@ GEM
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     hashdiff (0.3.8)
+    highline (2.0.1)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     i18n-debug (1.2.0)
       i18n (< 2)
+    i18n-tasks (0.9.28)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
     jaro_winkler (1.5.2)
     jquery-rails (4.3.3)
@@ -229,6 +240,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.2)
       actionpack (= 5.2.2)
       activesupport (= 5.2.2)
@@ -306,6 +320,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -351,6 +367,7 @@ DEPENDENCIES
   gov_uk_date_fields (~> 4.0.0)
   govuk_elements_form_builder (~> 1.3.0)
   i18n-debug
+  i18n-tasks (~> 0.9.28)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   lograge

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,133 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+# locales: [es, fr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `File.find` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+    ## More files:
+    - config/locales/%{locale}/*.yml
+
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+     - ['{:}.*', 'config/locales/%{locale}/\1.yml']
+    ## Catch-all default:
+     - config/locales/%{locale}/default.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle show vagrant].chomp %>/templates/locales/%{locale}.yml"
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: conservative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `File.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   %w(*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less *.yml *.json)
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Translation Services
+# translation:
+#   # Google Translate
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   google_translate_api_key: "AbC-dEf5"
+#   # DeepL Pro Translate
+#   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
+#   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+# ignore_unused:
+# - 'activerecord.attributes.*'
+# - '{devise,kaminari,will_paginate}.*'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Exclude these keys from the `i18n-tasks check-consistent-interpolations` report:
+# ignore_inconsistent_interpolations:
+# - 'activerecord.attributes.*'
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,1 @@
+I18n.load_path = I18n.load_path + Dir[File.expand_path('config/locales') + '/**/*.yml']

--- a/config/locales/en/caution.yml
+++ b/config/locales/en/caution.yml
@@ -1,0 +1,61 @@
+---
+en:
+  steps:
+    caution:
+      caution_date:
+        edit:
+          page_title: Caution date
+          heading: When did you get the caution?
+          lead_text: This date will be written on the caution document the police gave you.
+          no_caution_document:
+            title: I don’t have my caution document
+            content_html: If you don’t know the date you were cautioned, you can get this information for free by asking the police for a <a href='https://www.gov.uk/copy-of-police-records'>subject access request (SAR)</a>.
+          date_legend: Enter the date
+          date_hint: For example, 29 1 2018
+      conditional_end_date:
+        edit:
+          page_title: Caution date
+          heading: When did the conditions end?
+          lead_text: This is the date you agreed for the conditions to end. It will be written on the caution document the police gave you. For example, ‘29 01 2018’.
+          unknown_conditional_end:
+            title: I don’t know when the conditions ended
+            content_html: If you don’t know the date you agreed for conditions to end, you can get this information for free by asking the police for a <a href='https://www.gov.uk/copy-of-police-records'>subject access request (SAR)</a>.
+          date_legend: Enter the date
+          date_hint: For example, 29 1 2018
+      under_age:
+        edit:
+          page_title: How old were you when you got the caution?
+      caution_type:
+        edit:
+          page_title: Caution types
+      condition_complied:
+        edit:
+          page_title: Conditions complied
+          heading: Did you stick to the conditions of the caution?
+          inset_text_heading: If no is selected
+          inset_text_paragraph_one: Breaking the conditions of a caution usually leads to prosecution.
+          inset_text_paragraph_two: If you were convicted of an offence after breaking the conditions of your caution, you’ll need to start again and select conviction instead of caution.
+
+  caution_results_html:
+    kind:
+      question: Criminal record type
+      answers:
+        caution: Caution
+        conviction: Conviction
+    caution_date:
+      question: 'Date caution given:'
+      answers:
+        caution: Caution
+        conviction: Conviction
+    under_age:
+      question: 'Age at time of caution:'
+      answers:
+       'yes': Under 18
+       'no': 18 or over
+    caution_type:
+      question: 'Type of caution:'
+      answers:
+        simple_caution: Simple caution
+        conditional_caution: Conditional caution
+        youth_simple_caution: Youth Simple caution
+        youth_conditional_caution: Youth Conditional caution

--- a/config/locales/en/check.yml
+++ b/config/locales/en/check.yml
@@ -1,0 +1,7 @@
+---
+en:
+  steps:
+    check:
+      kind:
+        edit:
+          page_title: Caution or a conviction

--- a/config/locales/en/date.yml
+++ b/config/locales/en/date.yml
@@ -1,0 +1,6 @@
+---
+en:
+  date:
+    formats:
+      default: '%d %B %Y'
+      long: '%d %B %y'

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -1,0 +1,29 @@
+---
+en:
+  errors:
+    format: "%{message}"
+    page_title_prefix: 'Error: '
+    error_summary:
+      heading: There is a problem on this page
+    attributes:
+      kind:
+        inclusion: Select caution or conviction
+      caution_date:
+        blank: Enter the date of the caution
+        invalid: The caution date is not valid
+        future: The caution date can’t be in the future
+      conditional_date:
+        blank: Enter the date of the condition
+        invalid: The condition date is not valid
+        future: The condition date can’t be in the future
+      under_age:
+        inclusion: Select under 18 or over 18
+      caution_type:
+        inclusion: Select caution type
+    check_completed:
+      page_title: Check completed
+      heading: You have already completed this check
+      lead_text: If you want to make changes you will need to start a new check.
+      results_page: Go to results page
+      start_again: New check
+

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -1,0 +1,53 @@
+---
+en:
+  helpers:
+    submit:
+      continue: Continue
+    fieldset:
+      steps_check_kind_form:
+        kind: Did you get a caution or a conviction?
+      steps_caution_caution_date_form:
+        caution_date: When did you get the caution?
+      steps_caution_conditional_end_date_form:
+        conditional_end_date: When did the conditions end?
+      steps_caution_under_age_form:
+        under_age: How old were you when you got the caution?
+      steps_caution_caution_type_form:
+        caution_type: What type of caution did you get?
+      steps_caution_condition_complied_form:
+        condition_complied: Did you stick to the conditions of the caution?
+
+    hint:
+      steps_check_kind_form:
+        kind: This is an example hint
+      steps_caution_caution_date_form:
+        caution_date: For example, 12 11 2017
+      steps_caution_conditional_end_date_form:
+        caution_date: For example, 12 11 2017
+
+    label:
+      steps_check_kind_form:
+        kind:
+          caution: Caution
+          conviction: Conviction
+      steps_caution_caution_date_form:
+        day: Day
+        month: Month
+        year: Year
+      steps_caution_conditional_end_date_form:
+        day: Day
+        month: Month
+        year: Year
+      steps_caution_under_age_form:
+        under_age:
+          'yes': Under 18
+          'no': 18 or over
+      steps_caution_caution_type_form:
+        caution_type:
+          simple_caution: Simple caution
+          conditional_caution: Conditional caution
+          youth_simple_caution: Youth Simple caution
+          youth_conditional_caution: Youth Conditional caution
+
+
+

--- a/config/locales/en/home.yml
+++ b/config/locales/en/home.yml
@@ -1,0 +1,5 @@
+---
+en:
+  home:
+    index:
+      page_title: Home

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -1,0 +1,13 @@
+---
+en:
+  layouts:
+    footer_links:
+      header: Support links
+      help: Help
+      contact: Contact
+      cookies: Cookies
+      privacy: Privacy
+      terms_and_conditions: Terms and conditions
+    phase_banner:
+      feedback_contact_html: This is a new service. <a href="/about/contact">Report a problem</a> and help improve it for others.
+

--- a/config/locales/en/service.yml
+++ b/config/locales/en/service.yml
@@ -1,0 +1,5 @@
+---
+en:
+  service:
+    name: Check if you need to disclose your criminal record
+

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -1,0 +1,4 @@
+---
+en:
+  shared:
+    back_link: Back

--- a/config/locales/en/warning.yml
+++ b/config/locales/en/warning.yml
@@ -1,0 +1,8 @@
+---
+en:
+  warning:
+    reset_session:
+      page_title: Disclosure check in progress
+      heading: It looks like you already have an disclosure check in progress
+      resume_link: Resume disclosure check
+      restart_link: Start a new disclosure check

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,12 @@
+require 'i18n/tasks'
+require 'rails_helper'
+
+RSpec.describe 'I18n' do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+
+  it 'does not have missing keys' do
+    expect(missing_keys).to be_empty,
+                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+  end
+end

--- a/spec/lib/govuk_components/form_builder_spec.rb
+++ b/spec/lib/govuk_components/form_builder_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe GovukComponents::FormBuilder do
 
       let(:html_fixture) { file_fixture('radio_button_fieldset_legend_options.html').read }
 
-
       it 'outputs the expected markup' do
         expect(
           strip_text(html_output)


### PR DESCRIPTION
Locale file can be come very large, quickly an it becomes a chore to update the locale file.   I have separated the main section into different files to make editing/adding keys easier.  