### PR TITLE
add new step known caution date

### DIFF
--- a/app/controllers/steps/caution/known_caution_date_controller.rb
+++ b/app/controllers/steps/caution/known_caution_date_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Caution
+    class KnownCautionDateController < Steps::CautionStepController
+      def edit
+        @form_object = KnownCautionDateForm.new(
+          disclosure_check: current_disclosure_check,
+          known_caution_date: current_disclosure_check.known_caution_date
+        )
+      end
+
+      def update
+        update_and_advance(KnownCautionDateForm)
+      end
+    end
+  end
+end

--- a/app/forms/steps/caution/known_caution_date_form.rb
+++ b/app/forms/steps/caution/known_caution_date_form.rb
@@ -1,0 +1,9 @@
+module Steps
+  module Caution
+    class KnownCautionDateForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :known_caution_date
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,4 +54,10 @@ module ApplicationHelper
 
     title ''
   end
+
+  def display_result(object)
+    return object unless object.instance_of?(Date)
+
+    I18n.l(object)
+  end
 end

--- a/app/presenters/caution_result_presenter.rb
+++ b/app/presenters/caution_result_presenter.rb
@@ -8,10 +8,8 @@ class CautionResultPresenter
 
   def summary
     caution_questions.map do |item|
-      next if disclosure_check[item].nil?
-
       QuestionAnswerRow.new(item, disclosure_check[item])
-    end
+    end.compact
   end
 
   def expiry_date
@@ -19,6 +17,6 @@ class CautionResultPresenter
   end
 
   def caution_questions
-    [:kind, :caution_date, :under_age, :caution_date].freeze
+    [:kind, :known_caution_date, :caution_date, :under_age, :caution_type].freeze
   end
 end

--- a/app/services/caution_decision_tree.rb
+++ b/app/services/caution_decision_tree.rb
@@ -4,6 +4,8 @@ class CautionDecisionTree < BaseDecisionTree
     return next_step if next_step
 
     case step_name
+    when :known_caution_date
+      after_known_caution_date
     when :caution_date
       edit(:under_age)
     when :under_age
@@ -21,6 +23,12 @@ class CautionDecisionTree < BaseDecisionTree
   # rubocop:enable Metrics/CyclomaticComplexity
 
   private
+
+  def after_known_caution_date
+    return edit(:caution_date) if GenericYesNo.new(disclosure_check.known_caution_date).yes?
+
+    edit(:under_age)
+  end
 
   def after_caution_type
     return edit(:conditional_end_date) if CautionType.new(disclosure_check.caution_type).conditional?

--- a/app/services/check_decision_tree.rb
+++ b/app/services/check_decision_tree.rb
@@ -15,7 +15,7 @@ class CheckDecisionTree < BaseDecisionTree
   def after_kind_step
     case CheckKind.new(step_params[:kind])
     when CheckKind::CAUTION
-      edit('/steps/caution/caution_date')
+      edit('/steps/caution/known_caution_date')
     when CheckKind::CONVICTION
       show('/steps/conviction/exit')
     end

--- a/app/services/expiry_date_calculator.rb
+++ b/app/services/expiry_date_calculator.rb
@@ -12,12 +12,18 @@ class ExpiryDateCalculator
   private
 
   def caution
-    disclosure_check.conditional_caution_type? ? conditional_date : disclosure_check.caution_date
+    disclosure_check.conditional_caution_type? ? conditional_date : caution_result
   end
 
   def conviction
     # TODO: update when we implement the conviction journey
     raise NotImplementedError
+  end
+
+  def caution_result
+    return disclosure_check.caution_date if GenericYesNo.new(disclosure_check.known_caution_date).yes?
+
+    I18n.t('caution_result')
   end
 
   def conditional_date

--- a/app/views/steps/caution/known_caution_date/edit.html.erb
+++ b/app/views/steps/caution/known_caution_date/edit.html.erb
@@ -1,0 +1,24 @@
+<% title t('.page_title') %>
+
+<div class="govuk-width-container">
+  <%= step_header %>
+
+  <main class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= error_summary %>
+
+        <!-- The header is part of the radios legend by default, but can be configured -->
+
+        <%= step_form @form_object do |f| %>
+          <%= f.radio_button_fieldset :known_caution_date, inline: false, choices: GenericYesNo.values %>
+          <%= f.continue_button %>
+        <% end %>
+
+      </div>
+    </div>
+
+  </main>
+</div>
+

--- a/app/views/steps/caution/result/shared/_row.html.erb
+++ b/app/views/steps/caution/result/shared/_row.html.erb
@@ -1,8 +1,10 @@
-<div class="govuk-summary-list__row">
-  <dt class="govuk-summary-list__key">
-    <%=t "caution_results_html.#{row.question}.question" %>
-  </dt>
-  <dd class="govuk-summary-list__value">
-    <%=t "caution_results_html.#{row.question}.answers.#{row.value}", default: row.value %>
-  </dd>
-</div>
+<% unless row.value.nil? %>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      <%=t "caution_results_html.#{row.question}.question" %>
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%=t "caution_results_html.#{row.question}.answers.#{row.value}", default: row.value %>
+    </dd>
+  </div>
+<% end%>

