### PR TITLE
Add Step: Which type of conviction were you given?

### DIFF
--- a/app/controllers/steps/conviction/conviction_type_controller.rb
+++ b/app/controllers/steps/conviction/conviction_type_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Conviction
+    class ConvictionTypeController < Steps::ConvictionStepController
+      def edit
+        @form_object = ConvictionTypeForm.new(
+          disclosure_check: current_disclosure_check,
+          conviction_type: current_disclosure_check.conviction_type
+        )
+      end
+
+      def update
+        update_and_advance(ConvictionTypeForm)
+      end
+    end
+  end
+end

--- a/app/forms/steps/conviction/conviction_type_form.rb
+++ b/app/forms/steps/conviction/conviction_type_form.rb
@@ -1,0 +1,23 @@
+module Steps
+  module Conviction
+    class ConvictionTypeForm < BaseForm
+      attribute :conviction_type, String
+
+      def self.choices
+        ConvictionType.string_values
+      end
+
+      validates_inclusion_of :conviction_type, in: choices
+
+      private
+
+      def persist!
+        raise DisclosureCheckNotFound unless disclosure_check
+
+        disclosure_check.update(
+          conviction_type: conviction_type
+        )
+      end
+    end
+  end
+end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -1,4 +1,5 @@
 class ConvictionDecisionTree < BaseDecisionTree
+  # rubocop:disable Metrics/CyclomaticComplexity
   def destination
     return next_step if next_step
 
@@ -6,6 +7,10 @@ class ConvictionDecisionTree < BaseDecisionTree
     when :known_conviction_date
       after_known_conviction_date
     when :under_age_conviction
+      edit(:conviction_type)
+    when :conviction_date
+      edit(:under_age_conviction)
+    when :conviction_type
       show(:exit)
     when :exit
       show(:exit)
@@ -13,6 +18,7 @@ class ConvictionDecisionTree < BaseDecisionTree
       raise InvalidStep, "Invalid step '#{as || step_params}'"
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private
 

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -1,0 +1,16 @@
+class ConvictionType < ValueObject
+  VALUES = [
+    COMMUNITY_SENTENCE = new(:community_sentence),
+    CUSTODIAL_SENTENCE = new(:custodial_sentence),
+    DISCHARGE = new(:discharge),
+    FINANCIAL = new(:financial),
+    HOSPITAL_ORDER = new(:hospital_order),
+    MILITARY = new(:military),
+    MOTORING = new(:motoring),
+    REHABILITATION_OR_PREVENTION = new(:rehabilitation_or_prevention)
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+end

--- a/app/views/steps/conviction/conviction_type/edit.html.erb
+++ b/app/views/steps/conviction/conviction_type/edit.html.erb
@@ -1,0 +1,23 @@
+<% title t('.page_title') %>
+
+<div class="govuk-width-container">
+  <%= step_header %>
+
+  <main id="main-content" class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= error_summary %>
+
+        <!-- The header is part of the radios legend by default, but can be configured -->
+
+        <%= step_form @form_object do |f| %>
+          <%= f.radio_button_fieldset :conviction_type, inline: false, choices: Steps::Conviction::ConvictionTypeForm.choices, radio_hint: true %>
+          <%= f.continue_button %>
+        <% end %>
+      </div>
+    </div>
+
+  </main>
+</div>
+

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -18,4 +18,8 @@ en:
           date_hint: For example, 29 1 2018
       under_age_conviction:
         edit:
-          page_title: Do you know the date you were convicted?
+          page_title: convicted age
+      conviction_type:
+        edit:
+          page_title: conviction type
+          heading: Which type of conviction were you given?

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -32,6 +32,9 @@ en:
         blank: Enter the date of the conviction
         invalid: The conviction date is not valid
         future: The conviction date can’t be in the future
+      conviction_type:
+        inclusion: Select conviction type
+
     check_completed:
       page_title: Check completed
       heading: You have already completed this check

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -24,6 +24,8 @@ en:
         under_age_conviction: Do you know the date you were convicted?
       steps_conviction_conviction_date_form:
         conviction_date: When did you get convicted?
+      steps_conviction_conviction_type_form:
+        conviction_type: Which type of conviction were you given?
 
     hint:
       steps_check_kind_form:
@@ -34,6 +36,16 @@ en:
         caution_date: For example, 12 11 2017
       steps_conviction_conviction_date_form:
         conviction_date: For example, 12 11 2017
+      radio_buttons:
+         conviction_type:
+          community_sentence: For example, a curfew or unpaid work
+          custodial_sentence: For example, a prison sentence, suspended sentence or detention
+          discharge: For example, a conditional discharge order or bind over
+          financial: For example, paying a fine or compensation
+          hospital_order: For example, to treat a mental health problem
+          military: For example, removal from Her Majesty’s services
+          motoring: For example, penalty points or disqualification
+          rehabilitation_or_prevention: For example, an attendance centre order or supervision order
 
     label:
       steps_check_kind_form:
@@ -66,6 +78,16 @@ en:
         day: Day
         month: Month
         year: Year
+      steps_conviction_conviction_type_form:
+        conviction_type:
+          community_sentence: Community Sentence
+          custodial_sentence: Custodial Sentence
+          discharge: Discharge
+          financial: Financial
+          hospital_order: Hospital Order
+          military: Military
+          motoring: Motoring
+          rehabilitation_or_prevention: Rehabilitation or Prevention
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
       edit_step :known_conviction_date
       edit_step :under_age_conviction
       edit_step :conviction_date
+      edit_step :conviction_type
     end
   end
 

--- a/db/migrate/20190402130429_add_conviction_type_to_disclosure_checkt.rb
+++ b/db/migrate/20190402130429_add_conviction_type_to_disclosure_checkt.rb
@@ -1,0 +1,5 @@
+class AddConvictionTypeToDisclosureCheckt < ActiveRecord::Migration[5.2]
+  def change
+    add_column :disclosure_checks, :conviction_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_02_104426) do
+ActiveRecord::Schema.define(version: 2019_04_02_130429) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2019_04_02_104426) do
     t.string "known_conviction_date"
     t.string "under_age_conviction"
     t.date "conviction_date"
