### PR TITLE
 Make the `known_date` header dynamic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.6.2'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'govuk_elements_form_builder', '~> 1.3.0'
-gem 'gov_uk_date_fields', '~> 4.0.0'
+gem 'gov_uk_date_fields', '~> 4.0.1'
 gem 'jquery-rails'
 gem 'pg', '~> 1.0.0'
 gem 'puma', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    gov_uk_date_fields (4.0.0)
+    gov_uk_date_fields (4.0.1)
       rails (>= 5.0)
     govuk_elements_form_builder (1.3.0)
       govuk_elements_rails (>= 3.0.0)
@@ -364,7 +364,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker (>= 1.9.1)
-  gov_uk_date_fields (~> 4.0.0)
+  gov_uk_date_fields (~> 4.0.1)
   govuk_elements_form_builder (~> 1.3.0)
   i18n-debug
   i18n-tasks (~> 0.9.28)

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -9,6 +9,8 @@ class BaseForm
   attr_accessor :disclosure_check
   attr_accessor :record
 
+  delegate :conviction_type, :conviction_subtype, to: :disclosure_check
+
   # This will allow subclasses to define after_initialize callbacks
   # and is needed for some functionality to work, i.e. acts_as_gov_uk_date
   define_model_callbacks :initialize

--- a/app/forms/steps/conviction/conviction_subtype_form.rb
+++ b/app/forms/steps/conviction/conviction_subtype_form.rb
@@ -2,7 +2,6 @@ module Steps
   module Conviction
     class ConvictionSubtypeForm < BaseForm
       attribute :conviction_subtype, String
-      delegate :conviction_type, to: :disclosure_check
 
       validates_inclusion_of :conviction_subtype, in: :choices, if: :disclosure_check
 

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -41,6 +41,7 @@ class ConvictionType < ValueObject
     SEXUAL_HARM_PREVENTION_ORDER       = new(:sexual_harm_prevention_order,     parent: COMMUNITY_ORDER),
     SUPER_ORD_BREACH_CIVIL_INJUC       = new(:super_ord_breach_civil_injuc,     parent: COMMUNITY_ORDER),
     UNPAID_WORK                        = new(:unpaid_work,                      parent: COMMUNITY_ORDER),
+
     DETENTION_TRAINING_ORDER           = new(:detention_training_order,         parent: CUSTODIAL_SENTENCE),
     DETENTION                          = new(:detention,                        parent: CUSTODIAL_SENTENCE),
 

--- a/app/views/steps/conviction/known_date/edit.html.erb
+++ b/app/views/steps/conviction/known_date/edit.html.erb
@@ -10,7 +10,7 @@
         <%= error_summary %>
 
         <%= step_form @form_object do |f| %>
-          <%= f.gov_uk_date_field :known_date %>
+          <%= f.gov_uk_date_field :known_date, i18n_attribute: @form_object.conviction_subtype %>
 
           <%= f.continue_button %>
         <% end %>

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -9,13 +9,6 @@ en:
       known_date:
         edit:
           page_title: conviction date
-          heading: When did you get convicted?
-          lead_text: Date of conviction
-          no_caution_document:
-            title: I don’t have my caution document
-            content_html: If you don’t know the date you were cautioned, you can get this information for free by asking the police for a <a class="govuk-link" href='https://www.gov.uk/copy-of-police-records'>subject access request (SAR)</a>.
-          date_legend: Enter the date
-          date_hint: For example, 29 1 2018
       under_age:
         edit:
           page_title: convicted age

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -23,7 +23,16 @@ en:
       steps_conviction_under_age_form:
         under_age: How old were you when you got convicted?
       steps_conviction_known_date_form:
-        known_date: When did you get convicted?
+        known_date: When were you given the order?
+        detention_training_order: When were you given the detention and training order (DTO)?
+        detention: When were you given the detention?
+        absolute_discharge: When were you given the discharge?
+        conditional_discharge: When were you given the discharge?
+        behavioural_change_prog: When were you given the programme?
+        curfew: When were you given the curfew?
+        exclusion_requirement: When were you given the exclusion requirement?
+        intoxicating_substance_treatment: When were you given the treatment?
+        mental_health_treatment: When were you given the treatment?
       steps_conviction_conviction_type_form:
         conviction_type: What type of conviction did you get?
       steps_conviction_conviction_subtype_form:
