### PR TITLE
 Add subsection to the conviction views

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,6 +25,14 @@ module ApplicationHelper
     end
   end
 
+  def step_subsection(form_object = @form_object)
+    capture do
+      render partial: 'step_subsection', locals: {
+        subsection: form_object.conviction_subtype
+      }
+    end
+  end
+
   def error_summary(form_object = @form_object)
     return unless GovukElementsErrorsHelper.errors_exist?(form_object)
 

--- a/app/views/application/_step_subsection.html.erb
+++ b/app/views/application/_step_subsection.html.erb
@@ -1,0 +1,3 @@
+<span class="govuk-caption-l">
+  <%=t subsection, scope: [:shared, :subsection], default: '' %>
+</span>

--- a/app/views/steps/conviction/compensation_paid/edit.html.erb
+++ b/app/views/steps/conviction/compensation_paid/edit.html.erb
@@ -8,6 +8,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= error_summary %>
+        <%= step_subsection %>
 
         <!-- The header is part of the radios legend by default, but can be configured -->
 

--- a/app/views/steps/conviction/compensation_payment_date/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_date/edit.html.erb
@@ -8,6 +8,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= error_summary %>
+        <%= step_subsection %>
 
         <%= step_form @form_object do |f| %>
           <%= f.gov_uk_date_field :compensation_payment_date %>

--- a/app/views/steps/conviction/conviction_length/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length/edit.html.erb
@@ -8,6 +8,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= error_summary %>
+        <%= step_subsection %>
 
         <h1 class="govuk-heading-xl">
           <%=t ".heading.#{@form_object.conviction_subtype}", default: t('.heading.default') %>

--- a/app/views/steps/conviction/conviction_length_type/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length_type/edit.html.erb
@@ -8,6 +8,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= error_summary %>
+        <%= step_subsection %>
 
         <%= step_form @form_object do |f| %>
           <%= f.radio_button_fieldset :conviction_length_type,

--- a/app/views/steps/conviction/is_date_known/edit.html.erb
+++ b/app/views/steps/conviction/is_date_known/edit.html.erb
@@ -8,6 +8,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= error_summary %>
+        <%= step_subsection %>
 
         <!-- The header is part of the radios legend by default, but can be configured -->
 

--- a/app/views/steps/conviction/known_date/edit.html.erb
+++ b/app/views/steps/conviction/known_date/edit.html.erb
@@ -8,6 +8,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= error_summary %>
+        <%= step_subsection %>
 
         <%= step_form @form_object do |f| %>
           <%= f.gov_uk_date_field :known_date, i18n_attribute: @form_object.conviction_subtype %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -1,5 +1,49 @@
 ---
 en:
+  dictionary:
+    CONVICTION_TYPES: &CONVICTION_TYPES
+      community_order: Community or youth rehabilitation order (YRO)
+      custodial_sentence: Custodial sentence
+      discharge: Discharge
+      financial: Financial penalty
+      hospital_guard_order: Hospital or guardianship order
+    CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
+      # community_order
+      alcohol_abstinence_treatment: Alcohol abstinence or treatment
+      attendance_centre_order: Attendance centre order
+      behavioural_change_prog: Behavioural change programme
+      curfew: Curfew
+      drug_rehabilitation: Drug rehabilitation, treatment or testing
+      exclusion_requirement: Exclusion requirement
+      foreign_travel_prohibition: Foreign travel prohibition
+      intoxicating_substance_treatment: Intoxicating substance treatment requirement
+      mental_health_treatment: Mental health treatment
+      prohibition: Prohibition
+      referral_order: Referral order
+      rehab_activity_requirement: Rehabilitation activity requirement (RAR)
+      reparation_order: Reparation order
+      residence_requirement: Residence requirement
+      sexual_harm_prevention_order: Sexual harm prevention order (sexual offence prevention order)
+      super_ord_breach_civil_injuc: Supervision order on breach of a civil injunction
+      unpaid_work: Unpaid work
+      # custodial_sentence
+      detention_training_order: Detention and training order
+      detention: Detention
+      # discharge
+      absolute_discharge: Absolute discharge
+      conditional_discharge: Conditional discharge
+      # financial
+      fine: A fine
+      compensation_to_a_victim: Compensation to a victim
+      # hospital_guard_order
+      hospital_order: Hospital order
+      guardianship_order: Guardianship order
+
+  shared:
+    back_link: Back
+    subsection:
+      <<: *CONVICTION_SUBTYPES
+
   helpers:
     submit:
       continue: Continue
