### PR TITLE
Reset `caution_type` dependent attributes

### DIFF
--- a/app/forms/steps/caution/caution_type_form.rb
+++ b/app/forms/steps/caution/caution_type_form.rb
@@ -3,7 +3,7 @@ module Steps
     class CautionTypeForm < BaseForm
       attribute :caution_type, String
 
-      validates_inclusion_of :caution_type, in: :choices
+      validates_inclusion_of :caution_type, in: :choices, if: :disclosure_check
 
       def choices
         if under_age?
@@ -15,16 +15,24 @@ module Steps
 
       private
 
-      def persist!
-        raise DisclosureCheckNotFound unless disclosure_check
-
-        disclosure_check.update(
-          caution_type: caution_type
-        )
+      def under_age?
+        disclosure_check.under_age == 'yes'
       end
 
-      def under_age?
-        disclosure_check&.under_age == 'yes'
+      def changed?
+        disclosure_check.caution_type != caution_type
+      end
+
+      def persist!
+        raise DisclosureCheckNotFound unless disclosure_check
+        return true unless changed?
+
+        disclosure_check.update(
+          caution_type: caution_type,
+          # The following are dependent attributes that need to be reset if form changes
+          known_date: nil,
+          conditional_end_date: nil
+        )
       end
     end
   end

--- a/spec/forms/steps/caution/caution_type_form_spec.rb
+++ b/spec/forms/steps/caution/caution_type_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Steps::Caution::CautionTypeForm do
       caution_type: caution_type
     }
   end
-  let(:disclosure_check) { instance_double(DisclosureCheck, caution_type: caution_type, under_age: under_age) }
+  let(:disclosure_check) { instance_double(DisclosureCheck, caution_type: nil, under_age: under_age) }
   let(:caution_type) { nil }
   let(:under_age) { 'yes' }
 
@@ -45,10 +45,25 @@ RSpec.describe Steps::Caution::CautionTypeForm do
 
       it 'saves the record' do
         expect(disclosure_check).to receive(:update).with(
-          caution_type: caution_type
+          caution_type: caution_type,
+          # Dependent attributes to be reset
+          known_date: nil,
+          conditional_end_date: nil
         ).and_return(true)
 
         expect(subject.save).to be(true)
+      end
+
+      context 'when caution_type is already the same on the model' do
+        let(:disclosure_check) {
+          instance_double(DisclosureCheck, caution_type: 'youth_simple_caution', under_age: 'yes')
+        }
+        let(:caution_type) { 'youth_simple_caution' }
+
+        it 'does not save the record but returns true' do
+          expect(disclosure_check).to_not receive(:update)
+          expect(subject.save).to be(true)
+        end
       end
     end
   end


### PR DESCRIPTION
If CautionTypeForm changes with regards to the database (for example, if user advance but then go back and change their answers) we need to ensure some dependent attributes down the line are also reset, to avoid inconsistencies in the decision trees or result page.

This is easily done returning early from the `#persist!` method if there are no changes in the form.

I will do a similar thing with convictions in a separate PR.

Note: unrelated, but I removed the safe navigation operator in the `#under_age?`, ensuring we do the validations if we have a `disclosure_check`.