### PR TITLE
Add conviction end date calculator

### DIFF
--- a/app/services/base_calculator.rb
+++ b/app/services/base_calculator.rb
@@ -1,0 +1,13 @@
+class BaseCalculator
+  attr_reader :disclosure_check
+
+  def initialize(disclosure_check)
+    @disclosure_check = disclosure_check
+  end
+
+  private
+
+  def conviction_length
+    { disclosure_check.conviction_length_type.to_sym => disclosure_check.conviction_length }
+  end
+end

--- a/app/services/calculators/conviction_end_date_calculator.rb
+++ b/app/services/calculators/conviction_end_date_calculator.rb
@@ -1,0 +1,7 @@
+module Calculators
+  class ConvictionEndDateCalculator < BaseCalculator
+    def expiry_date
+      disclosure_check.known_date.advance(conviction_length)
+    end
+  end
+end

--- a/app/services/conviction_expiry_calculator.rb
+++ b/app/services/conviction_expiry_calculator.rb
@@ -6,6 +6,14 @@ class ConvictionExpiryCalculator
   end
 
   def expiry_date
-    'TBD'
+    return 'TBD' unless conviction_subtype.calculator_class?
+
+    conviction_subtype.calculator_class.new(disclosure_check).expiry_date
+  end
+
+  private
+
+  def conviction_subtype
+    ConvictionType.find_constant(disclosure_check.conviction_subtype)
   end
 end

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -1,10 +1,11 @@
 class ConvictionType < ValueObject
-  attr_reader :parent, :skip_length, :compensation
+  attr_reader :parent, :skip_length, :compensation, :calculator_class
 
   def initialize(raw_value, params = {})
     @parent = params.fetch(:parent, nil)
     @skip_length = params.fetch(:skip_length, false)
     @compensation = params.fetch(:compensation, false)
+    @calculator_class = params.fetch(:calculator_class, false)
 
     super(raw_value)
   end
@@ -15,6 +16,7 @@ class ConvictionType < ValueObject
 
   alias skip_length? skip_length
   alias compensation? compensation
