### PR TITLE
Add compensation_payment_date to conviction result table

### DIFF
--- a/app/presenters/conviction_result_presenter.rb
+++ b/app/presenters/conviction_result_presenter.rb
@@ -12,6 +12,7 @@ class ConvictionResultPresenter < ResultsPresenter
       :known_date,
       :conviction_length,
       :conviction_length_type,
+      :compensation_payment_date,
     ].freeze
   end
 

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -123,3 +123,6 @@ en:
         months: Months
         years: Years
         no_length: No length was given
+    compensation_payment_date:
+      question: Compensation payment date
+

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ConvictionResultPresenter do
     it {
       expect(
         subject.question_attributes
-      ).to eq([:kind, :conviction_type, :conviction_subtype, :under_age, :known_date, :conviction_length, :conviction_length_type])
+      ).to eq([:kind, :conviction_type, :conviction_subtype, :under_age, :known_date, :conviction_length, :conviction_length_type, :compensation_payment_date])
     }
   end
 


### PR DESCRIPTION
Add  compensation_payment_date to conviction result table

<img width="1228" alt="Screen Shot 2019-07-11 at 11 43 06" src="https://user-images.githubusercontent.com/22822829/61044707-1d810d80-a3d1-11e9-89ed-77a07a523cd7.png">
