### PR TITLE
Update caution results page

### DIFF
--- a/app/presenters/caution_result_presenter.rb
+++ b/app/presenters/caution_result_presenter.rb
@@ -4,7 +4,13 @@ class CautionResultPresenter < ResultsPresenter
   end
 
   def question_attributes
-    [:kind, :known_date, :under_age, :caution_type].freeze
+    [
+      :kind,
+      :caution_type,
+      :under_age,
+      :known_date,
+      :conditional_end_date,
+    ].freeze
   end
 
   private

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -67,7 +67,9 @@ en:
       answers:
         caution: Caution
     known_date:
-      question: Date caution given
+      question: Date caution was given
+    conditional_end_date:
+      question: Date conditions ended
     under_age:
       question: Age at time of caution
       answers:

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     kind { CheckKind::CAUTION }
     known_date { Faker::Date.backward(14).strftime('%Y-%m-%d') }
     under_age { 'yes' }
-    caution_type { CautionType::SIMPLE_CAUTION }
+    caution_type { CautionType::YOUTH_SIMPLE_CAUTION }
 
     trait :conviction do
       kind { CheckKind::CONVICTION }
@@ -20,17 +20,9 @@ FactoryBot.define do
       conviction_length_type { ConvictionLengthType::WEEKS }
     end
 
-    trait :conditional_caution do
-      caution_type { CautionType::CONDITIONAL_CAUTION }
-      conditional_end_date { Faker::Date.backward(8).strftime('%Y-%m-%d') }
-    end
-
-    trait :youth_simple_caution do
-      caution_type { CautionType::YOUTH_SIMPLE_CAUTION }
-    end
-
     trait :youth_conditional_caution do
       caution_type { CautionType::YOUTH_CONDITIONAL_CAUTION }
+      conditional_end_date { Faker::Date.backward(8).strftime('%Y-%m-%d') }
     end
   end
 end

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -8,18 +8,51 @@ RSpec.describe CautionResultPresenter do
   end
 
   describe '#question_attributes' do
-    it { expect(subject.question_attributes).to eq( [:kind, :known_date, :under_age, :caution_type]) }
+    it { expect(subject.question_attributes).to eq([:kind, :caution_type, :under_age, :known_date, :conditional_end_date]) }
   end
 
-  # TODO: this needs more tests
   describe '#summary' do
     let(:summary) { subject.summary }
 
-    it 'return array of objects' do
-      expect(summary.size).to eq(4)
+    context 'for a youth caution' do
+      it 'returns the correct question-answer pairs' do
+        expect(summary.size).to eq(4)
 
-      expect(summary[0].question).to eql(:kind)
-      expect(summary[0].answer).to eql('caution')
+        expect(summary[0].question).to eql(:kind)
+        expect(summary[0].answer).to eql('caution')
+
+        expect(summary[1].question).to eql(:caution_type)
+        expect(summary[1].answer).to eql('youth_simple_caution')
+
+        expect(summary[2].question).to eql(:under_age)
+        expect(summary[2].answer).to eql('yes')
+
+        expect(summary[3].question).to eql(:known_date)
+        expect(summary[3].answer).to be_kind_of(Date)
+      end
+    end
+
+    context 'for a youth conditional caution' do
+      let(:disclosure_check) { build(:disclosure_check, :youth_conditional_caution) }
+
+      it 'returns the correct question-answer pairs' do
+        expect(summary.size).to eq(5)
+
+        expect(summary[0].question).to eql(:kind)
+        expect(summary[0].answer).to eql('caution')
+
+        expect(summary[1].question).to eql(:caution_type)
+        expect(summary[1].answer).to eql('youth_conditional_caution')
+
+        expect(summary[2].question).to eql(:under_age)
+        expect(summary[2].answer).to eql('yes')
+
+        expect(summary[3].question).to eql(:known_date)
+        expect(summary[3].answer).to be_kind_of(Date)
+
+        expect(summary[4].question).to eql(:conditional_end_date)
+        expect(summary[4].answer).to be_kind_of(Date)
+      end
     end
   end
 

--- a/spec/services/caution_check_result_spec.rb
+++ b/spec/services/caution_check_result_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CautionCheckResult do
     end
 
     context 'for a conditional caution' do
-      let(:disclosure_check) { build(:disclosure_check, :conditional_caution) }
+      let(:disclosure_check) { build(:disclosure_check, :youth_conditional_caution) }
 
       it 'returns `conditional_end_date` (end date is the conditional date)' do
         expect(expiry_date).to eq(disclosure_check.conditional_end_date)


### PR DESCRIPTION
The results of the conditional caution didn't include the conditional end date.

Also, updated the order of the question-answer pairs to match prototype.

TODO: the output date should be localised to follow the usual ISO 8601 format. This might require a refactor of the presenters.

<img width="598" alt="Screen Shot 2019-07-10 at 16 28 42" src="https://user-images.githubusercontent.com/687910/60977668-c96e1e80-a327-11e9-845b-e437f4429a94.png">