@@ -140,7 +149,7 @@ en:
         under_age:
           'yes': Under 18
           'no': 18 or over
-      steps_conviction_conviction_date_form:
+      steps_conviction_known_date_form:
         day: Day
         month: Month
         year: Year

--- a/features/conviction_custodial_sentence.feature
+++ b/features/conviction_custodial_sentence.feature
@@ -6,7 +6,7 @@ Feature: Conviction
   @happy_path
   Scenario: Conviction Custodial sentence - Detention and training order
     And I choose "Detention and training order"
-    Then I should see "When did you get convicted?"
+    Then I should see "When were you given the detention and training order (DTO)?"
 
     When I enter a valid date
 
@@ -19,7 +19,7 @@ Feature: Conviction
   @happy_path
   Scenario: Conviction Custodial sentence - Detention
     And I choose "Detention"
-    Then I should see "When did you get convicted?"
+    Then I should see "When were you given the detention?"
 
     When I enter a valid date
 

--- a/features/conviction_financial.feature
+++ b/features/conviction_financial.feature
@@ -5,7 +5,7 @@ Feature: Conviction
   @happy_path
   Scenario: Conviction Financial penalty - Fine
     When I choose "A fine"
-    Then I should see "When did you get convicted?"
+    Then I should see "When were you given the order?"
     When I enter a valid date
     Then I should be on "/steps/check/results"
 

--- a/features/conviction_financial_discharge.feature
+++ b/features/conviction_financial_discharge.feature
@@ -6,14 +6,14 @@ Feature: Conviction
   @happy_path
   Scenario: Conviction Discharge - Absolute discharge
     And I choose "Absolute discharge"
-    Then I should see "When did you get convicted?"
+    Then I should see "When were you given the discharge?"
     When I enter a valid date
     Then I should be on "/steps/check/results"
 
   @happy_path
   Scenario: Conviction Discharge - Conditional discharge
     And I choose "Conditional discharge"
-    Then I should see "When did you get convicted?"
+    Then I should see "When were you given the discharge?"
     When I enter a valid date
 
     Then I should see "Was the length of conviction given in weeks, months or years?"

--- a/features/conviction_youth_rehabilitation_order.feature
+++ b/features/conviction_youth_rehabilitation_order.feature
@@ -2,7 +2,9 @@ Feature: Conviction
   Scenario Outline: Community or youth rehabilitation order (YRO)
   Given I am completing a basic under 18 "Community or youth rehabilitation order (YRO)" conviction
   Then I should see "What was your community order?"
-  And I choose <subtype>
+
+  When I choose <subtype>
+  Then I should see <header>
 
   When I enter a valid date
   Then I should see "Was the length of conviction given in weeks, months or years?"
@@ -13,20 +15,20 @@ Feature: Conviction
   Then I should be on <result>
 
   Examples:
