### PR TITLE
 Add new radio for `no length given`

### DIFF
--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -4,12 +4,12 @@ class BaseForm
   include Virtus.model
   include ActiveModel::Validations
   include FormAttributeMethods
+  include ValueObjectMethods
+
   extend ActiveModel::Callbacks
 
   attr_accessor :disclosure_check
   attr_accessor :record
-
-  delegate :conviction_type, :conviction_subtype, to: :disclosure_check
 
   # This will allow subclasses to define after_initialize callbacks
   # and is needed for some functionality to work, i.e. acts_as_gov_uk_date

--- a/app/forms/steps/conviction/conviction_length_type_form.rb
+++ b/app/forms/steps/conviction/conviction_length_type_form.rb
@@ -19,7 +19,8 @@ module Steps
         raise DisclosureCheckNotFound unless disclosure_check
 
         disclosure_check.update(
-          conviction_length_type: conviction_length_type
+          conviction_length_type: conviction_length_type,
+          conviction_length: nil
         )
       end
     end

--- a/app/forms/steps/conviction/conviction_length_type_form.rb
+++ b/app/forms/steps/conviction/conviction_length_type_form.rb
@@ -3,10 +3,14 @@ module Steps
     class ConvictionLengthTypeForm < BaseForm
       attribute :conviction_length_type, String
 
-      validates_inclusion_of :conviction_length_type, in: :choices
+      validates_inclusion_of :conviction_length_type, in: :choices, if: :disclosure_check
 
       def choices
-        ConvictionLengthType.string_values
+        if conviction_type.eql?(ConvictionType::COMMUNITY_ORDER)
+          ConvictionLengthType.values
+        else
+          ConvictionLengthType.values - [ConvictionLengthType::NO_LENGTH]
+        end.map(&:to_s)
       end
 
       private

--- a/app/forms/value_object_methods.rb
+++ b/app/forms/value_object_methods.rb
@@ -1,0 +1,15 @@
+module ValueObjectMethods
+  def self.included(base)
+    base.send :include, InstanceMethods
+  end
+
+  module InstanceMethods
+    def conviction_type
+      ConvictionType.find_constant(disclosure_check.conviction_type)
+    end
+
+    def conviction_subtype
+      ConvictionType.find_constant(disclosure_check.conviction_subtype)
+    end
+  end
+end

--- a/app/services/calculators/youth_rehabilitation_order_calculator.rb
+++ b/app/services/calculators/youth_rehabilitation_order_calculator.rb
@@ -7,7 +7,6 @@ module Calculators
     SPENT_DURATION_WITH_NO_LENGTH = { months: 24 }.freeze
 
     def expiry_date
-      # TODO: Update when no length option is added
       return conviction_start_date.advance(SPENT_DURATION_WITH_NO_LENGTH) if no_length?
 
       conviction_end_date.advance(SPENT_DURATION_WITH_LENGTH)

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -1,4 +1,6 @@
 class ConvictionDecisionTree < BaseDecisionTree
+  include ValueObjectMethods
+
   # rubocop:disable Metrics/CyclomaticComplexity
   def destination
     return next_step if next_step
@@ -7,7 +9,7 @@ class ConvictionDecisionTree < BaseDecisionTree
     when :under_age
       after_under_age
     when :conviction_type
-      after_conviction_type
+      edit(:conviction_subtype)
     when :conviction_subtype
       after_conviction_subtype
     when :known_date
@@ -30,12 +32,6 @@ class ConvictionDecisionTree < BaseDecisionTree
     return edit(:conviction_type) if GenericYesNo.new(disclosure_check.under_age).yes?
 
     show('/steps/check/exit_over18')
-  end
-
-  def after_conviction_type
-    return edit(:conviction_subtype) if conviction.children.any?
-
-    edit(:known_date)
   end
 
   def after_conviction_subtype
@@ -65,13 +61,5 @@ class ConvictionDecisionTree < BaseDecisionTree
 
   def results
     show('/steps/check/results')
-  end
-
-  def conviction
-    ConvictionType.find_constant(step_value(:conviction_type))
-  end
-
-  def conviction_subtype
-    ConvictionType.find_constant(disclosure_check.conviction_subtype)
   end
 end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -13,7 +13,7 @@ class ConvictionDecisionTree < BaseDecisionTree
     when :known_date
       after_known_date
     when :conviction_length_type
-      edit(:conviction_length)
+      after_conviction_length_type
     when :compensation_paid
       after_compensation_paid
     when :conviction_length, :compensation_payment_date
@@ -48,6 +48,12 @@ class ConvictionDecisionTree < BaseDecisionTree
     return results if conviction_subtype.skip_length?
 
     edit(:conviction_length_type)
+  end
+
+  def after_conviction_length_type
+    return results if step_value(:conviction_length_type).inquiry.no_length?
+
+    edit(:conviction_length)
   end
 
   def after_compensation_paid

--- a/app/value_objects/conviction_length_type.rb
+++ b/app/value_objects/conviction_length_type.rb
@@ -3,6 +3,7 @@ class ConvictionLengthType < ValueObject
     WEEKS = new(:weeks),
     MONTHS = new(:months),
     YEARS = new(:years),
+    NO_LENGTH = new(:no_length),
   ].freeze
 
   def self.values

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -42,7 +42,7 @@ en:
         steps/conviction/conviction_length_type_form:
           attributes:
             conviction_length_type:
-              inclusion: Select weeks or months
+              inclusion: Select how was the length given
         steps/conviction/conviction_length_form:
           attributes:
             conviction_length:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -169,11 +169,6 @@ en:
           hospital_order: ""
           guardianship_order: ""
 
-        conviction_length:
-          weeks: ""
-          months: ""
-          years: ""
-
     label:
       steps_check_kind_form:
         kind:
@@ -216,6 +211,7 @@ en:
           weeks: Weeks
           months: Months
           years: Years
+          no_length: No length was given
       steps_conviction_conviction_length_form:
         weeks: Number of weeks
         months: Number of months

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -96,3 +96,4 @@ en:
         weeks: Weeks
         months: Months
         years: Years
+        no_length: No length was given

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe BaseForm do
     end
   end
 
-  describe 'delegate some frequently used methods to `disclosure_check`' do
+  describe 'conviction_type and conviction_subtype value objects' do
     let(:disclosure_check) {
       instance_double(
-        DisclosureCheck, conviction_type: 'conviction_type', conviction_subtype: 'conviction_subtype'
+        DisclosureCheck, conviction_type: 'community_order', conviction_subtype: 'detention_training_order'
       )
     }
 
@@ -54,16 +54,14 @@ RSpec.describe BaseForm do
     end
 
     describe '#conviction_type' do
-      it 'delegates to `disclosure_checker`' do
-        expect(subject.conviction_type).to eq('conviction_type')
-        expect(disclosure_check).to have_received(:conviction_type)
+      it 'returns the value object constant' do
+        expect(subject.conviction_type).to eq(ConvictionType::COMMUNITY_ORDER)
       end
     end
 
     describe '#conviction_subtype' do
-      it 'delegates to `disclosure_checker`' do
-        expect(subject.conviction_subtype).to eq('conviction_subtype')
-        expect(disclosure_check).to have_received(:conviction_subtype)
+      it 'returns the value object constant' do
+        expect(subject.conviction_subtype).to eq(ConvictionType::DETENTION_TRAINING_ORDER)
       end
     end
   end

--- a/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
@@ -5,19 +5,35 @@ RSpec.describe Steps::Conviction::ConvictionLengthTypeForm do
     disclosure_check: disclosure_check,
     conviction_length_type: conviction_length_type
   } }
-  let(:disclosure_check) { instance_double(DisclosureCheck) }
+
+  let(:disclosure_check) { instance_double(DisclosureCheck, conviction_type: conviction_type) }
+  let(:conviction_type) { ConvictionType::COMMUNITY_ORDER.to_s }
   let(:conviction_length_type) { 'weeks' }
 
   subject { described_class.new(arguments) }
 
   describe '#choices' do
-    it 'returns the relevant choices' do
-      expect(subject.choices).to eq(%w(
-        weeks
-        months
-        years
-        no_length
-      ))
+    context 'for a community order' do
+      it 'the choices include `no_length`' do
+        expect(subject.choices).to eq(%w(
+          weeks
+          months
+          years
+          no_length
+        ))
+      end
+    end
+
+    context 'for an order, other than community order' do
+      let(:conviction_type) { ConvictionType::DISCHARGE.to_s }
+
+      it 'the choices does not include `no_length`' do
+        expect(subject.choices).to eq(%w(
+          weeks
+          months
+          years
+        ))
+      end
     end
   end
 

--- a/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe Steps::Conviction::ConvictionLengthTypeForm do
 
       it 'saves the record' do
         expect(disclosure_check).to receive(:update).with(
-          conviction_length_type: conviction_length_type
+          conviction_length_type: conviction_length_type,
+          conviction_length: nil
         ).and_return(true)
 
         expect(subject.save).to be(true)

--- a/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Steps::Conviction::ConvictionLengthTypeForm do
         weeks
         months
         years
+        no_length
       ))
     end
   end

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -79,8 +79,17 @@ RSpec.describe ConvictionDecisionTree do
   end
 
   context 'when the step is `conviction_length_type` ' do
-    let(:step_params) { { conviction_length_type: 'weeks' } }
-    it { is_expected.to have_destination(:conviction_length, :edit) }
+    let(:step_params) { { conviction_length_type: conviction_length_type } }
+
+    context 'and the answer is `no_length`' do
+      let(:conviction_length_type) { ConvictionLengthType::NO_LENGTH.to_s }
+      it { is_expected.to have_destination('/steps/check/results', :show) }
+    end
+
+    context 'and the answer is other than `no_length`' do
+      let(:conviction_length_type) { ConvictionLengthType::MONTHS.to_s }
+      it { is_expected.to have_destination(:conviction_length, :edit) }
+    end
   end
 
   context 'when the step is `conviction_length`' do

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -51,17 +51,9 @@ RSpec.describe ConvictionDecisionTree do
   end
 
   context 'when the step is `conviction_type`' do
-    let(:step_params) { { conviction_type: type } }
-
-    context 'and type has children subtypes' do
-      let(:type) { 'community_order' }
-      it { is_expected.to have_destination(:conviction_subtype, :edit) }
-    end
-
-    context 'and type has no children subtypes' do
-      let(:type) { 'hospital_order' }
-      it { is_expected.to have_destination(:known_date, :edit) }
-    end
+    let(:step_params) { { conviction_type: conviction_type } }
+    let(:conviction_type) { 'community_order' }
+    it { is_expected.to have_destination(:conviction_subtype, :edit) }
   end
 
   context 'when the step is `conviction_subtype`' do

--- a/spec/value_objects/conviction_length_type_spec.rb
+++ b/spec/value_objects/conviction_length_type_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe ConvictionLengthType do
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w(
+        weeks
+        months
+        years
+        no_length
+      ))
+    end
+  end
+end


### PR DESCRIPTION
This will jump straight to results, and do not ask for the length.

This radio will only show for `community_order` children convictions.

A bit of refactor in the value-object methods and decision tree.

<img width="636" alt="Screen Shot 2019-06-27 at 15 52 02" src="https://user-images.githubusercontent.com/687910/60276440-86598780-98f3-11e9-9094-1d78a2460a1b.png">
