### PR TITLE
Update question flow

### DIFF
--- a/app/services/caution_decision_tree.rb
+++ b/app/services/caution_decision_tree.rb
@@ -4,14 +4,12 @@ class CautionDecisionTree < BaseDecisionTree
     return next_step if next_step
 
     case step_name
-    when :is_date_known
-      after_is_date_known
-    when :known_date
-      edit(:under_age)
     when :under_age
-      edit(:caution_type)
+      after_under_age
     when :caution_type
       after_caution_type
+    when :known_date
+      result
     when :conditional_end_date
       edit(:condition_complied)
     when :condition_complied
@@ -24,16 +22,16 @@ class CautionDecisionTree < BaseDecisionTree
 
   private
 
-  def after_is_date_known
-    return edit(:known_date) if GenericYesNo.new(disclosure_check.is_date_known).yes?
+  def after_under_age
+    return edit(:caution_type) if GenericYesNo.new(disclosure_check.under_age).yes?
 
-    edit(:under_age)
+    show('/steps/conviction/exit')
   end
 
   def after_caution_type
     return edit(:conditional_end_date) if CautionType.new(disclosure_check.caution_type).conditional?
 
-    result
+    edit(:known_date)
   end
 
   def after_condition_complied

--- a/app/services/check_decision_tree.rb
+++ b/app/services/check_decision_tree.rb
@@ -15,9 +15,9 @@ class CheckDecisionTree < BaseDecisionTree
   def after_kind_step
     case CheckKind.new(step_params[:kind])
     when CheckKind::CAUTION
-      edit('/steps/caution/is_date_known')
+      edit('/steps/caution/under_age')
     when CheckKind::CONVICTION
-      edit('/steps/conviction/is_date_known')
+      edit('/steps/conviction/under_age')
     end
   end
 end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -4,12 +4,8 @@ class ConvictionDecisionTree < BaseDecisionTree
     return next_step if next_step
 
     case step_name
-    when :is_date_known
-      after_is_date_known
     when :under_age
-      edit(:conviction_type)
-    when :known_date
-      edit(:under_age)
+      after_under_age
     when :conviction_type
       after_conviction_type
     when conviction_type?(step_name)
@@ -26,10 +22,10 @@ class ConvictionDecisionTree < BaseDecisionTree
 
   private
 
-  def after_is_date_known
-    return edit(:known_date) if GenericYesNo.new(disclosure_check.is_date_known).yes?
+  def after_under_age
+    return edit(:conviction_type) if GenericYesNo.new(disclosure_check.under_age).yes?
 
-    edit(:under_age)
+    show(:exit)
   end
 
   def after_conviction_type

--- a/app/services/expiry_date_calculator.rb
+++ b/app/services/expiry_date_calculator.rb
@@ -21,7 +21,7 @@ class ExpiryDateCalculator
   end
 
   def caution_result
-    return disclosure_check.known_date if GenericYesNo.new(disclosure_check.is_date_known).yes?
+    return disclosure_check.known_date unless disclosure_check.known_date.nil?
 
     I18n.t('caution_result')
   end

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -21,7 +21,7 @@ en:
       steps_conviction_is_date_known_form:
         is_date_known: Do you know the date you were convicted?
       steps_conviction_under_age_form:
-        under_age: How old were you when you got the caution?
+        under_age: How old were you when you got convicted?
       steps_conviction_known_date_form:
         known_date: When did you get convicted?
       steps_conviction_conviction_type_form:

--- a/features/caution.feature
+++ b/features/caution.feature
@@ -6,50 +6,22 @@ Feature: Caution
     Then I should see "Did you get a caution or a conviction?"
 
   @happy_path
-  Scenario: Caution happy path - over 18, conditional caution
+  Scenario: Over 18
     When I choose "Caution"
-    Then I should see "Do you know the date you were given the caution?"
-    And I choose "Yes"
-    Then I should see "When did you get the caution?"
-
-    And I fill in "Day" with "1"
-    And I fill in "Month" with "1"
-    And I fill in "Year" with "1999"
-    And I click the "Continue" button
     Then I should see "How old were you when you got the caution?"
-
     And I choose "18 or over"
