### PR TITLE
Reset `kind` and `conviction_type` dependent attributes

### DIFF
--- a/app/forms/steps/check/kind_form.rb
+++ b/app/forms/steps/check/kind_form.rb
@@ -11,11 +11,21 @@ module Steps
 
       private
 
+      def changed?
+        disclosure_check.kind != kind
+      end
+
       def persist!
         raise DisclosureCheckNotFound unless disclosure_check
+        return true unless changed?
 
         disclosure_check.update(
-          kind: kind
+          kind: kind,
+          # The following are dependent attributes that need to be reset if form changes
+          under_age: nil,
+          caution_type: nil,
+          conviction_type: nil,
+          conviction_subtype: nil
         )
       end
     end

--- a/app/forms/steps/conviction/conviction_type_form.rb
+++ b/app/forms/steps/conviction/conviction_type_form.rb
@@ -10,11 +10,18 @@ module Steps
 
       private
 
+      def changed?
+        disclosure_check.conviction_type != conviction_type
+      end
+
       def persist!
         raise DisclosureCheckNotFound unless disclosure_check
+        return true unless changed?
 
         disclosure_check.update(
-          conviction_type: conviction_type
+          conviction_type: conviction_type,
+          # The following are dependent attributes that need to be reset if form changes
+          conviction_subtype: nil
         )
       end
     end

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -202,7 +202,7 @@ en:
           simple_caution: Simple caution
           conditional_caution: Conditional caution
           youth_simple_caution: Youth caution
-          youth_conditional_caution: Youth Conditional caution
+          youth_conditional_caution: Youth conditional caution
       steps_conviction_under_age_form:
         under_age:
           'yes': Under 18

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -78,8 +78,8 @@ en:
       answers:
         simple_caution: Simple caution
         conditional_caution: Conditional caution
-        youth_simple_caution: Youth Simple caution
-        youth_conditional_caution: Youth Conditional caution
+        youth_simple_caution: Youth caution
+        youth_conditional_caution: Youth conditional caution
 
 
   results/conviction:

--- a/features/caution.feature
+++ b/features/caution.feature
@@ -20,7 +20,7 @@ Feature: Caution
     And I choose "Under 18"
     Then I should see "What type of caution did you get?"
 
-    And I choose "Youth Conditional caution"
+    And I choose "Youth conditional caution"
 
     Then I should see "When did you get the caution?"
     When I enter a valid date

--- a/spec/forms/steps/check/kind_form_spec.rb
+++ b/spec/forms/steps/check/kind_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Steps::Check::KindForm do
     disclosure_check: disclosure_check,
     kind: kind
   } }
-  let(:disclosure_check) { instance_double(DisclosureCheck, kind: kind) }
+  let(:disclosure_check) { instance_double(DisclosureCheck, kind: nil) }
   let(:kind) { nil }
 
   subject { described_class.new(arguments) }
@@ -27,10 +27,25 @@ RSpec.describe Steps::Check::KindForm do
 
       it 'saves the record' do
         expect(disclosure_check).to receive(:update).with(
-          kind: 'caution'
+          kind: 'caution',
+          # Dependent attributes to be reset
+          under_age: nil,
+          caution_type: nil,
+          conviction_type: nil,
+          conviction_subtype: nil
         ).and_return(true)
 
         expect(subject.save).to be(true)
+      end
+
+      context 'when kind is already the same on the model' do
+        let(:disclosure_check) { instance_double(DisclosureCheck, kind: kind) }
+        let(:kind)  { 'conviction' }
+
+        it 'does not save the record but returns true' do
+          expect(disclosure_check).to_not receive(:update)
+          expect(subject.save).to be(true)
+        end
       end
     end
   end

--- a/spec/forms/steps/conviction/conviction_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_type_form_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Steps::Conviction::ConvictionTypeForm do
     }
   end
 
-  let(:under_age) { true }
-  let(:disclosure_check) { instance_double(DisclosureCheck, conviction_type: conviction_type, under_age: under_age) }
+  let(:disclosure_check) { instance_double(DisclosureCheck, conviction_type: nil) }
   let(:conviction_type) { nil }
 
   subject { described_class.new(arguments) }
@@ -35,10 +34,22 @@ RSpec.describe Steps::Conviction::ConvictionTypeForm do
 
       it 'saves the record' do
         expect(disclosure_check).to receive(:update).with(
-          conviction_type: 'discharge'
+          conviction_type: 'discharge',
+          # Dependent attributes to be reset
+          conviction_subtype: nil
         ).and_return(true)
 
         expect(subject.save).to be(true)
+      end
+
+      context 'when conviction_type is already the same on the model' do
+        let(:disclosure_check) { instance_double(DisclosureCheck, conviction_type: conviction_type) }
+        let(:conviction_type)  { 'community_order' }
+
+        it 'does not save the record but returns true' do
+          expect(disclosure_check).to_not receive(:update)
+          expect(subject.save).to be(true)
+        end
       end
     end
   end


### PR DESCRIPTION
Same as with previous PR #112.

Only resetting the most inmediate attributes and not all of them, because each form should take care of resetting the following ones, if needed.

Also I fixed a capitalisation typo in the locales.