### PR TITLE
Rename some classes to avoid confusion

### DIFF
--- a/app/presenters/caution_result_presenter.rb
+++ b/app/presenters/caution_result_presenter.rb
@@ -9,7 +9,7 @@ class CautionResultPresenter < ResultsPresenter
 
   private
 
-  def calculator_class
-    CautionExpiryCalculator
+  def result_class
+    CautionCheckResult
   end
 end

--- a/app/presenters/conviction_result_presenter.rb
+++ b/app/presenters/conviction_result_presenter.rb
@@ -17,7 +17,7 @@ class ConvictionResultPresenter < ResultsPresenter
 
   private
 
-  def calculator_class
-    ConvictionExpiryCalculator
+  def result_class
+    ConvictionCheckResult
   end
 end

--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -23,19 +23,19 @@ class ResultsPresenter
   end
 
   def expiry_date
-    calculator.expiry_date
+    result_service.expiry_date
   end
 
   private
 
-  def calculator
-    @_calculator ||= calculator_class.new(
+  def result_service
+    @_result_service ||= result_class.new(
       disclosure_check: disclosure_check
     )
   end
 
   # :nocov:
-  def calculator_class
+  def result_class
     raise NotImplementedError, 'implement in subclasses'
   end
 

--- a/app/services/caution_check_result.rb
+++ b/app/services/caution_check_result.rb
@@ -1,4 +1,4 @@
-class CautionExpiryCalculator
+class CautionCheckResult
   attr_reader :disclosure_check
 
   def initialize(disclosure_check:)

--- a/app/services/conviction_check_result.rb
+++ b/app/services/conviction_check_result.rb
@@ -1,4 +1,4 @@
-class ConvictionExpiryCalculator
+class ConvictionCheckResult
   include ValueObjectMethods
   attr_reader :disclosure_check
 

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CautionResultPresenter do
 
   describe '#expiry_date' do
     before do
-      allow_any_instance_of(CautionExpiryCalculator).to receive(:expiry_date).and_return('foobar')
+      allow_any_instance_of(CautionCheckResult).to receive(:expiry_date).and_return('foobar')
     end
 
     it 'delegates the method to the calculator' do

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ConvictionResultPresenter do
 
   describe '#expiry_date' do
     before do
-      allow_any_instance_of(ConvictionExpiryCalculator).to receive(:expiry_date).and_return('foobar')
+      allow_any_instance_of(ConvictionCheckResult).to receive(:expiry_date).and_return('foobar')
     end
 
     it 'delegates the method to the calculator' do

--- a/spec/services/caution_check_result_spec.rb
+++ b/spec/services/caution_check_result_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CautionExpiryCalculator do
+RSpec.describe CautionCheckResult do
   subject { described_class.new(disclosure_check: disclosure_check) }
 
   context '#expiry_date' do

--- a/spec/services/conviction_check_result_spec.rb
+++ b/spec/services/conviction_check_result_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ConvictionExpiryCalculator do
+RSpec.describe ConvictionCheckResult do
   subject { described_class.new(disclosure_check: disclosure_check, ) }
 
 


### PR DESCRIPTION
In the presenters we had a `#calculator_class` method that wasn't really returning the (new) calculator classes introduced in the ConvictionType.
This was done before the calculators were introduced.

I've renamed this method and also the associated classes to not have the wording 'Calculator' in them.