+    t.string "conviction_type"
     t.index ["status"], name: "index_disclosure_checks_on_status"
   end
 

--- a/lib/govuk_components/form_builder.rb
+++ b/lib/govuk_components/form_builder.rb
@@ -97,10 +97,16 @@ module GovukComponents
             localized_label("#{attribute}.#{choice}")
           end
         end
+        radio_hint = options[:radio_hint].present? ? radio_hint(attribute, value) : ''
         content_tag(:div, class: 'govuk-radios__item') do
-          input + label
+          input + label + radio_hint
         end
       end
+    end
+
+    def radio_hint(attribute, value)
+      text = I18n.t("helpers.hint.radio_buttons.#{attribute}.#{value}")
+      content_tag(:span, text, class: 'govuk-hint govuk-radios__hint', id: id_for("#{attribute}_#{value}", 'hint'))
     end
 
     def hint(attribute)

--- a/spec/controllers/steps/conviction/conviction_type_controller_spec.rb
+++ b/spec/controllers/steps/conviction/conviction_type_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Conviction::ConvictionTypeController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Conviction::ConvictionTypeForm, ConvictionDecisionTree
+end

--- a/spec/forms/steps/conviction/conviction_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_type_form_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Conviction::ConvictionTypeForm do
+  let(:arguments) do
+    {
+      disclosure_check: disclosure_check,
+      conviction_type: conviction_type
+    }
+  end
+  let(:disclosure_check) { instance_double(DisclosureCheck, conviction_type: conviction_type) }
+  let(:conviction_type) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '.choices' do
+    it 'returns the relevant choices' do
+      expect(described_class.choices).to eq(%w(
+        community_sentence
+        custodial_sentence
+        discharge
+        financial
+        hospital_order
+        military
+        motoring
+        rehabilitation_or_prevention
+      ))
+    end
+  end
+
+  describe '#save' do
+    it_behaves_like 'a value object form', attribute_name: :conviction_type, example_value: 'discharge'
+
+    context 'when form is valid' do
+      let(:conviction_type) { 'discharge' }
+
+      it 'saves the record' do
+        expect(disclosure_check).to receive(:update).with(
+          conviction_type: 'discharge'
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/lib/govuk_components/form_builder_spec.rb
+++ b/spec/lib/govuk_components/form_builder_spec.rb
@@ -29,11 +29,21 @@ RSpec.describe GovukComponents::FormBuilder do
   #
   describe '#radio_button_fieldset' do
     let(:disclosure_check) { DisclosureCheck.new }
-    let(:builder) { described_class.new :steps_check_kind_form, disclosure_check, helper, {} }
+    let(:form) { 'steps_check_kind_form' }
+    let(:builder) { described_class.new form.to_sym, disclosure_check, helper, {} }
     let(:legend_options) { { page_heading: true} }
-    let(:options) { { choices: CheckKind.string_values, legend_options: legend_options } }
+    let(:radio_hint) { nil }
+    let(:choices) { CheckKind.string_values }
+    let(:options) do
+      {
+        choices: choices,
+        legend_options: legend_options,
+        radio_hint: radio_hint
+      }
+    end
+    let(:attribute) { 'kind' }
     let(:html_output) do
-      builder.radio_button_fieldset :kind, options
+      builder.radio_button_fieldset attribute.to_sym, options
     end
     context 'no errors' do
       let(:html_fixture) { file_fixture('radio_button_fieldset.html').read }
@@ -45,6 +55,27 @@ RSpec.describe GovukComponents::FormBuilder do
           strip_text(html_fixture)
         )
       end
