### PR TITLE
Conviction length text field

### DIFF
--- a/app/forms/steps/conviction/conviction_length_form.rb
+++ b/app/forms/steps/conviction/conviction_length_form.rb
@@ -2,6 +2,7 @@ module Steps
   module Conviction
     class ConvictionLengthForm < BaseForm
       attribute :conviction_length, Integer
+      delegate :conviction_length_type, to: :disclosure_check
 
       validates_numericality_of :conviction_length, greater_than: 0, only_integer: true
 

--- a/app/forms/steps/conviction/conviction_subtype_form.rb
+++ b/app/forms/steps/conviction/conviction_subtype_form.rb
@@ -2,15 +2,12 @@ module Steps
   module Conviction
     class ConvictionSubtypeForm < BaseForm
       attribute :conviction_subtype, String
+      delegate :conviction_type, to: :disclosure_check
 
       validates_inclusion_of :conviction_subtype, in: :choices, if: :disclosure_check
 
       def choices
         conviction_subtypes.map(&:to_s)
-      end
-
-      def conviction_type
-        disclosure_check.conviction_type
       end
 
       private

--- a/app/views/steps/conviction/conviction_length/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length/edit.html.erb
@@ -8,9 +8,15 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= error_summary %>
-        <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+        <!-- The header is part of the text_field label -->
+
         <%= step_form @form_object do |f| %>
-          <%= f.text_field :conviction_length, class: 'govuk-input govuk-input--width-3', label_options: { class: 'govuk-label' } %>
+          <%= f.text_field :conviction_length,
+                           input_options: { class: 'govuk-input--width-4' },
+                           hint_options: { virtual_attribute: @form_object.conviction_length_type }
+          %>
+
           <%= f.continue_button %>
         <% end %>
       </div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -46,8 +46,8 @@ en:
         steps/conviction/conviction_length_form:
           attributes:
             conviction_length:
-              greater_than: Conviction length value must be 1 or more
-              not_a_number: Conviction length must be a number, like 3
+              greater_than: The length of conviction must be 1 or more
+              not_a_number: The length of conviction must be a number, like 3
         steps/conviction/compensation_payment_date_form:
           attributes:
             compensation_payment_date:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -52,6 +52,10 @@ en:
         under_age: This is your age when you were given the conviction, not when you committed the offence
       steps_conviction_compensation_payment_date_form:
         compensation_payment_date: For example, 23 9 2018
+      steps_conviction_conviction_length_form:
+        weeks: Number of weeks
+        months: Number of months
+        years: Number of years
       radio_buttons:
         kind:
           caution: You were given an official warning by the police
@@ -188,7 +192,7 @@ en:
           months: Months
           years: Years
       steps_conviction_conviction_length_form:
-        conviction_length: Length of conviction
+        conviction_length: What was the length of the order?
       steps_conviction_compensation_payment_date_form:
         day: Day
         month: Month

--- a/lib/govuk_components/form_builder.rb
+++ b/lib/govuk_components/form_builder.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 module GovukComponents
   class FormBuilder < GovukElementsFormBuilder::FormBuilder
     delegate :t, :concat, to: :@template
@@ -6,11 +7,20 @@ module GovukComponents
       submit t("helpers.submit.#{value}"), {class: 'govuk-button'}.merge(options)
     end
 
-    # This method overrides the one from the original gem, and reimplement it
+    # Methods below overrides the one from the original gem, and reimplement them
     # to produce new markup and style class names.
     # Also a few private methods have been reimplemented for this to work side
     # by side with the old gem.
     #
+    def text_field(attribute, options = {})
+      content_tag(:div, class: form_group_classes(attribute)) do
+        concat input_label(attribute, options)
+        concat hint(attribute, options)
+        concat error(attribute)
+        concat @template.text_field(@object_name, attribute, input_options(attribute, options))
+      end
+    end
+
     def radio_button_fieldset(attribute, options = {})
       wrapper_classes = ['govuk-radios']
       wrapper_classes << 'govuk-radios--inline' if options[:inline]
@@ -22,7 +32,7 @@ module GovukComponents
       content_tag(:div, class: form_group_classes(attribute)) do
         content_tag(:fieldset, fieldset_options(attribute, options)) do
           concat fieldset_legend(attribute, options)
-          concat hint(attribute)
+          concat hint(attribute, options)
           concat error(attribute)
           concat radios
         end
@@ -37,15 +47,28 @@ module GovukComponents
       classes
     end
 
-    def fieldset_options(attribute, options)
-      defaults = {class: 'govuk-fieldset'}
-
+    def aria_describes(attribute)
       aria_ids = []
       aria_ids << id_for(attribute, 'hint')  if hint(attribute)
       aria_ids << id_for(attribute, 'error') if error_for?(attribute)
 