-    Then I should see "What type of caution did you get?"
-
-    And I choose "Conditional caution"
-    Then I should see "When did the conditions end?"
-
-    And I fill in "Day" with "1"
-    And I fill in "Month" with "1"
-    And I fill in "Year" with "1999"
-    And I click the "Continue" button
-    Then I should see "Did you stick to the conditions of the caution?"
-
-    And I choose "Yes"
-    Then I should see "Your caution expired on 01 January 1999"
+    Then I should see "Sorry, you can't use this service yet"
 
   @happy_path
   Scenario: Caution happy path - under 18, conditional caution
     When I choose "Caution"
-    Then I should see "Do you know the date you were given the caution?"
-    And I choose "Yes"
-    Then I should see "When did you get the caution?"
-
-    And I fill in "Day" with "1"
-    And I fill in "Month" with "1"
-    And I fill in "Year" with "1999"
-    And I click the "Continue" button
     Then I should see "How old were you when you got the caution?"
 
     And I choose "Under 18"
     Then I should see "What type of caution did you get?"
 
     And I choose "Conditional caution"
+
     Then I should see "When did the conditions end?"
 
     And I fill in "Day" with "1"
@@ -61,42 +33,23 @@ Feature: Caution
     And I choose "Yes"
     Then I should see "Your caution expired on 01 January 1999"
 
-  @happy_path
-  Scenario: Caution happy path - over 18, simple caution
-    When I choose "Caution"
-    Then I should see "Do you know the date you were given the caution?"
-    And I choose "Yes"
-    Then I should see "When did you get the caution?"
-
-    And I fill in "Day" with "1"
-    And I fill in "Month" with "1"
-    And I fill in "Year" with "1999"
-    And I click the "Continue" button
-    Then I should see "How old were you when you got the caution?"
-
-    And I choose "18 or over"
-    Then I should see "What type of caution did you get?"
-
-    And I choose "Simple caution"
-    Then I should see "Your caution expired on 01 January 1999"
 
   @happy_path
   Scenario: Caution happy path - under 18, simple caution
     When I choose "Caution"
-    Then I should see "Do you know the date you were given the caution?"
-    And I choose "Yes"
+    Then I should see "How old were you when you got the caution?"
+    And I choose "Under 18"
+    Then I should see "What type of caution did you get?"
+
+    And I choose "Simple caution"
+
     Then I should see "When did you get the caution?"
 
     And I fill in "Day" with "1"
     And I fill in "Month" with "1"
     And I fill in "Year" with "1999"
     And I click the "Continue" button
-    Then I should see "How old were you when you got the caution?"
 
-    And I choose "Under 18"
-    Then I should see "What type of caution did you get?"
-
-    And I choose "Simple caution"
     Then I should see "Your caution expired on 01 January 1999"
 
     # TODO: to be continued...

--- a/features/conviction.feature
+++ b/features/conviction.feature
@@ -5,7 +5,8 @@ Feature: Conviction
     And I click the "Start now" link
     Then I should see "Did you get a caution or a conviction?"
 
+
   @happy_path
   Scenario: Conviction happy path
     When I choose "Conviction"
-    Then I should see "Do you know the date you were convicted?"
+    Then I should see "How old were you when you got convicted?"

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CautionResultPresenter do
     end
 
     context 'unknow caution date' do
-      let(:disclosure_check) { build(:disclosure_check, is_date_known: 'no') }
+      let(:disclosure_check) { build(:disclosure_check, known_date: nil) }
       it 'return a string' do
         expect(expiry_date).to eql(I18n.t('caution_result'))
       end

--- a/spec/services/caution_decision_tree_spec.rb
+++ b/spec/services/caution_decision_tree_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe CautionDecisionTree do
       caution_type: caution_type,
       condition_complied: condition_complied,
       is_date_known: is_date_known,
+      under_age: under_age
     )
   end
 
   let(:caution_type) { nil }
   let(:condition_complied) { nil }
   let(:is_date_known) { nil }
+  let(:under_age) { nil }
   let(:step_params)      { double('Step') }
   let(:next_step)        { nil }
   let(:as)               { nil }
@@ -21,32 +23,27 @@ RSpec.describe CautionDecisionTree do
 
   it_behaves_like 'a decision tree'
 
-  context 'when the step  `is_date_known` equal yes' do
-    let(:is_date_known) { GenericYesNo::YES }
-    let(:step_params) { { is_date_known: is_date_known} }
-    it { is_expected.to have_destination(:known_date, :edit) }
-  end
-
-  context 'when the step  `is_date_known` equal no' do
-    let(:is_date_known) { GenericYesNo::NO }
-    let(:step_params) { { is_date_known: is_date_known} }
-    it { is_expected.to have_destination(:under_age, :edit) }
-  end
-
   context 'when the step is `caution_date`' do
     let(:step_params) { { known_date: 'anything' } }
