### PR TITLE
Add compensation not paid exit page

### DIFF
--- a/app/controllers/steps/conviction/compensation_not_paid_controller.rb
+++ b/app/controllers/steps/conviction/compensation_not_paid_controller.rb
@@ -1,0 +1,7 @@
+module Steps
+  module Conviction
+    class CompensationNotPaidController < Steps::ConvictionStepController
+      def show; end
+    end
+  end
+end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -55,8 +55,7 @@ class ConvictionDecisionTree < BaseDecisionTree
   def after_compensation_paid
     return edit(:compensation_payment_date) if GenericYesNo.new(disclosure_check.compensation_paid).yes?
 
-    # TODO: waiting on new exit page
-    show('/steps/check/exit_over18')
+    show(:compensation_not_paid)
   end
 
   def results

--- a/app/views/steps/check/exit_over18/show.en.html.erb
+++ b/app/views/steps/check/exit_over18/show.en.html.erb
@@ -1,10 +1,13 @@
 <% title "Sorry, you can't use this service yet" %>
+
 <div class="govuk-width-container">
+  <%= step_header %>
+
   <main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Sorry, you cannot use this service yet</h1>
-        <p class="govuk-body">This service is currently in <a href="https://www.gov.uk/help/beta">beta</a>. It can only be used by people who were under 18 when they were cautioned or convicted.</p>
+        <p class="govuk-body">This service is currently in <a href="https://www.gov.uk/help/beta" class="govuk-link">beta</a>. It can only be used by people who were under 18 when they were cautioned or convicted.</p>
         <p class="govuk-body">The service will be available to over-18s later this year.</p>
       </div>
     </div>

--- a/app/views/steps/conviction/compensation_not_paid/show.en.html.erb
+++ b/app/views/steps/conviction/compensation_not_paid/show.en.html.erb
@@ -1,0 +1,18 @@
+<% title 'Sorry, we cannot tell you when your conviction is spent' %>
+
+<div class="govuk-width-container">
+  <%= step_header %>
+
+  <main id="main-content" class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Sorry, we cannot tell you when your conviction is spent</h1>
+
+        <p class="govuk-body">You've said that you have not paid the full compensation you were ordered to pay.</p>
+        <p class="govuk-body">Your conviction will not become spent until the compensation has been paid in full.</p>
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
       edit_step :conviction_length_type
       edit_step :compensation_paid
       edit_step :compensation_payment_date
+      show_step :compensation_not_paid
     end
   end
 

--- a/features/conviction_financial.feature
+++ b/features/conviction_financial.feature
@@ -25,4 +25,4 @@ Feature: Conviction
     When I choose "Compensation to a victim"
     Then I should see "Did you pay the compensation in full?"
     And I choose "No"
-    Then I should be on "/steps/check/exit_over18"
+    Then I should be on "/steps/conviction/compensation_not_paid"

--- a/spec/controllers/steps/conviction/compensation_not_paid_controller_spec.rb
+++ b/spec/controllers/steps/conviction/compensation_not_paid_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Conviction::CompensationNotPaidController, type: :controller do
+  it_behaves_like 'a show step controller'
+end

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ConvictionDecisionTree do
     context 'when the step is `compensation_paid` equal no' do
       let(:compensation_paid)  { GenericYesNo::NO }
       let(:step_params) { { compensation_paid: compensation_paid } }
-      it { is_expected.to have_destination('/steps/check/exit_over18', :show) }
+      it { is_expected.to have_destination(:compensation_not_paid, :show) }
     end
   end
 


### PR DESCRIPTION
This exit page was missing, temporarily pointing to the under18 page.

Also, added the back link to the under18 exit page.