### PR TITLE
Add content to error pages

### DIFF
--- a/app/views/errors/invalid_session.html.erb
+++ b/app/views/errors/invalid_session.html.erb
@@ -1,1 +1,21 @@
-Placeholder
+<% title t('.page_title') %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+        <p class="govuk-body"><%=t '.lead_text', session_timeout: session_expire_in_minutes %></p>
+        <p class="govuk-body"><%=t '.more_text' %></p>
+
+        <div class="form-submit">
+          <%= link_to t('.start_again'), root_path, class: 'govuk-button' %>
+        </div>
+
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,1 +1,20 @@
-Placeholder
+<% title t('.page_title') %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+        <p class="govuk-body"><%=t '.lead_text' %></p>
+
+        <div class="form-submit">
+          <%= link_to t('.start_again'), root_path, class: 'govuk-button' %>
+        </div>
+
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/app/views/errors/unhandled.html.erb
+++ b/app/views/errors/unhandled.html.erb
@@ -1,1 +1,22 @@
-Placeholder
+<% title t('.page_title') %>
+
+<%= render partial: 'layouts/sentry_feedback' if Raven.last_event_id %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+        <p class="govuk-body"><%=t '.lead_text' %></p>
+
+        <div class="form-submit">
+          <%= link_to t('.start_again'), root_path, class: 'govuk-button' %>
+        </div>
+
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/app/views/layouts/_sentry_feedback.html.erb
+++ b/app/views/layouts/_sentry_feedback.html.erb
@@ -1,0 +1,13 @@
+<% content_for(:head) do %>
+  <script src="https://cdn.ravenjs.com/3.24.0/raven.min.js"></script>
+<% end %>
+
+<% content_for(:body_end) do %>
+  <script>
+    Raven.showReportDialog({
+      eventId: '<%= Raven.last_event_id %>',
+      // Use only the public DSN here!
+      dsn: '<%= "https://#{Raven.configuration.public_key}@sentry.service.dsd.io/#{Raven.configuration.project_id}" %>'
+    });
+  </script>
+<% end %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -72,3 +72,19 @@ en:
       lead_text: If you want to make changes you will need to start a new check.
       results_page: Go to results page
       start_again: New check
+    invalid_session:
+      page_title: Invalid session
+      heading: Sorry, you'll have to start again
+      lead_text: Your session automatically ends if you don't use the service for %{session_timeout} minutes.
+      more_text: We do this for your security. Any unsaved details will be deleted.
+      start_again: New check
+    not_found:
+      page_title: Page not found
+      heading: Page not found
+      lead_text: If you copied a web address, please check it’s correct.
+      start_again: New check
+    unhandled:
+      page_title: Unexpected error
+      heading: Sorry, something went wrong with our service
+      lead_text: You can go back and retry, or start again.
+      start_again: New check


### PR DESCRIPTION
Although the copy will probably change , at least we have something to show and this will stop the stack trace showing in the browser.

Also, in parallel sentry will be setup to start accepting exceptions from this service.