-    | subtype                                                          | result                 |
-    | "Alcohol abstinence or treatment"                                | "/steps/check/results" |
-    | "Attendance centre order"                                        | "/steps/check/results" |
-    | "Behavioural change programme"                                   | "/steps/check/results" |
-    | "Curfew"                                                         | "/steps/check/results" |
-    | "Drug rehabilitation, treatment or testing"                      | "/steps/check/results" |
-    | "Exclusion requirement"                                          | "/steps/check/results" |
-    | "Intoxicating substance treatment requirement"                   | "/steps/check/results" |
-    | "Mental health treatment"                                        | "/steps/check/results" |
-    | "Prohibition"                                                    | "/steps/check/results" |
-    | "Referral order"                                                 | "/steps/check/results" |
-    | "Rehabilitation activity requirement (RAR)"                      | "/steps/check/results" |
-    | "Reparation order"                                               | "/steps/check/results" |
-    | "Residence requirement"                                          | "/steps/check/results" |
-    | "Sexual harm prevention order (sexual offence prevention order)" | "/steps/check/results" |
-    | "Supervision order on breach of a civil injunction"              | "/steps/check/results" |
-    | "Unpaid work"                                                    | "/steps/check/results" |
+    | subtype                                                          | header                                           | result                 |
+    | "Alcohol abstinence or treatment"                                | "When were you given the order?"                 | "/steps/check/results" |
+    | "Attendance centre order"                                        | "When were you given the order?"                 | "/steps/check/results" |
+    | "Behavioural change programme"                                   | "When were you given the programme?"             | "/steps/check/results" |
+    | "Curfew"                                                         | "When were you given the curfew?"                | "/steps/check/results" |
+    | "Drug rehabilitation, treatment or testing"                      | "When were you given the order?"                 | "/steps/check/results" |
+    | "Exclusion requirement"                                          | "When were you given the exclusion requirement?" | "/steps/check/results" |
+    | "Intoxicating substance treatment requirement"                   | "When were you given the treatment?"             | "/steps/check/results" |
+    | "Mental health treatment"                                        | "When were you given the treatment?"             | "/steps/check/results" |
+    | "Prohibition"                                                    | "When were you given the order?"                 | "/steps/check/results" |
+    | "Referral order"                                                 | "When were you given the order?"                 | "/steps/check/results" |
+    | "Rehabilitation activity requirement (RAR)"                      | "When were you given the order?"                 | "/steps/check/results" |
+    | "Reparation order"                                               | "When were you given the order?"                 | "/steps/check/results" |
+    | "Residence requirement"                                          | "When were you given the order?"                 | "/steps/check/results" |
+    | "Sexual harm prevention order (sexual offence prevention order)" | "When were you given the order?"                 | "/steps/check/results" |
+    | "Supervision order on breach of a civil injunction"              | "When were you given the order?"                 | "/steps/check/results" |
+    | "Unpaid work"                                                    | "When were you given the order?"                 | "/steps/check/results" |

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -41,4 +41,30 @@ RSpec.describe BaseForm do
       expect(subject.disclosure_check).to eq(disclosure_check)
     end
   end
+
+  describe 'delegate some frequently used methods to `disclosure_check`' do
+    let(:disclosure_check) {
+      instance_double(
+        DisclosureCheck, conviction_type: 'conviction_type', conviction_subtype: 'conviction_subtype'
+      )
+    }
+
+    before do
+      allow(subject).to receive(:disclosure_check).and_return(disclosure_check)
+    end
+
+    describe '#conviction_type' do
+      it 'delegates to `disclosure_checker`' do
+        expect(subject.conviction_type).to eq('conviction_type')
+        expect(disclosure_check).to have_received(:conviction_type)
+      end
+    end
+
+    describe '#conviction_subtype' do
+      it 'delegates to `disclosure_checker`' do
+        expect(subject.conviction_subtype).to eq('conviction_subtype')
+        expect(disclosure_check).to have_received(:conviction_subtype)
+      end
+    end
+  end
 end

--- a/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
@@ -17,13 +17,6 @@ RSpec.describe Steps::Conviction::ConvictionSubtypeForm do
 
   subject { described_class.new(arguments) }
 
-  describe '#conviction_type' do
-    it 'delegates to `disclosure_checker`' do
-      expect(disclosure_check).to receive(:conviction_type)
-      expect(subject.conviction_type).to eq('community_order')
-    end
-  end
-
   describe '#choices' do
     it 'returns the relevant choices (children of the conviction type)' do
       expect(subject.choices).to eq(%w(


### PR DESCRIPTION
Depending on the subtype of conviction, the header of this step can vary, so for example in most cases we talk about an `order` but in a few cases it can be a `sentence`, a `discharge` or even a `treatment`.

In order to do that we've bumped the version of the `gov_uk_date_fields` in this PR ministryofjustice/gov_uk_date_fields#36

Updated the cucumber tests to also test properly these headers.

Please note this is the first PR, but another one will be needed to do the same with other steps (and update the FormBuilder to also use the `i18n_attribute` for consistency).

<img width="665" alt="Screen Shot 2019-06-24 at 13 15 34" src="https://user-images.githubusercontent.com/687910/60028428-32526700-9697-11e9-817f-3342e8e1d8e2.png">

<img width="610" alt="Screen Shot 2019-06-24 at 15 46 33" src="https://user-images.githubusercontent.com/687910/60028477-472efa80-9697-11e9-9bf3-6c65637f9939.png">
