### PR TITLE
Rename service and reorg locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Check if you need to disclose your criminal record MVP
+# Check when a caution or conviction is spent (MVP)
 
 [![CircleCI](https://circleci.com/gh/ministryofjustice/disclosure-checker.svg?style=svg)](https://circleci.com/gh/ministryofjustice/disclosure-checker)
 

--- a/app/views/about/cookies.en.html.erb
+++ b/app/views/about/cookies.en.html.erb
@@ -118,7 +118,7 @@
             </tr>
           </tbody>
         </table>
-      
+      </div>
     </div>
   </main>
 </div>

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -5,7 +5,9 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <section class="intro">
-          <h1 class="govuk-heading-xl">Check if you need to disclose your criminal record</h1>
+          <h1 class="govuk-heading-xl">
+            <%= service_name %>
+          </h1>
 
           <p class="govuk-body">Use this service to check if you need to tell people about offences on your criminal record.</p>
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -16,7 +16,7 @@ data:
   # Locale files or `File.find` patterns where translations are read from:
   read:
     ## Default:
-    # - config/locales/%{locale}.yml
+    - config/locales/%{locale}.yml
     ## More files:
     - config/locales/%{locale}/*.yml
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,15 @@
+en:
+  service:
+    name: Check when a caution or conviction is spent
+
+  date:
+    formats:
+      default: '%d %B %Y'
+      long: '%d %B %y'
+
+  warning:
+    reset_session:
+      page_title: Check in progress
+      heading: It looks like you already have a check in progress
+      resume_link: Resume check
+      restart_link: Start a new check

--- a/config/locales/en/date.yml
+++ b/config/locales/en/date.yml
@@ -1,6 +1,0 @@
----
-en:
-  date:
-    formats:
-      default: '%d %B %Y'
-      long: '%d %B %y'

--- a/config/locales/en/home.yml
+++ b/config/locales/en/home.yml
@@ -1,5 +1,0 @@
----
-en:
-  home:
-    index:
-      page_title: Home

--- a/config/locales/en/service.yml
+++ b/config/locales/en/service.yml
@@ -1,5 +1,0 @@
----
-en:
-  service:
-    name: Check if you need to disclose your criminal record
-

--- a/config/locales/en/warning.yml
+++ b/config/locales/en/warning.yml
@@ -1,8 +1,0 @@
----
-en:
-  warning:
-    reset_session:
-      page_title: Disclosure check in progress
-      heading: It looks like you already have an disclosure check in progress
-      resume_link: Resume disclosure check
-      restart_link: Start a new disclosure check

--- a/features/caution.feature
+++ b/features/caution.feature
@@ -1,7 +1,6 @@
 Feature: Caution
   Background:
     When I visit "/"
-    Then I should see "Check if you need to disclose your criminal record"
     And I click the "Start now" link
     Then I should see "Were you cautioned or convicted?"
 

--- a/features/conviction.feature
+++ b/features/conviction.feature
@@ -1,7 +1,6 @@
 Feature: Conviction
   Background:
     When I visit "/"
-    Then I should see "Check if you need to disclose your criminal record"
     And I click the "Start now" link
     Then I should see "Were you cautioned or convicted?"
 

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -55,7 +55,6 @@ end
 
 When(/^I am completing a basic under 18 "([^"]*)" conviction$/) do |value|
   step %[I visit "/"]
-  step %[I should see "Check if you need to disclose your criminal record"]
   step %[I click the "Start now" link]
   step %[I should see "Were you cautioned or convicted?"]
   step %[I choose "Convicted"]

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -132,12 +132,12 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context 'for a blank value' do
       let(:value) { '' }
-      it { expect(title).to eq('Check if you need to disclose your criminal record - GOV.UK') }
+      it { expect(title).to eq('Check when a caution or conviction is spent - GOV.UK') }
     end
 
     context 'for a provided value' do
       let(:value) { 'Test page' }
-      it { expect(title).to eq('Test page - Check if you need to disclose your criminal record - GOV.UK') }
+      it { expect(title).to eq('Test page - Check when a caution or conviction is spent - GOV.UK') }
     end
   end
 


### PR DESCRIPTION
The name of the service has changed.

I've done a bit of reorg in the locales, so we don't have many 1 string files.
Also removed the `home` page_title locale as it is not used.

Note: fixed as part of this PR, although unrelated, the cookies page as it was missing a closing div.