@@ -94,7 +138,6 @@ en:
           discharge: For example, a conditional discharge order or bind over
           financial: For example, paying a fine or compensation
           hospital_guard_order: For example, if there were mental health concerns
-          motoring: For example you were given penalty points or a disqualification at court
         conviction_subtype:
           # community_order
           alcohol_abstinence_treatment: You were ordered not to drink, or were given help to stop you drinking
@@ -122,10 +165,6 @@ en:
           # financial
           fine: ""
           compensation_to_a_victim: ""
-          # motoring
-          disqualification: You were banned from driving for a certain period of time
-          endorsement: You were found guilty of a motoring offence, which is now included on your driver record
-          penalty_points: You were given number of penalty points for a driving offence
           # hospital_guard_order
           hospital_order: ""
           guardianship_order: ""
@@ -168,48 +207,10 @@ en:
         year: Year
       steps_conviction_conviction_type_form:
         conviction_type:
-          community_order: Community or youth rehabilitation order (YRO)
-          custodial_sentence: Custodial sentence
-          discharge: Discharge
-          financial: Financial penalty
-          hospital_guard_order: Hospital or guardianship order
-          motoring: Motoring endorsement
+          <<: *CONVICTION_TYPES
       steps_conviction_conviction_subtype_form:
         conviction_subtype:
-          # community_order
-          alcohol_abstinence_treatment: Alcohol abstinence or treatment
-          attendance_centre_order: Attendance centre order
-          behavioural_change_prog: Behavioural change programme
-          curfew: Curfew
-          drug_rehabilitation: Drug rehabilitation, treatment or testing
-          exclusion_requirement: Exclusion requirement
-          foreign_travel_prohibition: Foreign travel prohibition
-          intoxicating_substance_treatment: Intoxicating substance treatment requirement
-          mental_health_treatment: Mental health treatment
-          prohibition: Prohibition
-          referral_order: Referral order
-          rehab_activity_requirement: Rehabilitation activity requirement (RAR)
-          reparation_order: Reparation order
-          residence_requirement: Residence requirement
-          sexual_harm_prevention_order: Sexual harm prevention order (sexual offence prevention order)
-          super_ord_breach_civil_injuc: Supervision order on breach of a civil injunction
-          unpaid_work: Unpaid work
-          # custodial_sentence
-          detention_training_order: Detention and training order
-          detention: Detention
-          # discharge
-          absolute_discharge: Absolute discharge
-          conditional_discharge: Conditional discharge
-          # financial
-          fine: A fine
-          compensation_to_a_victim: Compensation to a victim
-          # motoring
-          disqualification: Disqualification
-          endorsement: Endorsement
-          penalty_points: Penalty points
-          # hospital_guard_order
-          hospital_order: Hospital order
-          guardianship_order: Guardianship order
+          <<: *CONVICTION_SUBTYPES
       steps_conviction_conviction_length_type_form:
         conviction_length_type:
           weeks: Weeks

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -1,5 +1,48 @@
 ---
 en:
+  dictionary:
+    CONVICTION_TYPES: &CONVICTION_TYPES
+      community_order: Community or youth rehabilitation order (YRO)
+      custodial_sentence: Custodial sentence
+      discharge: Discharge
+      financial: Financial penalty
+      hospital_guard_order: Hospital or guardianship order
+    CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
+      # community_order
+      alcohol_abstinence_treatment: Alcohol abstinence or treatment
+      attendance_centre_order: Attendance centre order
+      behavioural_change_prog: Behavioural change programme
+      curfew: Curfew
+      drug_rehabilitation: Drug rehabilitation, treatment or testing
+      exclusion_requirement: Exclusion requirement
+      foreign_travel_prohibition: Foreign travel prohibition
+      intoxicating_substance_treatment: Intoxicating substance treatment requirement
+      mental_health_treatment: Mental health treatment
+      prohibition: Prohibition
+      referral_order: Referral order
+      rehab_activity_requirement: Rehabilitation activity requirement (RAR)
+      reparation_order: Reparation order
+      residence_requirement: Residence requirement
+      sexual_harm_prevention_order: Sexual harm prevention order (sexual offence prevention order)
+      super_ord_breach_civil_injuc: Supervision order on breach of a civil injunction
+      unpaid_work: Unpaid work
+      # custodial_sentence
+      detention_training_order: Detention and training order
+      detention: Detention
+      # discharge
+      absolute_discharge: Absolute discharge
+      conditional_discharge: Conditional discharge
+      # financial
+      fine: A fine
+      compensation_to_a_victim: Compensation to a victim
+      # motoring
+      disqualification: Disqualification
+      endorsement: Endorsement
+      penalty_points: Penalty points
+      # hospital_guard_order
+      hospital_order: Hospital order
+      guardianship_order: Guardianship order
+
   results/caution:
     kind:
       question: Criminal record type
