### PR TITLE
Update Circle CI deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,6 @@ jobs:
             export BUILD_DATE=$(date -Is) >> $BASH_ENV
             source $BASH_ENV
 
-            docker build --file Dockerfile.nginx -t nginx .
-
             docker build \
               --label build.git.sha=${CIRCLE_SHA1} \
               --label build.git.branch=${CIRCLE_BRANCH} \
@@ -94,9 +92,6 @@ jobs:
             docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:staging.latest"
             docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:staging.latest"
 
-            docker tag nginx "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:nginx.latest"
-            docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:nginx.latest"
-
   deploy_staging:
     <<: *cloud_container
     steps:
@@ -116,7 +111,7 @@ jobs:
 
             kubectl set image -n disclosure-checker-staging \
                     deployment/disclosure-checker-deployment-staging \
-                    disclosure-checker-web-staging="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
+                    webapp="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
 
             kubectl annotate -n disclosure-checker-staging \
                     deployment/disclosure-checker-deployment-staging \

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@ logs/
 log/
 tmp/
 Dockerfile
+Dockerfile.nginx
 docker-compose.yml
 README.md
 .env*

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,3 +1,3 @@
-FROM nginx:latest
+FROM nginx:alpine
 
 COPY config/nginx.conf /etc/nginx/nginx.conf

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ nginx, and any other dependency for you, without having to configure anything in
 
 * `docker-compose up`
 
-The application will be run in "production" mode, so will be as accurate as the real production environment.  
+The application will be run in "production" mode, so will be as accurate as possible to a real production environment.  
 An nginx reverse proxy will also be run to serve the static assets and to fallback to a static error page if the 
 upstream server (rails with puma) does not respond.
 
-Please note, for simplicity, docker compose will create a shared volume for nginx to serve the precompiled 
-assets from the rails /public/assets directory.
+Please note, in production environments this is done in a slightly different way as we don't use docker-compose in those 
+environments (kubernetes cluster). But the general ideal is the same (nginx reverse proxy). 
 
 ## Getting Started
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,3 +1,16 @@
+#############################################################################
+# PLEASE NOTE: This config file is only intended for use with docker-compose
+# in local environments, and it is not the same file that will be used in
+# production environments using kubernetes.
+#
+# Some configuration here doesn't directly apply when running nginx on a
+# kubernetes Pod (for example the upstream server).
+#
+# The main purpose of this file is to facilitate testing, and to be able to
+# build a local container very similar to those in a real production
+# environment (but of course, without a kubernetes cluster).
+#############################################################################
+
 events {
   worker_connections 1024;
 }


### PR DESCRIPTION
The change to CircleCI is needed as we now have 2 containers inside the deployment, one is named `webapp` and is the rails application, the other is named `nginx`. The names are now accurate to what they represent.

Some other minor improvements to the documentation.