-    it { is_expected.to have_destination(:under_age, :edit) }
+    it { is_expected.to have_destination(:result, :show) }
   end
 
-  context 'when the step is `under_age`' do
-    let(:step_params) { { under_age: 'yes' } }
+  context 'when the step is `under_age` is equal to yes' do
+    let(:under_age)  { GenericYesNo::YES }
+    let(:step_params) { { under_age: under_age } }
     it { is_expected.to have_destination(:caution_type, :edit) }
+  end
+
+   context 'when the step is `under_age` is equal to no' do
+    let(:under_age)  { GenericYesNo::NO }
+    let(:step_params) { { under_age: under_age } }
+    it { is_expected.to have_destination('/steps/conviction/exit', :show) }
   end
 
   context 'when the step is `caution_type` does not equal conditional' do
     let(:caution_type)  { CautionType::SIMPLE_CAUTION }
     let(:step_params) { { caution_type: caution_type } }
-    it { is_expected.to have_destination(:result, :show) }
+    it { is_expected.to have_destination(:known_date, :edit) }
   end
 
   context 'when the step is `caution_type` is equal to conditional' do

--- a/spec/services/check_decision_tree_spec.rb
+++ b/spec/services/check_decision_tree_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe CheckDecisionTree do
 
     context 'and the answer is `caution`' do
       let(:kind) { 'caution' }
-      it { is_expected.to have_destination('/steps/caution/is_date_known', :edit) }
+      it { is_expected.to have_destination('/steps/caution/under_age', :edit) }
     end
 
     context 'and the answer is `conviction`' do
       let(:kind) { 'conviction' }
-      it { is_expected.to have_destination('/steps/conviction/is_date_known', :edit) }
+      it { is_expected.to have_destination('/steps/conviction/under_age', :edit) }
     end
   end
 end

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -4,13 +4,14 @@ RSpec.describe ConvictionDecisionTree do
   let(:disclosure_check) do
     instance_double(
       DisclosureCheck,
-      is_date_known: is_date_known,
+      under_age: under_age,
       conviction_type: conviction_type,
     )
   end
 
   let(:step_params)      { double('Step') }
   let(:next_step)        { nil }
+  let(:under_age)        { nil }
   let(:as)               { nil }
   let(:is_date_known)    { nil }
   let(:conviction_type)  { nil }
@@ -19,31 +20,21 @@ RSpec.describe ConvictionDecisionTree do
 
   it_behaves_like 'a decision tree'
 
-  context 'when the step  `is_date_known` equal yes' do
-    let(:is_date_known) { GenericYesNo::YES }
-    let(:step_params) { { is_date_known: is_date_known} }
-    it { is_expected.to have_destination(:known_date, :edit) }
-  end
-
-  context 'when the step `is_date_known` equal no' do
-    let(:is_date_known) { GenericYesNo::NO }
-    let(:step_params) { { is_date_known: is_date_known} }
-    it { is_expected.to have_destination(:under_age, :edit) }
-  end
-
   context 'when the step is `under_age_conviction`' do
-    let(:step_params) { { under_age: 'yes' } }
+    let(:under_age)  { GenericYesNo::YES }
+    let(:step_params) { { under_age: under_age } }
     it { is_expected.to have_destination(:conviction_type, :edit) }
   end
 
   context 'when the step is `under_age_conviction` equal no' do
-    let(:step_params) { { under_age: 'no' } }
-    it { is_expected.to have_destination(:conviction_type, :edit) }
+    let(:under_age)  { GenericYesNo::NO }
+    let(:step_params) { { under_age: under_age } }
+    it { is_expected.to have_destination(:exit, :show) }
   end
 
   context 'when the step is `conviction_date` ' do
-    let(:step_params) { { known_date: 'anything' } }
-    it { is_expected.to have_destination(:under_age, :edit) }
+    let(:step_params) { { conviction_end_date: 'anything' } }
+    it { is_expected.to have_destination(:exit, :show) }
   end
 
   context 'when the step is `conviction_type`' do


### PR DESCRIPTION
Update question flow for both conviction and caution paths to match MVP flow diagram https://dsdmoj.atlassian.net/wiki/spaces/CJDT/pages/1390018589/Disclosure+Checker

Please note the conviction path only goes up to entering a conviction date.

I another pr will be open for length of conviction.