@@ -33,45 +76,11 @@ en:
     conviction_type:
       question: Type of conviction
       answers:
-        community_order: Community order
-        custodial_sentence: Custodial sentence
-        discharge: Discharge
-        financial: Financial penalty
-        hospital_order: Hospital Order
-        motoring: Motoring endorsement
+        <<: *CONVICTION_TYPES
     conviction_subtype:
       question: Name of conviction
       answers:
-        # community_order
-        alcohol_abstinence: Alcohol abstinence
-        alcohol_treatment: Alcohol treatment
-        behavioural_change_prog: Behavioural change programme
-        curfew: Curfew
-        drug_rehabilitation: Drug rehabilitation
-        exclusion_requirement: Exclusion requirement
-        foreign_travel_prohibition: Foreign travel prohibition
-        mental_health_treatment: Mental health treatment
-        prohibition: Prohibition
-        referral_order: Referral order
-        rehab_activity_requirement: Rehabilitation activity requirement
-        reparation_order: Reparation order
-        residence_requirement: Residence requirement
-        sexual_harm_prevention_order: Sexual harm prevention order (sexual offence prevention order)
-        super_ord_breach_civil_injuc: Supervision order on breach of a civil injunction
-        unpaid_work: Unpaid work
-        # custodial_sentence
-        detention_training_order: Detention and training order
-        detention: Detention (4 years or over)
-        # discharge
-        absolute_discharge: Absolute discharge
-        conditional_discharge: Conditional discharge
-        # financial
-        fine: A fine
-        compensation_to_a_victim: Compensation to a victim
-        # motoring
-        disqualification: Disqualification
-        endorsement: Endorsement
-        penalty_points: Penalty points
+        <<: *CONVICTION_SUBTYPES
     under_age:
       question: Age at time of conviction
       answers:

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -1,4 +1,0 @@
----
-en:
-  shared:
-    back_link: Back

--- a/features/conviction_discharge.feature
+++ b/features/conviction_discharge.feature
@@ -6,16 +6,19 @@ Feature: Conviction
   @happy_path
   Scenario: Conviction Discharge - Absolute discharge
     And I choose "Absolute discharge"
-    Then I should see "When were you given the discharge?"
+    Then I should see subsection "Absolute discharge"
+    And I should see "When were you given the discharge?"
+
     When I enter a valid date
     Then I should be on "/steps/check/results"
 
   @happy_path
   Scenario: Conviction Discharge - Conditional discharge
     And I choose "Conditional discharge"
-    Then I should see "When were you given the discharge?"
-    When I enter a valid date
+    Then I should see subsection "Conditional discharge"
+    And I should see "When were you given the discharge?"
 
+    When I enter a valid date
     Then I should see "Was the length of the conditions given in weeks, months or years?"
     And I choose "Years"
 

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -14,6 +14,10 @@ Then(/^I should not see "([^"]*)"$/) do |text|
   expect(page).not_to have_text(text)
 end
 
+And(/^I should see subsection "([^"]*)"$/) do |text|
+  expect(page).to have_css('span.govuk-caption-l', exact_text: text)
+end
+
 Then(/^I should see a "([^"]*)" link to "([^"]*)"$/) do |text, href|
   expect(page).to have_link(text, href: href)
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#step_subsection' do
+    let(:form_object) { double('form object', conviction_subtype: 'conviction_subtype') }
+
+    it 'renders the expected content' do
+      expect(helper).to receive(:render).with(partial: 'step_subsection', locals: {subsection: 'conviction_subtype'}).and_return('foobar')
+      expect(helper.step_subsection(form_object)).to eq('foobar')
+    end
+  end
+
   describe '#error_summary' do
     context 'when no form object is given' do
       let(:form_object) { nil }


### PR DESCRIPTION
Identical to what we do with the `step_header` to render the "back" link, in some steps we want to show the conviction subtype as a subsection.

The locales have been reorganised a bit so we can take advantage of shared keys.

<img width="582" alt="Screen Shot 2019-06-26 at 15 42 10" src="https://user-images.githubusercontent.com/687910/60189599-14b50700-9829-11e9-8a56-cc6cd85633b6.png">