-      # If the array is empty, `#presence` will return nil
-      defaults['aria-describedby'] = aria_ids.presence
+      # If the array is empty, will return nil
+      aria_ids.presence
+    end
+
+    def input_options(attribute, options)
+      defaults = { class: 'govuk-input' }
+      defaults['aria-describedby'] = aria_describes(attribute)
+
+      merge_attributes(
+        options[:input_options],
+        default: defaults
+      )
+    end
+
+    def fieldset_options(attribute, options)
+      defaults = { class: 'govuk-fieldset' }
+      defaults['aria-describedby'] = aria_describes(attribute)
 
       merge_attributes(
         options[:fieldset_options],
@@ -92,6 +115,48 @@ module GovukComponents
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
+    # Note: there is a lot of repetition here and in the `fieldset_legend` method,
+    # but until we have a clear understanding of how we will refactor all this code
+    # (for example, extract to a gem?) and the functionality that we can cover, it
+    # is better to have a bit of duplication to iterate quicker.
+    #
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def input_label(attribute, options)
+      default_attrs = { class: 'govuk-label' }.freeze
+      default_opts  = { visually_hidden: false, page_heading: true, size: 'xl' }.freeze
+
+      label_options = merge_attributes(
+        options[:label_options],
+        default: default_attrs
+      ).reverse_merge(
+        default_opts
+      )
+
+      opts = label_options.extract!(*default_opts.keys)
+
+      label_options[:class] << " govuk-label--#{opts[:size]}"
+      label_options[:class] << ' govuk-visually-hidden' if opts[:visually_hidden]
+
+      html = Nokogiri::HTML.fragment(
+        label(attribute, label_options)
+      )
+
+      # Remove the error span Rails introduce, as we are handling errors
+      # in a different way and with different markup.
+      html.at(:span)&.unlink
+      label_html = html.to_html.html_safe
+
+      # The `page_heading` option can be false to disable "Legends as page headings"
+      # https://design-system.service.gov.uk/get-started/labels-legends-headings/
+      #
+      if opts[:page_heading]
+        content_tag(:h1, label_html, class: 'govuk-label-wrapper')
+      else
+        label_html
+      end
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
     def radio_inputs(attribute, options)
       choices = options[:choices] || [:yes, :no]
       choices.map do |choice|
@@ -119,14 +184,16 @@ module GovukComponents
       content_tag(:span, text, class: 'govuk-hint govuk-radios__hint', id: id_for("#{attribute}_#{value}", 'hint'))
     end
 
-    # :nocov:
-    # TODO: add spec for hint text
-    def hint(attribute)
+    def hint(attribute, options = {})
+      # If a form view is reused but the attribute doesn't change (for example in
+      # partials) a `virtual_attribute` can be passed to the `hint_options` to
+      # lookup the hint locale based on this, instead of the original attribute.
+      #
+      attribute = options.dig(:hint_options, :virtual_attribute) || attribute
       return unless hint_text(attribute)
 
       content_tag(:span, hint_text(attribute), class: 'govuk-hint', id: id_for(attribute, 'hint'))
     end
-    # :nocov:
 
     def error(attribute)
       return unless error_for?(attribute)
@@ -140,3 +207,4 @@ module GovukComponents
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/spec/fixtures/files/text_field.html
+++ b/spec/fixtures/files/text_field.html
@@ -1,0 +1,8 @@
+<div class="govuk-form-group">
+    <h1 class="govuk-label-wrapper">
+        <label class="govuk-label govuk-label--xl" for="steps_conviction_conviction_length_form_conviction_length">
+            What was the length of the order?
+        </label>
+    </h1>
+    <input class="govuk-input govuk-input--width-4" type="text" name="steps_conviction_conviction_length_form[conviction_length]" id="steps_conviction_conviction_length_form_conviction_length" />
+</div>

--- a/spec/fixtures/files/text_field_error.html
+++ b/spec/fixtures/files/text_field_error.html
@@ -1,0 +1,9 @@
+<div class="govuk-form-group govuk-form-group--error">
+    <h1 class="govuk-label-wrapper">
+        <label class="govuk-label govuk-label--xl" for="steps_conviction_conviction_length_form_conviction_length">
+            What was the length of the order?
+        </label>
+    </h1>
+    <span class="govuk-error-message" id="steps_conviction_conviction_length_form_conviction_length_error">is not a number</span>
+    <input class="govuk-input govuk-input--width-4" aria-describedby="steps_conviction_conviction_length_form_conviction_length_error" type="text" name="steps_conviction_conviction_length_form[conviction_length]" id="steps_conviction_conviction_length_form_conviction_length" />
+</div>

--- a/spec/fixtures/files/text_field_no_page_heading.html
+++ b/spec/fixtures/files/text_field_no_page_heading.html
@@ -1,0 +1,6 @@
+<div class="govuk-form-group">
+    <label class="govuk-label govuk-label--xl" for="steps_conviction_conviction_length_form_conviction_length">
+        What was the length of the order?
+    </label>
+    <input class="govuk-input" type="text" name="steps_conviction_conviction_length_form[conviction_length]" id="steps_conviction_conviction_length_form_conviction_length" />
+</div>

--- a/spec/forms/steps/conviction/conviction_length_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_form_spec.rb
@@ -5,10 +5,17 @@ RSpec.describe Steps::Conviction::ConvictionLengthForm do
     disclosure_check: disclosure_check,
     conviction_length: conviction_length
   } }
