### PR TITLE
Fix some styling and copy issues

### DIFF
--- a/app/views/about/cookies.en.html.erb
+++ b/app/views/about/cookies.en.html.erb
@@ -5,7 +5,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Cookies</h1>
-        <p class="govuk-body"><%= service_name -%> puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.</p>
+        <p class="govuk-body">‘<%= service_name -%>’ puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.</p>
         <p class="govuk-body">Cookies are used to:</p>
         
         <ul class="govuk-list govuk-list--bullet">
@@ -13,12 +13,12 @@
           <li>measure how you use the website so it can be updated and improved based on your needs</li>
         </ul>
         
-        <p class="govuk-body"><%= service_name -%> cookies aren't used to identify you personally.</p>
+        <p class="govuk-body">Cookies aren't used to identify you personally.</p>
         <p class="govuk-body">You'll normally see a message on the site before we store a cookie on your computer.</p>
         <p class="govuk-body">Find out more about <a class="govuk-link" rel="external" target="_blank" href="https://www.aboutcookies.org">how to manage cookies</a>.</p>
-        <h2 class="govuk-heading-m">How cookies are used on <%= service_name -%></h2>
+        <h2 class="govuk-heading-m">How cookies are used on ‘<%= service_name -%>’</h2>
         <p class="govuk-body"><strong>Our introductory message</strong></p>
-        <p class="govuk-body">You may see a pop-up welcome message when you first visit <%= service_name -%>. We'll store a cookie so that your computer knows you've seen it and knows not to show it again.</p>
+        <p class="govuk-body">You may see a pop-up welcome message when you first visit the site. We'll store a cookie so that your computer knows you've seen it and knows not to show it again.</p>
         
         <table class="govuk-table">
           <thead class="govuk-table__head">
@@ -38,7 +38,7 @@
         </table>
         
         <h2 class="govuk-heading-m">Remembering your progress</h2>
-        <p class="govuk-body">We will store a cookie to remember your application progress in this computer and to expire your session after <%= session_expire_in_minutes %> minutes of inactivity or when you close your browser.</p>
+        <p class="govuk-body">We will store a cookie to remember your progress in this computer and to expire your session after <%= session_expire_in_minutes %> minutes of inactivity or when you close your browser.</p>
         
         <table class="govuk-table">
           <thead class="govuk-table__head">
@@ -50,7 +50,7 @@
           </thead>
           <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell">_c100_application_session</td>
+              <td class="govuk-table__cell">_disclosure_checker_session</td>
               <td class="govuk-table__cell">Saves your current progress in this computer and tracks inactivity periods</td>
               <td class="govuk-table__cell">After <%= session_expire_in_minutes %> minutes of inactivity or when you close your browser</td>
             </tr>
@@ -58,12 +58,12 @@
         </table>
         
         <h2 class="govuk-heading-m">Measuring website usage (Google Analytics)</h2>
-        <p class="govuk-body">We use Google Analytics software to collect information about how you use <%= service_name -%>. We do this to help make sure the site is meeting the needs of its users and to help us make improvements, for example <a class="govuk-link" rel="external" target="_blank" href="https://insidegovuk.blog.gov.uk/2015/03/26/new-tool-to-see-trending-searches/">improving site search</a>.</p>
+        <p class="govuk-body">We use Google Analytics software to collect information about how you use ‘<%= service_name -%>’. We do this to help make sure the site is meeting the needs of its users and to help us make improvements, for example <a class="govuk-link" rel="external" target="_blank" href="https://insidegovuk.blog.gov.uk/2015/03/26/new-tool-to-see-trending-searches/">improving site search</a>.</p>
         <p class="govuk-body">Google Analytics stores information about:</p>
         
         <ul class="govuk-list govuk-list--bullet">
-          <li>the pages you visit on <%= service_name -%></li>
-          <li>how long you spend on each <%= service_name -%> page </li>
+          <li>the pages you visit on ‘<%= service_name -%>’</li>
+          <li>how long you spend on each page </li>
           <li>how you got to the site  </li>
           <li>what you click on while you’re visiting the site</li>
         </ul>
@@ -83,12 +83,12 @@
           <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">_ga</td>
-              <td class="govuk-table__cell">This helps us count how many people visit <%= service_name -%> by tracking if you've visited before</td>
+              <td class="govuk-table__cell">This helps us count how many people visit ‘<%= service_name -%>’ by tracking if you've visited before</td>
               <td class="govuk-table__cell">2 years</td>
             </tr>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">_gid</td>
-              <td class="govuk-table__cell">This helps us count how many people visit <%= service_name -%> by tracking if you've visited before</td>
+              <td class="govuk-table__cell">This helps us count how many people visit ‘<%= service_name -%>’ by tracking if you've visited before</td>
               <td class="govuk-table__cell">24 hours</td>
             </tr>
             <tr class="govuk-table__row">
@@ -98,12 +98,12 @@
             </tr>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">_utma</td>
-              <td class="govuk-table__cell">Like _ga, this lets us know if you've visited before, so we can count how many of our visitors are new to <%= service_name -%> or to a certain page </td>
+              <td class="govuk-table__cell">Like _ga, this lets us know if you've visited before, so we can count how many of our visitors are new to ‘<%= service_name -%>’ or to a certain page </td>
               <td>2 years</td>
             </tr>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">_utmb</td>
-              <td class="govuk-table__cell">This works with _utmc to calculate the average length of time you spend on <%= service_name -%></td>
+              <td class="govuk-table__cell">This works with _utmc to calculate the average length of time you spend on ‘<%= service_name -%>’</td>
               <td class="govuk-table__cell">30 minutes</td>
             </tr>
             <tr class="govuk-table__row">
@@ -113,7 +113,7 @@
             </tr>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">_utmz</td>
-              <td class="govuk-table__cell">This tells us how you reached <%= service_name -%> (for example from another website or a search engine)</td>
+              <td class="govuk-table__cell">This tells us how you reached ‘<%= service_name -%>’ (for example from another website or a search engine)</td>
               <td class="govuk-table__cell">6 months</td>
             </tr>
           </tbody>

--- a/app/views/warning/reset_session.html.erb
+++ b/app/views/warning/reset_session.html.erb
@@ -8,8 +8,11 @@
         <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
         <div class="form-submit">
-          <%= link_to t('.resume_link'), previous_step_path, class: 'govuk-button', data: {ga_category: 'in progress warning', ga_label: 'resume application'} %>
-          <%= link_to t('.restart_link'), root_path(new: 'y'), class: 'govuk-link govuk-!-margin-5 ', data: {ga_category: 'in progress warning', ga_label: 'new application'} %>
+          <%= link_to t('.resume_link'), previous_step_path, class: 'govuk-button govuk-!-margin-right-3 ga-pageLink',
+                      data: { ga_category: 'in progress warning', ga_label: 'resume check' } %>
+
+          <%= link_to t('.restart_link'), root_path(new: 'y'), class: 'govuk-button govuk-button--secondary ga-pageLink',
+                      data: { ga_category: 'in progress warning', ga_label: 'new check' } %>
         </div>
 
       </div>


### PR DESCRIPTION
In the reset session warning, and in the cookie pages. Mainly removing references to C100 and/or application, and replacing with "check".

The cookies page copy is still provisional but based on other services so pretty standard, should not be that many changes.

<img width="675" alt="Screen Shot 2019-07-09 at 09 45 17" src="https://user-images.githubusercontent.com/687910/60873422-4917c280-a22e-11e9-95a9-61734e87b949.png">
