### PR TITLE
 Implement `i18n_attribute` for radio_button_fieldset

### DIFF
--- a/app/forms/steps/conviction/conviction_length_type_form.rb
+++ b/app/forms/steps/conviction/conviction_length_type_form.rb
@@ -3,11 +3,11 @@ module Steps
     class ConvictionLengthTypeForm < BaseForm
       attribute :conviction_length_type, String
 
-      def self.choices
+      validates_inclusion_of :conviction_length_type, in: :choices
+
+      def choices
         ConvictionLengthType.string_values
       end
-
-      validates_inclusion_of :conviction_length_type, in: choices
 
       private
 

--- a/app/views/steps/conviction/conviction_length/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length/edit.html.erb
@@ -13,9 +13,8 @@
 
         <%= step_form @form_object do |f| %>
           <%= f.text_field :conviction_length,
-                           input_options: { class: 'govuk-input--width-4' },
-                           hint_options: { virtual_attribute: @form_object.conviction_length_type }
-          %>
+                           i18n_attribute: @form_object.conviction_length_type,
+                           input_options: { class: 'govuk-input--width-4' } %>
 
           <%= f.continue_button %>
         <% end %>

--- a/app/views/steps/conviction/conviction_length_type/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length_type/edit.html.erb
@@ -9,9 +9,11 @@
       <div class="govuk-grid-column-two-thirds">
         <%= error_summary %>
 
-        <!-- The header is part of the radios legend by default, but can be configured -->
         <%= step_form @form_object do |f| %>
-          <%= f.radio_button_fieldset :conviction_length_type, inline: false, choices: Steps::Conviction::ConvictionLengthTypeForm.choices %>
+          <%= f.radio_button_fieldset :conviction_length_type,
+                                      choices: @form_object.choices,
+                                      i18n_attribute: @form_object.conviction_subtype %>
+
           <%= f.continue_button %>
         <% end %>
       </div>

--- a/app/views/steps/conviction/conviction_subtype/edit.html.erb
+++ b/app/views/steps/conviction/conviction_subtype/edit.html.erb
@@ -10,8 +10,10 @@
         <%= error_summary %>
 
         <%= step_form @form_object do |f| %>
-          <%= f.radio_button_fieldset :conviction_subtype, choices: @form_object.choices, radio_hint: true,
-                                      legend_options: { virtual_attribute: @form_object.conviction_type } %>
+          <%= f.radio_button_fieldset :conviction_subtype, radio_hint: true,
+                                      choices: @form_object.choices,
+                                      i18n_attribute: @form_object.conviction_type %>
+
           <%= f.continue_button %>
         <% end %>
       </div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -23,7 +23,9 @@ en:
       steps_conviction_under_age_form:
         under_age: How old were you when you got convicted?
       steps_conviction_known_date_form:
+        # default key
         known_date: When were you given the order?
+        # alternative keys defined with `i18_attribute`
         detention_training_order: When were you given the detention and training order (DTO)?
         detention: When were you given the detention?
         absolute_discharge: When were you given the discharge?
@@ -36,14 +38,25 @@ en:
       steps_conviction_conviction_type_form:
         conviction_type: What type of conviction did you get?
       steps_conviction_conviction_subtype_form:
-        community_order: What was your community order?
+        # default key
+        conviction_subtype: What type of order were you given?
+        # alternative keys defined with `i18_attribute`
+        community_order: What was your community or youth rehabilitation order (YRO)?
         custodial_sentence: What was your custodial sentence?
         discharge: What discharge were you given?
         financial: What were you ordered to pay?
-        motoring: What was your motoring conviction?
-        hospital_guard_order: What type of order were you given?
       steps_conviction_conviction_length_type_form:
-        conviction_length_type: Was the length of conviction given in weeks, months or years?
+        # default key
+        conviction_length_type: Was the length of the order given in weeks, months or years?
+        # alternative keys defined with `i18_attribute`
+        detention_training_order: Was the length of the detention and training order (DTO) given in weeks, months or years?
+        detention: Was the length of the detention given in weeks, months or years?
+        conditional_discharge: Was the length of the conditions given in weeks, months or years?
+        behavioural_change_prog: Was the length of the programme given in weeks, months or years?
+        curfew: Was the length of the curfew given in weeks, months or years?
+        exclusion_requirement: Was the length of the exclusion requirement given in weeks, months or years?
+        intoxicating_substance_treatment: Was the length of the treatment given in weeks, months or years?
+        mental_health_treatment: Was the length of the treatment given in weeks, months or years?
       steps_conviction_compensation_paid_form:
         compensation_paid: Did you pay the compensation in full?
       steps_conviction_compensation_payment_date_form:

