### PR TITLE
Add conviction custodial sentence feature specs

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -172,7 +172,7 @@ en:
           unpaid_work: Unpaid work
           # custodial_sentence
           detention_training_order: Detention and training order
-          detention: Detention (4 years or over)
+          detention: Detention
           # discharge
           absolute_discharge: Absolute discharge
           conditional_discharge: Conditional discharge

--- a/features/caution.feature
+++ b/features/caution.feature
@@ -7,20 +7,20 @@ Feature: Caution
 
   @happy_path
   Scenario: Over 18
-    When I choose "Caution"
+    When I choose "Cautioned"
     Then I should see "How old were you when you got cautioned?"
     And I choose "18 or over"
     Then I should see "Sorry, you cannot use this service yet"
 
   @happy_path
   Scenario: Caution happy path - under 18, conditional caution
-    When I choose "Caution"
+    When I choose "Cautioned"
     Then I should see "How old were you when you got cautioned?"
 
     And I choose "Under 18"
     Then I should see "What type of caution did you get?"
 
-    And I choose "Conditional caution"
+    And I choose "Youth Conditional caution"
 
     Then I should see "Did you stick to the conditions of the caution?"
 
@@ -38,7 +38,7 @@ Feature: Caution
 
   @happy_path
   Scenario: Caution happy path - under 18, simple caution
-    When I choose "Caution"
+    When I choose "Cautioned"
     Then I should see "How old were you when you got cautioned?"
     And I choose "Under 18"
     Then I should see "What type of caution did you get?"

--- a/features/caution.feature
+++ b/features/caution.feature
@@ -28,10 +28,7 @@ Feature: Caution
 
     Then I should see "When did the conditions end?"
 
-    And I fill in "Day" with "1"
-    And I fill in "Month" with "1"
-    And I fill in "Year" with "1999"
-    And I click the "Continue" button
+    When I enter a valid date
 
     Then I should see "Your caution expired on 01 January 1999"
 
@@ -47,10 +44,7 @@ Feature: Caution
 
     Then I should see "When did you get the caution?"
 
-    And I fill in "Day" with "1"
-    And I fill in "Month" with "1"
-    And I fill in "Year" with "1999"
-    And I click the "Continue" button
+    When I enter a valid date
 
     Then I should see "Your caution expired on 01 January 1999"
 

--- a/features/conviction_custodial_sentence.feature
+++ b/features/conviction_custodial_sentence.feature
@@ -1,0 +1,36 @@
+Feature: Conviction
+  Background:
+    When I am completing a basic under 18 "Custodial sentence" conviction
+    Then I should see "What was your custodial sentence?"
+
+  @happy_path
+  Scenario: Conviction Custodial sentence - Detention and training order
+    And I choose "Detention and training order"
+    Then I should see "When did you get convicted?"
+
+    And I fill in "Day" with "1"
+    And I fill in "Month" with "1"
+    And I fill in "Year" with "1999"
+    And I click the "Continue" button
+
+    Then I should see "Was the length of conviction given in weeks, months or years?"
+    And I choose "Weeks"
+
+    Then I should see "What was the length of the order?"
+    And I fill in "steps_conviction_conviction_length_form_conviction_length" with "10"
+
+  @happy_path
+  Scenario: Conviction Custodial sentence - Detention
+    And I choose "Detention"
+    Then I should see "When did you get convicted?"
+
+    And I fill in "Day" with "1"
+    And I fill in "Month" with "1"
+    And I fill in "Year" with "1999"
+    And I click the "Continue" button
+
+    Then I should see "Was the length of conviction given in weeks, months or years?"
+    And I choose "Weeks"
+
+    Then I should see "What was the length of the order?"
+    And I fill in "What was the length of the order?" with "10"

--- a/features/conviction_custodial_sentence.feature
+++ b/features/conviction_custodial_sentence.feature
@@ -8,26 +8,20 @@ Feature: Conviction
     And I choose "Detention and training order"
     Then I should see "When did you get convicted?"
 
-    And I fill in "Day" with "1"
-    And I fill in "Month" with "1"
-    And I fill in "Year" with "1999"
-    And I click the "Continue" button
+    When I enter a valid date
 
     Then I should see "Was the length of conviction given in weeks, months or years?"
     And I choose "Weeks"
 
     Then I should see "What was the length of the order?"
-    And I fill in "steps_conviction_conviction_length_form_conviction_length" with "10"
+    And I fill in "What was the length of the order?" with "10"
 
   @happy_path
   Scenario: Conviction Custodial sentence - Detention
     And I choose "Detention"
     Then I should see "When did you get convicted?"
 
-    And I fill in "Day" with "1"
-    And I fill in "Month" with "1"
-    And I fill in "Year" with "1999"
-    And I click the "Continue" button
+    When I enter a valid date
 
     Then I should see "Was the length of conviction given in weeks, months or years?"
     And I choose "Weeks"

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -35,7 +35,7 @@ When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |field, value|
 end
 
 When(/^I click the radio button "([^"]*)"$/) do |text|
-  find('label', text: text).click
+  find('label', exact_text: text).click
 end
 
 When(/^I choose "([^"]*)"$/) do |text|
@@ -47,4 +47,16 @@ And(/^I choose "([^"]*)" and fill in "([^"]*)" with "([^"]*)"$/) do |text, field
   step %[I click the radio button "#{text}"]
   step %[I fill in "#{field}" with "#{value}"]
   find('[name=commit]').click
+end
+
+When(/^I am completing a basic under 18 "([^"]*)" conviction$/) do |value|
+  step %[I visit "/"]
+  step %[I should see "Check if you need to disclose your criminal record"]
+  step %[I click the "Start now" link]
+  step %[I should see "Were you cautioned or convicted?"]
+  step %[I choose "Convicted"]
+  step %[I should see "How old were you when you got convicted?"]
+  step %[I choose "Under 18"]
+  step %[I should see "What type of conviction did you get?"]
+  step %[I choose "#{value}"]
 end

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -60,3 +60,10 @@ When(/^I am completing a basic under 18 "([^"]*)" conviction$/) do |value|
   step %[I should see "What type of conviction did you get?"]
   step %[I choose "#{value}"]
 end
+
+When(/^I enter a valid date$/) do
+  step %[I fill in "Day" with "1"]
+  step %[I fill in "Month" with "1"]
+  step %[I fill in "Year" with "1999"]
+  step %[I click the "Continue" button]
+end


### PR DESCRIPTION
Add feature tests for conviction custodial sentence basis on [Conviction rules matrix](https://docs.google.com/spreadsheets/d/1ZSCk-wgMfIc22GQahKH_ys4u-E9GWIn6dQ7mm5t1RFI/edit#gid=0).

Update Caution feature tests to include exact text 