### PR TITLE
Add daily maintenance rake task

### DIFF
--- a/app/models/disclosure_check.rb
+++ b/app/models/disclosure_check.rb
@@ -3,4 +3,11 @@ class DisclosureCheck < ApplicationRecord
     in_progress: 0,
     completed: 10,
   }
+
+  # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
+  default_scope { order(created_at: :asc) }
+
+  def self.purge!(date)
+    where('created_at <= :date', date: date).destroy_all
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,11 @@ module Disclosure
     config.generators.system_tests = nil
 
     config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 60).to_i
+
+    # Maintain `in_progress` checks for this number of days
+    config.x.checks.incomplete_purge_after_days = 7
+
+    # Maintain `completed` checks for this number of days
+    config.x.checks.complete_purge_after_days = 60
   end
 end

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -1,0 +1,31 @@
+task daily_tasks: :environment do
+  log 'Starting daily tasks'
+  log "Checks count: #{DisclosureCheck.count}"
+
+  Rake::Task['purge:checks'].invoke
+
+  log "Checks count: #{DisclosureCheck.count}"
+  log 'Finished daily tasks'
+end
+
+namespace :purge do
+  task checks: :environment do
+    # incomplete checks
+    expire_after = Rails.configuration.x.checks.incomplete_purge_after_days
+    log "Purging incomplete checks older than #{expire_after} days"
+    purged = DisclosureCheck.in_progress.purge!(expire_after.days.ago)
+    log "Purged #{purged.size} incomplete checks"
+
+    # complete checks
+    expire_after = Rails.configuration.x.checks.complete_purge_after_days
+    log "Purging complete checks older than #{expire_after} days"
+    purged = DisclosureCheck.completed.purge!(expire_after.days.ago)
+    log "Purged #{purged.size} complete checks"
+  end
+end
+
+private
+
+def log(message)
+  puts "[#{Time.now}] #{message}"
+end

--- a/spec/models/disclosure_check_spec.rb
+++ b/spec/models/disclosure_check_spec.rb
@@ -1,4 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe DisclosureCheck, type: :model do
+  subject { described_class.new(attributes) }
+
+  let(:attributes) { {} }
+
+  describe '.purge!' do
+    let(:finder_double) { double.as_null_object }
+
+    before do
+      travel_to Time.now
+    end
+
+    it 'picks records equal to or older than the passed-in date' do
+      expect(described_class).to receive(:where).with(
+        'created_at <= :date', date: 28.days.ago
+      ).and_return(finder_double)
+
+      described_class.purge!(28.days.ago)
+    end
+
+    it 'calls #destroy_all on the records it finds' do
+      allow(described_class).to receive(:where).and_return(finder_double)
+      expect(finder_double).to receive(:destroy_all)
+
+      described_class.purge!(28.days.ago)
+    end
+  end
 end

--- a/worker.sh
+++ b/worker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd /usr/src/app
+
+bundle exec rake daily_tasks


### PR DESCRIPTION
This will run daily through a cronjob pod, and will purge old checks so the database doesn't grow unnecessarily with stale data.