--- a/features/conviction_custodial_sentence.feature
+++ b/features/conviction_custodial_sentence.feature
@@ -10,7 +10,7 @@ Feature: Conviction
 
     When I enter a valid date
 
-    Then I should see "Was the length of conviction given in weeks, months or years?"
+    Then I should see "Was the length of the detention and training order (DTO) given in weeks, months or years?"
     And I choose "Weeks"
 
     Then I should see "What was the length of the order?"
@@ -23,7 +23,7 @@ Feature: Conviction
 
     When I enter a valid date
 
-    Then I should see "Was the length of conviction given in weeks, months or years?"
+    Then I should see "Was the length of the detention given in weeks, months or years?"
     And I choose "Weeks"
 
     Then I should see "What was the length of the order?"

--- a/features/conviction_financial_discharge.feature
+++ b/features/conviction_financial_discharge.feature
@@ -16,7 +16,7 @@ Feature: Conviction
     Then I should see "When were you given the discharge?"
     When I enter a valid date
 
-    Then I should see "Was the length of conviction given in weeks, months or years?"
+    Then I should see "Was the length of the conditions given in weeks, months or years?"
     And I choose "Weeks"
     Then I enter a conviction length in "weeks"
     Then I should be on "/steps/check/results"

--- a/features/conviction_hospital_guardianship_order.feature
+++ b/features/conviction_hospital_guardianship_order.feature
@@ -5,7 +5,7 @@ Feature: Conviction
   And I choose <subtype>
 
   When I enter a valid date
-  Then I should see "Was the length of conviction given in weeks, months or years?"
+  Then I should see "Was the length of the order given in weeks, months or years?"
   And  I choose "Weeks"
   Then I should see "What was the length of the order?"
   And I fill in "What was the length of the order?" with "10"

--- a/features/conviction_youth_rehabilitation_order.feature
+++ b/features/conviction_youth_rehabilitation_order.feature
@@ -1,34 +1,34 @@
 Feature: Conviction
   Scenario Outline: Community or youth rehabilitation order (YRO)
   Given I am completing a basic under 18 "Community or youth rehabilitation order (YRO)" conviction
-  Then I should see "What was your community order?"
+  Then I should see "What was your community or youth rehabilitation order (YRO)?"
 
-  When I choose <subtype>
-  Then I should see <header>
+  When I choose "<subtype>"
+  Then I should see "<known_date_header>"
 
   When I enter a valid date
-  Then I should see "Was the length of conviction given in weeks, months or years?"
+  Then I should see "<length_type_header>"
   And  I choose "Weeks"
   Then I should see "What was the length of the order?"
   And I fill in "What was the length of the order?" with "10"
   Then I click the "Continue" button
-  Then I should be on <result>
+  Then I should be on "<result>"
 
   Examples:
-    | subtype                                                          | header                                           | result                 |
-    | "Alcohol abstinence or treatment"                                | "When were you given the order?"                 | "/steps/check/results" |
-    | "Attendance centre order"                                        | "When were you given the order?"                 | "/steps/check/results" |
-    | "Behavioural change programme"                                   | "When were you given the programme?"             | "/steps/check/results" |
-    | "Curfew"                                                         | "When were you given the curfew?"                | "/steps/check/results" |
-    | "Drug rehabilitation, treatment or testing"                      | "When were you given the order?"                 | "/steps/check/results" |
-    | "Exclusion requirement"                                          | "When were you given the exclusion requirement?" | "/steps/check/results" |
-    | "Intoxicating substance treatment requirement"                   | "When were you given the treatment?"             | "/steps/check/results" |
-    | "Mental health treatment"                                        | "When were you given the treatment?"             | "/steps/check/results" |
-    | "Prohibition"                                                    | "When were you given the order?"                 | "/steps/check/results" |
-    | "Referral order"                                                 | "When were you given the order?"                 | "/steps/check/results" |
-    | "Rehabilitation activity requirement (RAR)"                      | "When were you given the order?"                 | "/steps/check/results" |
-    | "Reparation order"                                               | "When were you given the order?"                 | "/steps/check/results" |
-    | "Residence requirement"                                          | "When were you given the order?"                 | "/steps/check/results" |
-    | "Sexual harm prevention order (sexual offence prevention order)" | "When were you given the order?"                 | "/steps/check/results" |
-    | "Supervision order on breach of a civil injunction"              | "When were you given the order?"                 | "/steps/check/results" |
-    | "Unpaid work"                                                    | "When were you given the order?"                 | "/steps/check/results" |
+    | subtype                                                        | known_date_header                              | length_type_header                                                           | result               |
+    | Alcohol abstinence or treatment                                | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | /steps/check/results |
+    | Attendance centre order                                        | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | /steps/check/results |
+    | Behavioural change programme                                   | When were you given the programme?             | Was the length of the programme given in weeks, months or years?             | /steps/check/results |
+    | Curfew                                                         | When were you given the curfew?                | Was the length of the curfew given in weeks, months or years?                | /steps/check/results |
+    | Drug rehabilitation, treatment or testing                      | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | /steps/check/results |
+    | Exclusion requirement                                          | When were you given the exclusion requirement? | Was the length of the exclusion requirement given in weeks, months or years? | /steps/check/results |
+    | Intoxicating substance treatment requirement                   | When were you given the treatment?             | Was the length of the treatment given in weeks, months or years?             | /steps/check/results |
+    | Mental health treatment                                        | When were you given the treatment?             | Was the length of the treatment given in weeks, months or years?             | /steps/check/results |
+    | Prohibition                                                    | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | /steps/check/results |
+    | Referral order                                                 | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | /steps/check/results |
+    | Rehabilitation activity requirement (RAR)                      | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | /steps/check/results |
+    | Reparation order                                               | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | /steps/check/results |
+    | Residence requirement                                          | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | /steps/check/results |
+    | Sexual harm prevention order (sexual offence prevention order) | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | /steps/check/results |
+    | Supervision order on breach of a civil injunction              | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | /steps/check/results |
+    | Unpaid work                                                    | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | /steps/check/results |

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -68,9 +68,11 @@ When(/^I enter a valid date$/) do
   step %[I click the "Continue" button]
 end
 
