### PR TITLE
Update date steps copy and hints

### DIFF
--- a/app/views/steps/conviction/compensation_payment_date/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_date/edit.html.erb
@@ -10,8 +10,13 @@
         <%= error_summary %>
         <%= step_subsection %>
 
+        <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+        <p class="govuk-body"><%=t '.lead_text' %></p>
+
         <%= step_form @form_object do |f| %>
-          <%= f.gov_uk_date_field :compensation_payment_date %>
+          <%= f.gov_uk_date_field :compensation_payment_date,
+                                  legend_options: { page_heading: false, visually_hidden: true } %>
 
           <%= f.continue_button %>
         <% end %>

--- a/config/locales/en/caution.yml
+++ b/config/locales/en/caution.yml
@@ -6,14 +6,10 @@ en:
         edit:
           page_title: Caution date
           heading: When did you get the caution?
-          date_legend: Enter the date
-          date_hint: For example, 23 9 2018
       conditional_end_date:
         edit:
           page_title: Caution date
           heading: When did the conditions end?
-          date_legend: Enter the date
-          date_hint: For example, 29 1 2018
       under_age:
         edit:
           page_title: How old were you when you got the caution?

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -57,3 +57,5 @@ en:
       compensation_payment_date:
         edit:
           page_title: compensation payment date
+          heading: When did you pay the compensation in full?
+          lead_text: If you paid the compensation in stages, enter the date you made the final payment.

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -117,7 +117,7 @@ en:
       steps_caution_conditional_end_date_form:
         conditional_end_date: This is the date you and the police agreed the conditions would end. For example, 23 9 2018.
       steps_conviction_known_date_form:
-        known_date: For example, 23 9 2018
+        known_date: This is the date you were convicted by a court. For example, 23 9 2018
       steps_conviction_under_age_form:
         under_age: This is your age when you were given the conviction, not when you committed the offence
       steps_conviction_compensation_payment_date_form:


### PR DESCRIPTION
* Updated the hint text for the conviction `known_date` step.
* Removed unused locales
* Update the `compensation_payment_date` step to have lead text (thus we can't continue using page_heading).

<img width="673" alt="Screen Shot 2019-07-15 at 12 42 29" src="https://user-images.githubusercontent.com/687910/61213802-648b3d80-a706-11e9-9395-47cdaf1bbd1f.png">