--- a/app/views/steps/caution/result/show.html.erb
+++ b/app/views/steps/caution/result/show.html.erb
@@ -9,7 +9,7 @@
       <div class="govuk-grid-column-full">
         <div class="govuk-panel govuk-panel--confirmation">
           <h1 class="govuk-panel__title">
-            Your caution expired on <%=  l(@presenter.expiry_date) %>
+            Your caution expired on <%=  display_result(@presenter.expiry_date) %>
           </h1>
           <div class="govuk-panel__body">
             You do not need to tell anyone about the caution unless an <a class="govuk-link" href="https://www.gov.uk/exoffenders-and-employment?#when-employers-still-need-to-know-about-your-conviction">exception applies</a>.

--- a/config/locales/en/caution.yml
+++ b/config/locales/en/caution.yml
@@ -2,6 +2,10 @@
 en:
   steps:
     caution:
+      known_caution_date:
+        edit:
+          page_title: Know caution date
+          heading: Do you know the date you were given the caution?
       caution_date:
         edit:
           page_title: Caution date
@@ -36,17 +40,21 @@ en:
           inset_text_paragraph_one: Breaking the conditions of a caution usually leads to prosecution.
           inset_text_paragraph_two: If you were convicted of an offence after breaking the conditions of your caution, you’ll need to start again and select conviction instead of caution.
 
+  caution_result: "the day you were given it"
+
   caution_results_html:
     kind:
       question: Criminal record type
       answers:
         caution: Caution
         conviction: Conviction
+    known_caution_date:
+      question: Known caution date
+      answers:
+        'yes': 'Yes'
+        'no': 'No'
     caution_date:
       question: 'Date caution given:'
-      answers:
-        caution: Caution
-        conviction: Conviction
     under_age:
       question: 'Age at time of caution:'
       answers:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -6,6 +6,8 @@ en:
     error_summary:
       heading: There is a problem on this page
     attributes:
+      known_caution_date:
+        inclusion: Select know caution date yes or no
       kind:
         inclusion: Select caution or conviction
       caution_date:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -6,6 +6,8 @@ en:
     fieldset:
       steps_check_kind_form:
         kind: Did you get a caution or a conviction?
+      steps_caution_known_caution_date_form:
+        known_caution_date: Do you know the date you were given the caution?
       steps_caution_caution_date_form:
         caution_date: When did you get the caution?
       steps_caution_conditional_end_date_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     end
 
     namespace :caution do
+      edit_step :known_caution_date
       edit_step :caution_date
       edit_step :under_age
       edit_step :caution_type

--- a/db/migrate/20190328091950_add_known_caution_date_to_disclosure_check.rb
+++ b/db/migrate/20190328091950_add_known_caution_date_to_disclosure_check.rb
@@ -1,0 +1,5 @@
+class AddKnownCautionDateToDisclosureCheck < ActiveRecord::Migration[5.2]
+  def change
+    add_column :disclosure_checks, :known_caution_date, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_12_154353) do
+ActiveRecord::Schema.define(version: 2019_03_28_091950) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2019_03_12_154353) do
     t.string "caution_type"
     t.date "conditional_end_date"
     t.string "condition_complied"
+    t.string "known_caution_date"
     t.index ["status"], name: "index_disclosure_checks_on_status"
   end
 

--- a/features/caution.feature
+++ b/features/caution.feature
@@ -8,6 +8,8 @@ Feature: Caution
   @happy_path
   Scenario: Caution happy path - over 18, conditional caution
     When I choose "Caution"
+    Then I should see "Do you know the date you were given the caution?"
+    And I choose "Yes"
     Then I should see "When did you get the caution?"
 
     And I fill in "Day" with "1"
@@ -34,6 +36,8 @@ Feature: Caution
   @happy_path
   Scenario: Caution happy path - under 18, conditional caution
     When I choose "Caution"
+    Then I should see "Do you know the date you were given the caution?"
+    And I choose "Yes"
     Then I should see "When did you get the caution?"
 
     And I fill in "Day" with "1"
@@ -60,6 +64,8 @@ Feature: Caution
   @happy_path
   Scenario: Caution happy path - over 18, simple caution
     When I choose "Caution"
+    Then I should see "Do you know the date you were given the caution?"
+    And I choose "Yes"
     Then I should see "When did you get the caution?"
 
     And I fill in "Day" with "1"
@@ -77,6 +83,8 @@ Feature: Caution
   @happy_path
   Scenario: Caution happy path - under 18, simple caution
     When I choose "Caution"
+    Then I should see "Do you know the date you were given the caution?"
+    And I choose "Yes"
     Then I should see "When did you get the caution?"
 
     And I fill in "Day" with "1"

--- a/spec/controllers/steps/caution/known_caution_date_controller_spec.rb
+++ b/spec/controllers/steps/caution/known_caution_date_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Caution::KnownCautionDateController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Caution::KnownCautionDateForm, CautionDecisionTree
+end

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     caution_date { Faker::Date.backward(14).strftime('%Y-%m-%d') }
     under_age { 'no' }
     caution_type { CautionType::SIMPLE_CAUTION }
