### PR TITLE
Format result page dates

### DIFF
--- a/app/presenters/question_answer_row.rb
+++ b/app/presenters/question_answer_row.rb
@@ -3,7 +3,7 @@ class QuestionAnswerRow
 
   def initialize(question, answer, scope:)
     @question = question
-    @answer = answer
+    @answer = format_answer(answer)
     @scope = scope
   end
 
@@ -13,5 +13,11 @@ class QuestionAnswerRow
 
   def to_partial_path
     'results/shared/row'
+  end
+
+  private
+
+  def format_answer(value)
+    value.is_a?(Date) ? I18n.l(value, format: :short) : value
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,7 @@ en:
   date:
     formats:
       default: '%d %B %Y'
-      long: '%d %B %y'
+      short: '%d/%m/%Y'
 
   warning:
     reset_session:

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -1,8 +1,11 @@
+# Important: factories should always produce predictable data, specially dates.
+# This will avoid headaches with flaky tests.
+#
 FactoryBot.define do
   factory :disclosure_check do
     kind { CheckKind::CAUTION }
-    known_date { Faker::Date.backward(14).strftime('%Y-%m-%d') }
-    under_age { 'yes' }
+    known_date { Date.new(2018, 10, 31) }
+    under_age { GenericYesNo::YES }
     caution_type { CautionType::YOUTH_SIMPLE_CAUTION }
 
     trait :conviction do
@@ -22,7 +25,7 @@ FactoryBot.define do
 
     trait :youth_conditional_caution do
       caution_type { CautionType::YOUTH_CONDITIONAL_CAUTION }
-      conditional_end_date { Faker::Date.backward(8).strftime('%Y-%m-%d') }
+      conditional_end_date { Date.new(2018, 12, 25) }
     end
   end
 end

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CautionResultPresenter do
         expect(summary[2].answer).to eql('yes')
 
         expect(summary[3].question).to eql(:known_date)
-        expect(summary[3].answer).to be_kind_of(Date)
+        expect(summary[3].answer).to eq('31/10/2018')
       end
     end
 
@@ -48,10 +48,10 @@ RSpec.describe CautionResultPresenter do
         expect(summary[2].answer).to eql('yes')
 
         expect(summary[3].question).to eql(:known_date)
-        expect(summary[3].answer).to be_kind_of(Date)
+        expect(summary[3].answer).to eq('31/10/2018')
 
         expect(summary[4].question).to eql(:conditional_end_date)
-        expect(summary[4].answer).to be_kind_of(Date)
+        expect(summary[4].answer).to eq('25/12/2018')
       end
     end
   end

--- a/spec/presenters/question_answer_row_spec.rb
+++ b/spec/presenters/question_answer_row_spec.rb
@@ -13,7 +13,14 @@ RSpec.describe QuestionAnswerRow do
   end
 
   describe '#answer' do
-    it { expect(subject.answer).to eq('answer') }
+    context 'for a date answer' do
+      let(:answer) { Date.new(2018, 10, 31) }
+      it { expect(subject.answer).to eq('31/10/2018') }
+    end
+
+    context 'for an answer of other type' do
+      it { expect(subject.answer).to eq('answer') }
+    end
   end
 
   describe '#show?' do


### PR DESCRIPTION
This will format the user-provided dates following ISO 8601.

Before: `2018-12-01`
Now: `01/12/2018`

Updated the factory to produce predictable dates to simplify and avoid flaky tests.