+  alias calculator_class? calculator_class
 
   VALUES = [
     PARENT_TYPES = [
@@ -36,23 +38,23 @@ class ConvictionType < ValueObject
     PROHIBITION                        = new(:prohibition,                      parent: COMMUNITY_ORDER),
     REFERRAL_ORDER                     = new(:referral_order,                   parent: COMMUNITY_ORDER),
     REHAB_ACTIVITY_REQUIREMENT         = new(:rehab_activity_requirement,       parent: COMMUNITY_ORDER),
-    REPARATION_ORDER                   = new(:reparation_order,                 parent: COMMUNITY_ORDER),
+    REPARATION_ORDER                   = new(:reparation_order,                 parent: COMMUNITY_ORDER, calculator_class: Calculators::ConvictionEndDateCalculator),
     RESIDENCE_REQUIREMENT              = new(:residence_requirement,            parent: COMMUNITY_ORDER),
     SEXUAL_HARM_PREVENTION_ORDER       = new(:sexual_harm_prevention_order,     parent: COMMUNITY_ORDER),
-    SUPER_ORD_BREACH_CIVIL_INJUC       = new(:super_ord_breach_civil_injuc,     parent: COMMUNITY_ORDER),
+    SUPER_ORD_BREACH_CIVIL_INJUC       = new(:super_ord_breach_civil_injuc,     parent: COMMUNITY_ORDER, calculator_class: Calculators::ConvictionEndDateCalculator),
     UNPAID_WORK                        = new(:unpaid_work,                      parent: COMMUNITY_ORDER),
 
     DETENTION_TRAINING_ORDER           = new(:detention_training_order,         parent: CUSTODIAL_SENTENCE),
     DETENTION                          = new(:detention,                        parent: CUSTODIAL_SENTENCE),
 
     ABSOLUTE_DISCHARGE                 = new(:absolute_discharge,               parent: DISCHARGE, skip_length: true),
-    CONDITIONAL_DISCHARGE              = new(:conditional_discharge,            parent: DISCHARGE),
+    CONDITIONAL_DISCHARGE              = new(:conditional_discharge,            parent: DISCHARGE, calculator_class: Calculators::ConvictionEndDateCalculator),
 
     FINE                               = new(:fine,                             parent: FINANCIAL, skip_length: true),
     COMPENSATION_TO_A_VICTIM           = new(:compensation_to_a_victim,         parent: FINANCIAL, compensation: true),
 
-    HOSPITAL_ORDER                     = new(:hospital_order,                   parent: HOSPITAL_GUARD_ORDER),
-    GUARDIANSHIP_ORDER                 = new(:guardianship_order,               parent: HOSPITAL_GUARD_ORDER),
+    HOSPITAL_ORDER                     = new(:hospital_order,                   parent: HOSPITAL_GUARD_ORDER, calculator_class: Calculators::ConvictionEndDateCalculator),
+    GUARDIANSHIP_ORDER                 = new(:guardianship_order,               parent: HOSPITAL_GUARD_ORDER, calculator_class: Calculators::ConvictionEndDateCalculator),
   ].flatten.freeze
 
   # :nocov:

--- a/spec/services/calculators/conviction_end_date_calculator_spec.rb
+++ b/spec/services/calculators/conviction_end_date_calculator_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::ConvictionEndDateCalculator do
+  subject { described_class.new(disclosure_check) }
+
+  context '#expiry_date' do
+    let(:disclosure_check) { build(:disclosure_check,
+                                   known_date: known_date,
+                                   conviction_length: conviction_length,
+                                   conviction_length_type: conviction_length_type) }
+
+    let(:known_date) { Date.new(2018, 10, 31) }
+    let(:conviction_length) { 10 }
+
+    context 'conviction length in months' do
+      let(:conviction_length_type) { 'months' }
+
+      it 'returns expiry date 10 months advance' do
+        expect(subject.expiry_date.to_s).to eq(Date.new(2019, 8, 31).to_s)
+      end
+    end
+
+    context 'conviction length in weeks' do
+      let(:conviction_length_type) { 'weeks' }
+
+      it 'returns expiry date 10 weeks advance' do
+        expect(subject.expiry_date.to_s).to eq(Date.new(2019, 1, 9).to_s)
+      end
+    end
+
+    context 'conviction length in years' do
+      let(:conviction_length_type) { 'years' }
+
+      it 'returns expiry date 10 years advance' do
+        expect(subject.expiry_date.to_s).to eq(Date.new(2028, 10, 31).to_s)
+      end
+    end
+  end
+end

--- a/spec/services/conviction_expiry_calculator_spec.rb
+++ b/spec/services/conviction_expiry_calculator_spec.rb
@@ -1,14 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe ConvictionExpiryCalculator do
-  subject { described_class.new(disclosure_check: disclosure_check) }
+  subject { described_class.new(disclosure_check: disclosure_check, ) }
 
   context '#expiry_date' do
-    let(:disclosure_check) { build(:disclosure_check, :conviction) }
-    let(:expiry_date) { subject.expiry_date }
+    let(:disclosure_check) { build(:disclosure_check, :conviction,
+                                   conviction_subtype: conviction_subtype,
+                                   known_date: known_date,
+                                   conviction_length: conviction_length,
+                                   conviction_length_type: conviction_length_type) }
 
-    it 'is not yet implemented' do
-      expect(expiry_date).to eq('TBD')
+    let(:expiry_date) { subject.expiry_date }
+    let(:known_date) { nil }
+    let(:conviction_length) { nil }
+    let(:conviction_length_type) { nil }
+    let(:conviction_subtype) { nil }
+
+
+    context 'TBD' do
+      let (:conviction_subtype) { 'absolute_discharge' }
+      it 'is not yet implemented' do
+        expect(expiry_date).to eq('TBD')
+      end
+    end
+
+    context 'Rehabilitation finishes at the end of conviction period' do
+      let(:conviction_subtype) { 'hospital_order' }
+      let(:known_date) { Date.new(2018, 10, 31) }
+      let(:conviction_length) { 10 }
+      let(:conviction_length_type) { 'months' }
+
+      it 'is not yet implemented' do
+        expect(expiry_date.to_s).to eq('2019-08-31')
+      end
     end
   end
 end


### PR DESCRIPTION
Small class to calculate the end of conviction by adding conviction start date (known_date) with conviction length.  i.e  2000-01-01 + 1.year. 

Please note:  conviction length type is saved as  plural (months, weeks, days) has to be singular for the calculation. 

