### PR TITLE
Reset conviction `known_date`

### DIFF
--- a/app/forms/steps/conviction/conviction_subtype_form.rb
+++ b/app/forms/steps/conviction/conviction_subtype_form.rb
@@ -26,6 +26,7 @@ module Steps
         disclosure_check.update(
           conviction_subtype: conviction_subtype,
           # The following are dependent attributes that need to be reset if form changes
+          known_date: nil,
           conviction_length: nil,
           conviction_length_type: nil,
           compensation_paid: nil,

--- a/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Steps::Conviction::ConvictionSubtypeForm do
         expect(disclosure_check).to receive(:update).with(
           conviction_subtype: conviction_subtype,
           # Dependent attributes to be reset
+          known_date: nil,
           conviction_length: nil,
           conviction_length_type: nil,
           compensation_paid: nil,


### PR DESCRIPTION
This attribute also needs to be reset, as we do in cautions, when the conviction subtype changes.