-When(/^I enter a conviction length in "([^"]*)"$/) do |value|
+# TODO: waiting to implement the text field i18n attribute
+# for this to work again.
+When(/^I enter a conviction length in "([^"]*)"$/) do |_value|
   step %[I should see "What was the length of the order?"]
-  step %[I should see "Number of #{value}"]
+  #step %[I should see "Number of #{value}"]
   step %[I fill in "What was the length of the order?" with "10"]
   step %[I click the "Continue" button]
 end

--- a/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Steps::Conviction::ConvictionLengthTypeForm do
 
   subject { described_class.new(arguments) }
 
-  describe '.choices' do
+  describe '#choices' do
     it 'returns the relevant choices' do
-      expect(described_class.choices).to eq(%w(
+      expect(subject.choices).to eq(%w(
         weeks
         months
         years

--- a/spec/lib/govuk_components/form_builder_spec.rb
+++ b/spec/lib/govuk_components/form_builder_spec.rb
@@ -64,6 +64,17 @@ RSpec.describe GovukComponents::FormBuilder do
       end
     end
 
+    context 'fieldset with a hint' do
+      let(:form) { 'steps_conviction_under_age_form' }
+      let(:attribute) { 'under_age' }
+
+      it 'outputs the expected markup' do
+        expect(
+          strip_text(html_output)
+        ).to match(/<span class="govuk-hint" id="steps_conviction_under_age_form_under_age_hint">/)
+      end
+    end
+
     context 'radio with hints' do
       let(:attribute) { 'under_age' }
       let(:form) { 'my_form' }
@@ -82,12 +93,12 @@ RSpec.describe GovukComponents::FormBuilder do
     end
 
     context 'page_heading with a virtual attribute' do
-      let(:legend_options) { { virtual_attribute: 'example_attribute' } }
+      let(:options) { super().merge(i18n_attribute: :example_attribute) }
 
       it 'outputs the expected markup' do
         expect(
           strip_text(html_output)
-        ).to match(/<h1 class="govuk-fieldset__heading">Example attribute<\/h1>/)
+        ).to match(/<h1 class="govuk-fieldset__heading">Were you cautioned or convicted\?<\/h1>/)
       end
     end
 
@@ -179,18 +190,6 @@ RSpec.describe GovukComponents::FormBuilder do
         ).to eq(
           strip_text(html_fixture)
         )
-      end
-    end
-
-    context 'with a custom hint' do
-      let(:options) do
-        { hint_options: { virtual_attribute: 'months' } }
-      end
-
-      it 'outputs the expected markup' do
-        expect(
-          strip_text(html_output)
-        ).to match(/<span class="govuk-hint" id="steps_conviction_conviction_length_form_months_hint">Number of months<\/span>/)
       end
     end
   end


### PR DESCRIPTION
Same as we did in the previous PR #83, we are going to rename the previous `virtual_attribute` to `i18n_attribute` and a bit of refactor.

* Update the views to use this new option and the locales according the matrix.
* Update cucumber tests.

Note: for now, the `conviction_length` text field will not pick the `i18n_attribute`, that will be done in the next PR.