### PR TITLE
Add detention calculator

### DIFF
--- a/app/services/calculators/detention_calculator.rb
+++ b/app/services/calculators/detention_calculator.rb
@@ -1,0 +1,42 @@
+module Calculators
+  class DetentionCalculator < BaseCalculator
+    NEVER_SPENT_DURATION = 48
+    SIX_MONTHS_LESS_SPENT_DURATION = { months: 18 }.freeze
+    THIRTY_MONTHS_LESS_SPENT_DURATION = { months: 24 }.freeze
+    FOUR_YEARS_LESS_SPENT_DURATION =  { months: 42 }.freeze
+
+    def expiry_date
+      return 'never spent' if conviction_length_in_months >= NEVER_SPENT_DURATION
+
+      conviction_end_date.advance(spent_time)
+    end
+
+    private
+
+    def spent_time
+      case conviction_length_in_months
+      when 0..6
+        SIX_MONTHS_LESS_SPENT_DURATION
+      when 7..30
+        THIRTY_MONTHS_LESS_SPENT_DURATION
+      when 31..47
+        FOUR_YEARS_LESS_SPENT_DURATION
+      end
+    end
+
+    # TODO: this needs more testing as it's a bit of a work around.
+    def conviction_length_in_months
+      (conviction_start_date.beginning_of_month...conviction_end_date.beginning_of_month).select do |date|
+        date.day == 1
+      end.size
+    end
+
+    def conviction_start_date
+      @conviction_start_date ||= disclosure_check.known_date
+    end
+
+    def conviction_end_date
+      @conviction_end_date ||= disclosure_check.known_date.advance(conviction_length)
+    end
+  end
+end

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -44,8 +44,8 @@ class ConvictionType < ValueObject
     SUPER_ORD_BREACH_CIVIL_INJUC       = new(:super_ord_breach_civil_injuc,     parent: COMMUNITY_ORDER, calculator_class: Calculators::ConvictionEndDateCalculator),
     UNPAID_WORK                        = new(:unpaid_work,                      parent: COMMUNITY_ORDER),
 
-    DETENTION_TRAINING_ORDER           = new(:detention_training_order,         parent: CUSTODIAL_SENTENCE),
-    DETENTION                          = new(:detention,                        parent: CUSTODIAL_SENTENCE),
+    DETENTION_TRAINING_ORDER           = new(:detention_training_order,         parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::DetentionCalculator),
+    DETENTION                          = new(:detention,                        parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::DetentionCalculator),
 
     ABSOLUTE_DISCHARGE                 = new(:absolute_discharge,               parent: DISCHARGE, skip_length: true),
     CONDITIONAL_DISCHARGE              = new(:conditional_discharge,            parent: DISCHARGE, calculator_class: Calculators::ConvictionEndDateCalculator),

--- a/spec/services/calculators/detention_calculator_spec.rb
+++ b/spec/services/calculators/detention_calculator_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::DetentionCalculator do
+  subject { described_class.new(disclosure_check) }
+
+  context '#expiry_date' do
+    let(:disclosure_check) { build(:disclosure_check,
+                                   known_date: known_date,
+                                   conviction_length: conviction_length,
+                                   conviction_length_type: conviction_length_type) }
+
+    let(:known_date) { Date.new(2016, 10, 20) }
+    let(:conviction_length) { nil }
+
+    context 'never spent for conviction length over 4 years' do
+      let(:result) { 'never spent' }
+      context 'conviction length in weeks' do
+        let(:conviction_length_type) { 'weeks' }
+        let(:conviction_length) { 208 }
+        it { expect(subject.expiry_date).to eq(result) }
+      end
+
+      context 'conviction length in months' do
+        let(:conviction_length_type) { 'months' }
+        let(:conviction_length) { 48 }
+        it { expect(subject.expiry_date).to eq(result) }
+      end
+
+      context 'conviction length in years' do
+        let(:conviction_length_type) { 'years' }
+        let(:conviction_length) { 4 }
+        it { expect(subject.expiry_date).to eq(result) }
+      end
+    end
+
+    context 'Spent duration for conviction length of 6 months or less' do
+      context 'conviction length in weeks' do
+        let(:conviction_length_type) { 'weeks' }
+        let(:conviction_length) { 27 }
+        it { expect(subject.expiry_date.to_s).to eq('2018-10-27') }
+      end
+
+      context 'conviction length in months' do
+        let(:conviction_length_type) { 'months' }
+        let(:conviction_length) { 5 }
+        it { expect(subject.expiry_date.to_s).to eq('2018-09-20') }
+      end
+
+      context 'conviction length in years' do
+        let(:conviction_length_type) { 'years' }
+        let(:conviction_length) { 0 }
+        it { expect(subject.expiry_date.to_s).to eq('2018-04-20') }
+      end
+    end
+
+    context 'Spent duration for conviction length of 7 to 30 months' do
+      context 'conviction length in weeks' do
+        let(:conviction_length_type) { 'weeks' }
+        let(:conviction_length) { 29 }
+        it { expect(subject.expiry_date.to_s).to eq('2019-05-11') }
+      end
+
+      context 'conviction length in months' do
+        let(:conviction_length_type) { 'months' }
+        let(:conviction_length) { 29 }
+        it { expect(subject.expiry_date.to_s).to eq('2021-03-20') }
+      end
+
+      context 'conviction length in years' do
+        let(:conviction_length_type) { 'years' }
+        let(:conviction_length) { 2 }
+        it { expect(subject.expiry_date.to_s).to eq('2020-10-20') }
+      end
+    end
+
+    context 'Spent duration for conviction length of over 30 months and less than 4 years' do
+      context 'conviction length in weeks' do
+        let(:conviction_length_type) { 'weeks' }
+        let(:conviction_length) { 190 }
+        it { expect(subject.expiry_date.to_s).to eq('2023-12-11') }
+      end
+
+      context 'conviction length in months' do
+        let(:conviction_length_type) { 'months' }
+        let(:conviction_length) { 47 }
+        it { expect(subject.expiry_date.to_s).to eq('2024-03-20') }
+      end
+
+      context 'conviction length in years' do
+        let(:conviction_length_type) { 'years' }
+        let(:conviction_length) { 3 }
+        it { expect(subject.expiry_date.to_s).to eq('2023-04-20') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Small class to calculate the spent date for detention based on the following logic:

- If conviction length is 6 months or less: conviction start date + conviction length + 18 months
- If conviction length is over 6 months and less than or equal to 30 months: conviction start date + conviction length + 2 years
- If conviction length is over 30 months and less than 4 years: conviction start date + conviction length + 3.5 years
- If conviction length is 4 years or over: never spent"