### PR TITLE
fix issue with error message focus with text boxes

### DIFF
--- a/lib/govuk_components/error_helpers.rb
+++ b/lib/govuk_components/error_helpers.rb
@@ -61,18 +61,19 @@ module GovukComponents
       end
 
       def self.link_to_error(object_prefixes, attribute, suffix)
-        [*object_prefixes, attribute, suffix].join('_').prepend('#')
+        [*object_prefixes, attribute, suffix].reject(&:blank?).join('_').prepend('#')
       end
 
       def self.error_suffix(object)
         return choice_string(object) if choice?(object)
-        return 'dd' if date_type?(object)
+        return 'dd' if type?(object, 'date')
+        return if type?(object, 'integer')
 
         GenericYesNo.values.first.value.to_s
       end
 
-      def self.date_type?(object)
-        DisclosureCheck.columns_hash[object.class.attribute_names.first.to_s].type.to_s == 'date'
+      def self.type?(object, type)
+        DisclosureCheck.columns_hash[object.class.attribute_names.first.to_s].type.to_s == type
       end
 
       def self.choice?(object)

--- a/spec/fixtures/files/error_summary_text_box.html
+++ b/spec/fixtures/files/error_summary_text_box.html
@@ -1,0 +1,10 @@
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" data-module="error-summary" role="alert" tabindex="-1">
+  <h2 id="error-summary-title" class="govuk-error-summary__title">The length of conviction must be a number, like 3</h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <li>
+        <a href="#steps_conviction_conviction_length_form_conviction_length">The length of conviction must be a number, like 3</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/spec/lib/govuk_components/error_helpers_spec.rb
+++ b/spec/lib/govuk_components/error_helpers_spec.rb
@@ -46,5 +46,22 @@ RSpec.describe GovukElementsErrorsHelper do
         )
       end
     end
+
+
+    context 'text box' do
+      let(:html_output) { GovukElementsErrorsHelper.error_summary(conviction_length_form, 'The length of conviction must be a number, like 3') }
+      let(:html_fixture) { file_fixture('error_summary_text_box.html').read }
+      let(:conviction_length_form) { Steps::Conviction::ConvictionLengthForm.build(disclosure_check) }
+
+
+      it 'choice outputs the expected markup' do
+        conviction_length_form.errors.add(:conviction_length, :not_a_number)
+        expect(
+          strip_text(html_output)
+        ).to eq(
+          strip_text(html_fixture)
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Error message link will now focus on the text box. <img width="909" alt="Screen Shot 2019-06-24 at 13 37 03" src="https://user-images.githubusercontent.com/22822829/60019183-34132f00-9685-11e9-90c4-f42695affe0b.png"> 