+
+      it 'does not contains radio label' do
+        expect(
+          strip_text(html_output)
+        ).not_to include('govuk-hint govuk-radios__hint')
+      end
+    end
+
+    context 'radio with hints' do
+      let(:attribute) { 'conviction_type' }
+      let(:form) { 'steps_conviction_conviction_type_form' }
+      let(:radio_hint) { true }
+      let(:choices) { ConvictionType.string_values }
+      let(:html_fixture) { file_fixture('radio_button_fieldset_legend_options.html').read }
+
+      it 'contains radio label' do
+        expect(
+          strip_text(html_output)
+        ).to include('govuk-hint govuk-radios__hint')
+      end
+
     end
 
     context 'page_heading set to false' do

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -1,11 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe ConvictionDecisionTree do
-  let(:disclosure_check) { instance_double(DisclosureCheck, known_conviction_date: known_conviction_date) }
+  let(:disclosure_check) do
+    instance_double(DisclosureCheck, known_conviction_date: known_conviction_date,
+                                     conviction_type: conviction_type)
+  end
+
   let(:step_params)      { double('Step') }
   let(:next_step)        { nil }
   let(:as)               { nil }
   let(:known_conviction_date) { nil }
+  let(:conviction_type) { nil }
 
   subject { described_class.new(disclosure_check: disclosure_check, step_params: step_params, as: as, next_step: next_step) }
 
@@ -25,11 +30,21 @@ RSpec.describe ConvictionDecisionTree do
 
   context 'when the step is `under_age_conviction`' do
     let(:step_params) { { under_age_conviction: 'yes' } }
-    it { is_expected.to have_destination(:exit, :show) }
+    it { is_expected.to have_destination(:conviction_type, :edit) }
   end
 
   context 'when the step is `under_age_conviction` equal no' do
     let(:step_params) { { under_age_conviction: 'no' } }
+    it { is_expected.to have_destination(:conviction_type, :edit) }
+  end
+
+  context 'when the step is `conviction_date` ' do
+    let(:step_params) { { conviction_date: 'anything' } }
+    it { is_expected.to have_destination(:under_age_conviction, :edit) }
+  end
+
+  context 'when the step is `conviction_type`' do
+    let(:step_params) { { conviction_type: 'anything' } }
     it { is_expected.to have_destination(:exit, :show) }
   end
 


### PR DESCRIPTION
[Link to story](https://www.pivotaltracker.com/n/projects/2311302/stories/165022999)

Add the following

- a step a new to select type of conviction
- conviction type value object
- update form builder to add radio hint messages as describe in the [design system](https://design-system.service.gov.uk/components/radios/)


You see conviction type radio buttons with hints below:

<img width="772" alt="Screen Shot 2019-04-03 at 11 17 19" src="https://user-images.githubusercontent.com/22822829/55471661-30ca5300-5602-11e9-8c74-804559ac9bd3.png">