+    known_caution_date { 'yes' }
 
     trait :conviction do
       kind { CheckKind::CONVICTION }

--- a/spec/forms/steps/caution/known_caution_date_form_spec.rb
+++ b/spec/forms/steps/caution/known_caution_date_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Caution::KnownCautionDateForm do
+  it_behaves_like 'a yes-no question form', attribute_name: :known_caution_date
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -144,4 +144,22 @@ RSpec.describe ApplicationHelper, type: :helper do
       helper.fallback_title
     end
   end
+
+  describe '#display_result' do
+    let(:display_result) { helper.display_result(value) }
+
+    context 'is a date' do
+      let(:value) { Date.new(2019, 1, 1) }
+      it 'returns a formatted date' do
+        expect(display_result).to eq(I18n.l(value))
+      end
+    end
+
+    context 'is not a date' do
+      let(:value) { Faker::TvShows::SiliconValley.quote }
+      it 'returns a string' do
+        expect(display_result).to eq(value)
+      end
+    end
+  end
 end

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe CautionResultPresenter do
   let(:disclosure_check) { build(:disclosure_check) }
 
   describe '#caution_questions' do
-    it { expect(subject.caution_questions).to eq( [:kind, :caution_date, :under_age, :caution_date]) }
+    it { expect(subject.caution_questions).to eq( [:kind, :known_caution_date, :caution_date, :under_age, :caution_type]) }
   end
 
   describe '#summary' do
     let(:summary) { subject.summary }
 
     it 'return array of objects' do
-      expect(summary.size).to eq(4)
+      expect(summary.size).to eq(5)
 
       expect(summary[0].question).to eql(:kind)
       expect(summary[0].value).to eql(disclosure_check.kind)
@@ -20,9 +20,17 @@ RSpec.describe CautionResultPresenter do
 
   describe '#expiry_date' do
     let(:expiry_date) { subject.expiry_date }
+    context 'know caution date' do
+      it 'return formatted expiry_date' do
+        expect(expiry_date).to eql(disclosure_check.caution_date )
+      end
+    end
 
-    it 'return formatted expiry_date' do
-      expect(expiry_date).to eql(disclosure_check.caution_date )
+    context 'unknow caution date' do
+      let(:disclosure_check) { build(:disclosure_check, known_caution_date: 'no') }
+      it 'return a string' do
+        expect(expiry_date).to eql(I18n.t('caution_result'))
+      end
     end
   end
 end

--- a/spec/services/caution_decision_tree_spec.rb
+++ b/spec/services/caution_decision_tree_spec.rb
@@ -1,9 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe CautionDecisionTree do
-  let(:disclosure_check) { instance_double(DisclosureCheck, caution_type: caution_type, condition_complied: condition_complied) }
-  let(:caution_type)     { nil }
+  let(:disclosure_check) do
+    instance_double(DisclosureCheck, caution_type: caution_type,
+                                     condition_complied: condition_complied,
+                                     known_caution_date: known_caution_date)
+  end
+  let(:caution_type) { nil }
   let(:condition_complied) { nil }
+  let(:known_caution_date) { nil }
   let(:step_params)      { double('Step') }
   let(:next_step)        { nil }
   let(:as)               { nil }
@@ -11,6 +16,18 @@ RSpec.describe CautionDecisionTree do
   subject { described_class.new(disclosure_check: disclosure_check, step_params: step_params, as: as, next_step: next_step) }
 
   it_behaves_like 'a decision tree'
+
+  context 'when the step  `known_caution_date` equal yes' do
+    let(:known_caution_date) { GenericYesNo::YES }
+    let(:step_params) { { known_caution_date: known_caution_date} }
+    it { is_expected.to have_destination(:caution_date, :edit) }
+  end
+
+  context 'when the step  `known_caution_date` equal no' do
+    let(:known_caution_date) { GenericYesNo::NO }
+    let(:step_params) { { known_caution_date: known_caution_date} }
+    it { is_expected.to have_destination(:under_age, :edit) }
+  end
 
   context 'when the step is `caution_date`' do
     let(:step_params) { { caution_date: 'anything' } }

--- a/spec/services/check_decision_tree_spec.rb
+++ b/spec/services/check_decision_tree_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CheckDecisionTree do
 
     context 'and the answer is `caution`' do
       let(:kind) { 'caution' }
-      it { is_expected.to have_destination('/steps/caution/caution_date', :edit) }
+      it { is_expected.to have_destination('/steps/caution/known_caution_date', :edit) }
     end
 
     context 'and the answer is `conviction`' do


### PR DESCRIPTION
[Link to ticket](https://www.pivotaltracker.com/n/projects/2311302/stories/164953853)

Add the following 
- a step between caution or conviction question  and enter caution date
- migration to add known_caution_date to disclosure-check table.
- update caution decision tree to bypass entering caution date if not know
- update caution result page to display caution date if caution date is known else this:

> Your caution expired on the day you were given it

- update feature tests