### PR TITLE
update conviction result page

### DIFF
--- a/app/helpers/conviction_helper.rb
+++ b/app/helpers/conviction_helper.rb
@@ -3,9 +3,7 @@ module ConvictionHelper
     return t('conviction_title.never', scope: 'results/conviction') unless object.instance_of?(Date)
 
     statement_type = object < Date.today ? 'past' : 'present'
-    statement = t("conviction_title.#{statement_type}", scope: 'results/conviction')
-
-    "#{statement} #{I18n.l(object)}"
+    t("conviction_title.#{statement_type}", scope: 'results/conviction', date: I18n.l(object))
   end
 
   def conviction_statement_string(object)

--- a/app/helpers/conviction_helper.rb
+++ b/app/helpers/conviction_helper.rb
@@ -1,0 +1,17 @@
+module ConvictionHelper
+  def conviction_title_string(object)
+    return t('conviction_title.never', scope: 'results/conviction') unless object.instance_of?(Date)
+
+    statement_type = object < Date.today ? 'past' : 'present'
+    statement = t("conviction_title.#{statement_type}", scope: 'results/conviction')
+
+    "#{statement} #{I18n.l(object)}"
+  end
+
+  def conviction_statement_string(object)
+    return t('conviction_statement.never', scope: 'results/conviction') unless object.instance_of?(Date)
+
+    statement_type = object < Date.today ? 'past_html' : 'present_html'
+    t("conviction_statement.#{statement_type}", scope: 'results/conviction')
+  end
+end

--- a/app/services/calculators/detention_calculator.rb
+++ b/app/services/calculators/detention_calculator.rb
@@ -11,7 +11,7 @@ module Calculators
     FOUR_YEARS_LESS_SPENT_DURATION =  { months: 42 }.freeze
 
     def expiry_date
-      return 'never spent' if conviction_length_in_months >= NEVER_SPENT_DURATION
+      return false if conviction_length_in_months >= NEVER_SPENT_DURATION
 
       conviction_end_date.advance(spent_time)
     end

--- a/app/views/steps/check/results/_conviction.en.html.erb
+++ b/app/views/steps/check/results/_conviction.en.html.erb
@@ -1,10 +1,8 @@
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">
-    Your conviction expired on <%= display_result(expiry_date) %>
+    <%= conviction_title_string(expiry_date) %>
   </h1>
   <div class="govuk-panel__body">
-    You do not need to tell anyone about this conviction unless you're applying for a job that needs a full
-    <a class="govuk-link" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal
-      record check</a>.
+    <%= conviction_statement_string(expiry_date) %>
   </div>
 </div>

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -66,8 +66,8 @@ en:
 
   results/conviction:
     conviction_title:
-      past: Your conviction was spent on
-      present: Your conviction will be spent on
+      past: Your conviction was spent on %{date}
+      present: Your conviction will be spent on %{date}
       never: Your conviction will never be spent
     conviction_statement:
       past_html: |

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -63,7 +63,18 @@ en:
         youth_simple_caution: Youth Simple caution
         youth_conditional_caution: Youth Conditional caution
 
+
   results/conviction:
+    conviction_title:
+      past: Your conviction was spent on
+      present: Your conviction will be spent on
+      never: Your conviction will never be spent
+    conviction_statement:
+      past_html: |
+       You do not need to tell anyone about this conviction unless you're applying for a job that needs a full <a class="govuk-link" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
+      present_html: |
+        After this date you will not need to tell anyone about this conviction unless you're applying for a job that needs a <a class="govuk-link" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
+      never: If asked, you will always have to tell people about this conviction.
     kind:
       question: Criminal record type
       answers:

--- a/spec/helpers/conviction_helper_spec.rb
+++ b/spec/helpers/conviction_helper_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+RSpec.describe ConvictionHelper, type: :helper do
+  describe '#conviction_title_string' do
+    it 'returns past tense title' do
+      expect(helper.conviction_title_string(Date.yesterday)).to include('was spent on')
+    end
+
+    it 'returns present tense title' do
+      expect(helper.conviction_title_string(Date.tomorrow)).to include('will be spent on')
+    end
+
+     it 'returns never spent title' do
+      expect(helper.conviction_title_string(nil)).to include('never be spent')
+    end
+  end
+
+  describe '#conviction_statement_string' do
+    it 'returns past tense title' do
+      expect(helper.conviction_statement_string(Date.yesterday)).to include('You do not need to tell anyone about this conviction')
+    end
+
+    it 'returns present tense title' do
+      expect(helper.conviction_statement_string(Date.tomorrow)).to include('After this date you will not need to tell anyone')
+    end
+
+     it 'returns never spent title' do
+      expect(helper.conviction_statement_string(nil)).to include(' you will always have to tell people')
+    end
+  end
+end

--- a/spec/services/calculators/detention_calculator_spec.rb
+++ b/spec/services/calculators/detention_calculator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Calculators::DetentionCalculator do
     let(:conviction_length) { nil }
 
     context 'never spent for conviction length over 4 years' do
-      let(:result) { 'never spent' }
+      let(:result) { false }
       context 'conviction length in weeks' do
         let(:conviction_length_type) { 'weeks' }
         let(:conviction_length) { 208 }


### PR DESCRIPTION
Update the conviction result page to return the correct title and statement in the right tense.

Copy can be [found here](https://docs.google.com/spreadsheets/d/1ZSCk-wgMfIc22GQahKH_ys4u-E9GWIn6dQ7mm5t1RFI/edit#gid=0)