### PR TITLE
Make errors specific for each form

### DIFF
--- a/app/forms/steps/conviction/known_date_form.rb
+++ b/app/forms/steps/conviction/known_date_form.rb
@@ -8,6 +8,7 @@ module Steps
       acts_as_gov_uk_date :known_date
 
       validates_presence_of :known_date
+      validates :known_date, sensible_date: true
 
       private
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -1,19 +1,39 @@
 ---
 en:
+  activemodel:
+    errors:
+      models:
+        steps/caution/is_date_known_form:
+          attributes:
+            is_date_known:
+              inclusion: Select if you know the date you were given the caution
+        steps/caution/known_date_form:
+          attributes:
+            known_date:
+              blank: Enter the date of the caution
+              invalid: The date of the caution is not valid
+              future: The date of the caution can’t be in the future
+        steps/conviction/is_date_known_form:
+          attributes:
+            is_date_known:
+              inclusion: Select if you know the date you were given the conviction
+        steps/conviction/known_date_form:
+          attributes:
+            known_date:
+              blank: Enter the date of the conviction
+              invalid: The date of the conviction is not valid
+              future: The date of the conviction can’t be in the future
+
   errors:
     format: "%{message}"
     page_title_prefix: 'Error: '
     error_summary:
       heading: There is a problem on this page
     attributes:
+      # TODO: move all errors below to `activemodel.errors.models` section, so even in the case
+      # multiple forms points to the same attribute, the errors can be different for each one.
       kind:
         inclusion: Select caution or conviction
-      is_date_known:
-        inclusion: Select if you know the date
-      known_date:
-        blank: Enter the date of the *****
-        invalid: The date is not valid
-        future: The date can’t be in the future
       conditional_date:
         blank: Enter the date of the condition
         invalid: The condition date is not valid

--- a/spec/forms/steps/conviction/known_date_form_spec.rb
+++ b/spec/forms/steps/conviction/known_date_form_spec.rb
@@ -35,12 +35,30 @@ RSpec.describe Steps::Conviction::KnownDateForm do
         end
       end
 
-      xcontext 'when date is invalid' do
-        # Implement as needed
+      context 'when date is invalid' do
+        let(:known_date) { Date.new(18, 10, 31) } # 2-digits year (18)
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:known_date, :invalid)).to eq(true)
+        end
       end
 
-      xcontext 'when date is in the future' do
-        # Implement as needed
+      context 'when date is in the future' do
+        let(:known_date) { Date.tomorrow }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:known_date, :future)).to eq(true)
+        end
       end
     end
 


### PR DESCRIPTION
Now we are re-using some DB attributes in different form objects, we need a way to specify different error messages depending on the step we are.

I didn't remember, but the gem provides this mechanism out of the box. The only thing we need to do is reorganise a bit the locales, as shown in this PR.

We should do the same for the rest of errors.