### PR TITLE
Styling fixes in the results page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,4 +5,4 @@ $govuk-assets-path: '/assets/govuk-frontend/assets/';
 @import 'govuk-frontend/all';
 
 // Local CSS
-@import 'local/panels';
+@import 'local/custom';

--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -1,0 +1,3 @@
+.nowrap {
+  white-space: nowrap;
+}

--- a/app/assets/stylesheets/local/panels.scss
+++ b/app/assets/stylesheets/local/panels.scss
@@ -1,3 +1,0 @@
-.panel-border-wide {
-    margin: 30px 0;
-}

--- a/app/helpers/result_helper.rb
+++ b/app/helpers/result_helper.rb
@@ -1,15 +1,21 @@
 module ResultHelper
   def title_string(object, kind)
-    return t('title.no_date', scope: "results/#{kind}") unless object.instance_of?(Date)
+    return t('title.no_date_html', scope: "results/#{kind}") unless object.instance_of?(Date)
 
-    title_type = object < Date.today ? 'past' : 'present'
-    t("title.#{title_type}", scope: "results/#{kind}", date: I18n.l(object))
+    tense = past_or_present(object)
+    t("title.#{tense}_html", scope: "results/#{kind}", date: I18n.l(object))
   end
 
   def statement_string(object, kind)
     return t('statement.no_date_html', scope: "results/#{kind}") unless object.instance_of?(Date)
 
-    statement_type = object < Date.today ? 'past_html' : 'present_html'
-    t("statement.#{statement_type}", scope: "results/#{kind}")
+    tense = past_or_present(object)
+    t("statement.#{tense}_html", scope: "results/#{kind}")
+  end
+
+  private
+
+  def past_or_present(date)
+    date.past? ? 'past' : 'present'
   end
 end

--- a/app/views/steps/check/results/show.en.html.erb
+++ b/app/views/steps/check/results/show.en.html.erb
@@ -1,8 +1,6 @@
 <% title '' %>
 
 <div class="govuk-width-container">
-  <%= step_header %>
-
   <main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,8 +4,8 @@ en:
 
   date:
     formats:
-      default: '%d %B %Y'
-      short: '%d/%m/%Y'
+      default: '%-d %B %Y'  # 3 January 2019
+      short: '%d/%m/%Y'     # 03/01/2019
 
   warning:
     reset_session:

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -52,16 +52,16 @@ en:
 
   results/caution:
     title:
-      past: Your caution was spent on %{date}
-      present: Your caution will be spent on %{date}
-      no_date: The caution date was not provided
+      past_html: Your caution was spent on <span class="nowrap">%{date}</span>
+      present_html: Your caution will be spent on <span class="nowrap">%{date}</span>
+      no_date_html: The caution date was not provided
     statement:
       past_html: |
-       You do not need to tell anyone about this caution unless you're applying for a job that needs a full <a class="govuk-link" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
+       You do not need to tell anyone about this caution unless you're applying for a job that needs a full <a class="govuk-link nowrap" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
       present_html: |
-       After this date you will not need to tell anyone about this caution unless you're applying for a job that needs a full <a class="govuk-link" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
+       After this date you will not need to tell anyone about this caution unless you're applying for a job that needs a full <a class="govuk-link nowrap" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
       no_date_html: |
-       You do not need to tell anyone about this caution unless you're applying for a job that needs a full <a class="govuk-link" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
+       You do not need to tell anyone about this caution unless you're applying for a job that needs a full <a class="govuk-link nowrap" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
     kind:
       question: Criminal record type
       answers:
@@ -83,17 +83,16 @@ en:
         youth_simple_caution: Youth caution
         youth_conditional_caution: Youth conditional caution
 
-
   results/conviction:
     title:
-      past: Your conviction was spent on %{date}
-      present: Your conviction will be spent on %{date}
-      no_date: Your conviction will never be spent
+      past_html: Your conviction was spent on <span class="nowrap">%{date}</span>
+      present_html: Your conviction will be spent on <span class="nowrap">%{date}</span>
+      no_date_html: Your conviction will never be spent
     statement:
       past_html: |
-       You do not need to tell anyone about this conviction unless you're applying for a job that needs a full <a class="govuk-link" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
+       You do not need to tell anyone about this conviction unless you're applying for a job that needs a full <a class="govuk-link nowrap" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
       present_html: |
-        After this date you will not need to tell anyone about this conviction unless you're applying for a job that needs a <a class="govuk-link" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
+        After this date you will not need to tell anyone about this conviction unless you're applying for a job that needs a <a class="govuk-link nowrap" href="http://hub.unlock.org.uk/knowledgebase/eligibility-criminal-record-checks/">criminal record check</a>.
       no_date_html: If asked, you will always have to tell people about this conviction.
     kind:
       question: Criminal record type

--- a/features/caution.feature
+++ b/features/caution.feature
@@ -28,7 +28,7 @@ Feature: Caution
     Then I should see "When did the conditions end?"
     When I enter a valid date
 
-    Then I should see "Your caution was spent on 01 January 1999"
+    Then I should see "Your caution was spent on 1 January 1999"
 
   @happy_path
   Scenario: Caution happy path - under 18, simple caution
@@ -43,4 +43,4 @@ Feature: Caution
     Then I should see "When did you get the caution?"
     When I enter a valid date
 
-    Then I should see "Your caution was spent on 01 January 1999"
+    Then I should see "Your caution was spent on 1 January 1999"


### PR DESCRIPTION
* Removed the `back` link, as it has no effect on the results page (the user can't go back to a completed check).

* Removed the leading zeros in the day in the long date.

* Made some elements `nowrap`.

Note: `local/panels.scss` was not being used, so I renamed it to `custom` and added the nowrap style there.

Before:
<img width="1011" alt="Screen Shot 2019-07-12 at 11 41 58" src="https://user-images.githubusercontent.com/687910/61119747-cdbb4880-a49b-11e9-95ec-09d44452acaf.png">

After:
<img width="1005" alt="Screen Shot 2019-07-12 at 11 44 38" src="https://user-images.githubusercontent.com/687910/61119782-d9a70a80-a49b-11e9-98fa-e05f1e2af00c.png">
