### PR TITLE
remove unused db columns

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -47,12 +47,12 @@ en:
     hint:
       steps_check_kind_form:
         kind: This is an example hint
-      steps_caution_caution_date_form:
-        caution_date: For example, 12 11 2017
+      steps_caution_known_date_form:
+        known_date: For example, 12 11 2017
       steps_caution_conditional_end_date_form:
-        caution_date: For example, 12 11 2017
-      steps_conviction_conviction_date_form:
-        conviction_date: For example, 12 11 2017
+        conditional_end_date: For example, 12 11 2017
+      steps_conviction_known_date_form:
+        known_date: For example, 12 11 2017
       radio_buttons:
         conviction_type:
           community_order: For example, a curfew or unpaid work
@@ -102,7 +102,7 @@ en:
         kind:
           caution: Caution
           conviction: Conviction
-      steps_caution_caution_date_form:
+      steps_caution_known_date_form:
         day: Day
         month: Month
         year: Year

--- a/db/migrate/20190606134632_remove_columns_from_disclosure_check.rb
+++ b/db/migrate/20190606134632_remove_columns_from_disclosure_check.rb
@@ -1,0 +1,7 @@
+class RemoveColumnsFromDisclosureCheck < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :disclosure_checks, :caution_date, :string
+    remove_column :disclosure_checks, :under_age_conviction, :string
+    remove_column :disclosure_checks, :conviction_date, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_06_110029) do
+ActiveRecord::Schema.define(version: 2019_06_06_134632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -22,14 +22,11 @@ ActiveRecord::Schema.define(version: 2019_06_06_110029) do
     t.integer "status", default: 0
     t.string "navigation_stack", default: [], array: true
     t.string "kind"
-    t.date "caution_date"
     t.string "under_age"
     t.string "caution_type"
     t.date "conditional_end_date"
     t.string "condition_complied"
     t.string "is_date_known"
-    t.string "under_age_conviction"
-    t.date "conviction_date"
     t.string "conviction_type"
     t.string "community_order"
     t.string "discharge"

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :disclosure_check do
     kind { CheckKind::CAUTION }
-    caution_date { Faker::Date.backward(14).strftime('%Y-%m-%d') }
+    known_date { Faker::Date.backward(14).strftime('%Y-%m-%d') }
     under_age { 'no' }
     caution_type { CautionType::SIMPLE_CAUTION }
     is_date_known { 'yes' }
 
     trait :conviction do
       kind { CheckKind::CONVICTION }
-      caution_date { nil }
+      known_date { nil }
       under_age { nil }
       caution_type { nil }
     end


### PR DESCRIPTION
Delete caution_date, under_age_conviction and conviction_date columns.

General clean up any use of the above column names.