-  let(:disclosure_check) { instance_double(DisclosureCheck) }
+  let(:disclosure_check) { instance_double(DisclosureCheck, conviction_length_type: 'months') }
   let(:conviction_length) { 3 }
 
   subject { described_class.new(arguments) }
+
+  describe '#conviction_length_type' do
+    it 'delegates to `disclosure_checker`' do
+      expect(disclosure_check).to receive(:conviction_length_type)
+      expect(subject.conviction_length_type).to eq('months')
+    end
+  end
 
   describe '#save' do
     context 'when form is valid' do

--- a/spec/lib/govuk_components/form_builder_spec.rb
+++ b/spec/lib/govuk_components/form_builder_spec.rb
@@ -4,6 +4,7 @@ class TestHelper < ActionView::Base
 end
 
 RSpec.describe GovukComponents::FormBuilder do
+  let(:disclosure_check) { DisclosureCheck.new }
   let(:helper) { TestHelper.new }
 
   def strip_text(text)
@@ -28,7 +29,6 @@ RSpec.describe GovukComponents::FormBuilder do
   # then the HTML fixture will need to also be updated.
   #
   describe '#radio_button_fieldset' do
-    let(:disclosure_check) { DisclosureCheck.new }
     let(:form) { 'steps_check_kind_form' }
     let(:builder) { described_class.new form.to_sym, disclosure_check, helper, {} }
     let(:legend_options) { { page_heading: true} }
@@ -118,6 +118,79 @@ RSpec.describe GovukComponents::FormBuilder do
         ).to eq(
           strip_text(html_fixture)
         )
+      end
+    end
+  end
+
+  # Note: This is just a very broad and `happy path` test.
+  # It is also coupled to current i18n so, if the strings change,
+  # then the HTML fixture will need to also be updated.
+  #
+  describe '#text_field' do
+    let(:builder) { described_class.new form.to_sym, disclosure_check, helper, {} }
+
+    let(:form) { 'steps_conviction_conviction_length_form' }
+    let(:attribute) { :conviction_length }
+
+    let(:options) do
+      { input_options: { class: 'govuk-input--width-4' } }
+    end
+
+    let(:html_output) { builder.text_field attribute, options }
+
+    context 'no errors' do
+      let(:html_fixture) { file_fixture('text_field.html').read }
+
+      it 'outputs the expected markup' do
+        expect(
+          strip_text(html_output)
+        ).to eq(
+          strip_text(html_fixture)
+        )
+      end
+    end
+
+    context 'with errors' do
+      let(:html_fixture) { file_fixture('text_field_error.html').read }
+
+      before do
+        disclosure_check.errors.add(:conviction_length, :not_a_number)
+      end
+
+      it 'outputs the expected markup' do
+        expect(
+          strip_text(html_output)
+        ).to eq(
+          strip_text(html_fixture)
+        )
+      end
+    end
+
+    context 'page_heading set to false' do
+      let(:html_fixture) { file_fixture('text_field_no_page_heading.html').read }
+
+      let(:options) do
+        { label_options: { page_heading: false } }
+      end
+
+      it 'outputs the expected markup' do
+        expect(
+          strip_text(html_output)
+        ).to eq(
+          strip_text(html_fixture)
+        )
+      end
+    end
+
+    context 'with a custom hint' do
+      let(:options) do
+        { hint_options: { virtual_attribute: 'months' } }
+      end
+
+      it 'outputs the expected markup' do
+        expect(
+          strip_text(html_output)
+        ).to match(/<span class="govuk-hint" id="steps_conviction_conviction_length_form_months_hint">Number of months<\/span>/)
       end
     end
   end


### PR DESCRIPTION
Similar to what we did for `#radio_button_fieldset`, we must reimplement the `#text_field` method in order to produce the new markup expected with the new Design System.

It works in a similar way to `#radio_button_fieldset` and supports most of the options.

Also, the hint can be customised and will take its locales from the `conviction_length_type` attribute value. So we can change the hint based on weeks, months or years.

<img width="636" alt="Screen Shot 2019-06-20 at 10 26 41" src="https://user-images.githubusercontent.com/687910/59837978-1329a180-9346-11e9-8d2a-d5f1e97edd19.png">

<img width="682" alt="Screen Shot 2019-06-20 at 10 26 52" src="https://user-images.githubusercontent.com/687910/59837981-13c23800-9346-11e9-92b8-62495393f6d0.png">
