### PR TITLE
Validate that conditional end date is after caution date

### DIFF
--- a/app/forms/steps/caution/conditional_end_date_form.rb
+++ b/app/forms/steps/caution/conditional_end_date_form.rb
@@ -9,6 +9,7 @@ module Steps
 
       validates_presence_of :conditional_end_date
       validates :conditional_end_date, sensible_date: { allow_future: true }
+      validate :after_caution_date?
 
       private
 
@@ -18,6 +19,12 @@ module Steps
         disclosure_check.update(
           conditional_end_date: conditional_end_date
         )
+      end
+
+      def after_caution_date?
+        return if conditional_end_date.blank? || disclosure_check.known_date.blank?
+
+        errors.add(:conditional_end_date, :after_caution_date) if conditional_end_date < disclosure_check.known_date
       end
     end
   end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -13,6 +13,12 @@ en:
           attributes:
             under_age:
               inclusion: Select under 18 or over 18
+        steps/caution/conditional_end_date_form:
+          attributes:
+            conditional_end_date:
+              blank: Enter the conditional end date
+              invalid: The conditional end date is not valid
+              after_caution_date: The conditional end date must be after the caution date
         steps/conviction/known_date_form:
           attributes:
             known_date:

--- a/spec/forms/steps/caution/conditional_end_date_form_spec.rb
+++ b/spec/forms/steps/caution/conditional_end_date_form_spec.rb
@@ -1,5 +1,49 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Caution::ConditionalEndDateForm do
-  it_behaves_like 'a date question form', attribute_name: :conditional_end_date, allow_future: true
+  it_behaves_like 'a date question form', attribute_name: :conditional_end_date, allow_future: true do |variable|
+    before do
+      allow(subject).to receive(:after_caution_date?).and_return(true)
+    end
+  end
+
+
+  context '#after_caution_date? validation' do
+
+
+    let(:disclosure_check) { instance_double(DisclosureCheck, known_date: known_date) }
+    let(:known_date) { Date.today }
+    let(:conditional_end_date) { nil }
+    let(:arguments) {
+      {
+        disclosure_check: disclosure_check,
+        conditional_end_date: conditional_end_date
+      }
+    }
+
+    subject { described_class.new(arguments) }
+
+    context 'when conditional end date is before caution date' do
+      let(:conditional_end_date) { Date.yesterday }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.added?(:conditional_end_date, :after_caution_date)).to eq(true)
+      end
+    end
+
+    context 'when conditional end date is after caution date' do
+      let(:conditional_end_date) { Date.tomorrow }
+      let(:known_date) { 3.months.ago.to_date }
+
+      it 'has no validation errors on the field' do
+        expect(subject).to be_valid
+        expect(subject.errors.added?(:conditional_end_date, :after_caution_date)).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Return an error message when conditional end date is before caution date i.e  
caution date: 1/7/2019 and when conditional end date: 1/7/2018
