### PR TITLE
Hide armed forces convictions

### DIFF
--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -19,12 +19,18 @@ class ConvictionType < ValueObject
 
   VALUES = [
     PARENT_TYPES = [
-      ARMED_FORCES          = new(:armed_forces),
       COMMUNITY_ORDER       = new(:community_order),
       CUSTODIAL_SENTENCE    = new(:custodial_sentence),
       DISCHARGE             = new(:discharge),
       FINANCIAL             = new(:financial),
       HOSPITAL_GUARD_ORDER  = new(:hospital_guard_order),
+    ].freeze,
+
+    # Quick way of enabling/disabling convictions. These will not show in the interface to users.
+    # If there are cucumber test, tag the affected scenarios with `@skip`.
+    #
+    PARENT_TYPES_DISABLED_FOR_MVP = [
+      ARMED_FORCES = new(:armed_forces),
     ].freeze,
 
     DISMISSAL                          = new(:dismissal,                        parent: ARMED_FORCES, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,0 +1,5 @@
+default: >
+  -r features/support/env.rb
+  -r features/step_definitions features
+  --format pretty
+  --tags 'not @skip'

--- a/features/armed_forces.feature
+++ b/features/armed_forces.feature
@@ -1,17 +1,19 @@
- Feature: Conviction
+Feature: Conviction
+
+  @skip
   Scenario Outline: Armed forces
-  Given I am completing a basic under 18 "Armed forces" conviction
-  Then I should see "What type of order were you given?"
+    Given I am completing a basic under 18 "Armed forces" conviction
+    Then I should see "What type of order were you given?"
 
-  When I choose "<subtype>"
-  Then I should see "<known_date_header>"
+    When I choose "<subtype>"
+    Then I should see "<known_date_header>"
 
-  And I enter a valid date
-  Then I should be on "<result>"
+    And I enter a valid date
+    Then I should be on "<result>"
 
- Examples:
-    | subtype                   | known_date_header                   | result               |
-    | Dismissal                 | When were you given the dismissal?  | /steps/check/results |
-    | Service detention         | When were you given the detention?  | /steps/check/results |
-    | Service community order   | When were you given the order?      | /steps/check/results |
-    | Overseas community order  | When were you given the order?      | /steps/check/results |
+    Examples:
+      | subtype                  | known_date_header                  | result               |
+      | Dismissal                | When were you given the dismissal? | /steps/check/results |
+      | Service detention        | When were you given the detention? | /steps/check/results |
+      | Service community order  | When were you given the order?     | /steps/check/results |
+      | Overseas community order | When were you given the order?     | /steps/check/results |

--- a/spec/forms/steps/conviction/conviction_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_type_form_spec.rb
@@ -14,15 +14,8 @@ RSpec.describe Steps::Conviction::ConvictionTypeForm do
   subject { described_class.new(arguments) }
 
   describe '.choices' do
-    it 'returns the relevant choices' do
-      expect(described_class.choices).to eq(%w(
-        armed_forces
-        community_order
-        custodial_sentence
-        discharge
-        financial
-        hospital_guard_order
-      ))
+    it 'returns the parent types' do
+      expect(described_class.choices).to eq(ConvictionType::PARENT_TYPES.map(&:to_s))
     end
   end
 

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -6,12 +6,21 @@ RSpec.describe ConvictionType do
 
     it 'returns top level conviction' do
       expect(values).to eq(%w(
-        armed_forces
         community_order
         custodial_sentence
         discharge
         financial
         hospital_guard_order
+      ))
+    end
+  end
+
+  describe 'PARENT_TYPES_DISABLED_FOR_MVP' do
+    let(:values) { described_class::PARENT_TYPES_DISABLED_FOR_MVP.map(&:to_s) }
+
+    it 'returns top level conviction' do
+      expect(values).to eq(%w(
+        armed_forces
       ))
     end
   end


### PR DESCRIPTION
We will not have these for MVP, but as we've done most of the work and we will eventually need them, instead of removing everything let's just hide the parent group.

This mechanism can also be used in the future to show/hide any other convictions if needed.

Added a default cucumber profile that skips scenarios tagged as `@skip`.