### PR TITLE
Proof of concept: error focus

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -49,5 +49,25 @@ en:
           youth_simple_caution: Youth Simple caution
           youth_conditional_caution: Youth Conditional caution
 
-
-
+    # Name of the input element (radio, checkbox, text, etc) where the
+    # errors summary should link to gain focus.
+    #
+    focus:
+      steps_check_kind_form:
+        kind: caution
+      steps_caution_caution_date_form:
+        caution_date: dd
+      steps_caution_under_age_form:
+        under_age: 'yes'
+      # Gotcha: `caution_type_form` is dynamic, shows different radios based on
+      # a previous question, so with this solution we can't know where to link.
+      # In order for this to work we could:
+      #   a) refactor this form into 2 separate forms
+      #   b) add logic (and thus complexity) to `error_helpers.rb`
+      #   c) handle the focus with javascript? (controversial)
+      steps_caution_caution_type_form:
+        caution_type: error
+      steps_caution_conditional_end_date_form:
+        conditional_end_date: dd
+      steps_caution_condition_complied_form:
+        condition_complied: 'yes'

--- a/lib/govuk_components/error_helpers.rb
+++ b/lib/govuk_components/error_helpers.rb
@@ -48,8 +48,22 @@ module GovukComponents
         end
       end
 
+      # As stated in GOV.UK Design System, errors to questions that require a user
+      # to select one or more options from a list using radios or checkboxes,
+      # should link to the first radio or checkbox.
+      #
+      # In order to do this in the most decoupled way possible we make use of the
+      # locales to store the name of the input to link to from the error summary.
+      # If no locale is found, a default `error` one is used, which will link to
+      # the form element as a whole not a particular input.
+      #
       def self.link_to_error(object_prefixes, attribute)
-        [*object_prefixes, attribute, 'error'].join('_').prepend('#')
+        suffix = I18n.t(
+          [*object_prefixes, attribute].join('.'),
+          scope: 'helpers.focus', default: 'error'
+        )
+
+        [*object_prefixes, attribute, suffix].join('_').prepend('#')
       end
     end
     # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Possible alternative way to do the linking to a specific form input to gain the focus, from the error summary, in a very decoupled way.

Only gotcha so far I've found is we have a dynamic form object (`caution_type_form`) which shows different radios based on a previous question (`under_age`), so with this solution we can't know where to link in a static way.

There are possible ways around this, but perhaps better to settle with the default behaviour (same we have now, link to the fieldset, not a specific radio) while we work on introducing more form objects as it might well be this solution can't handle all scenarios.