### PR TITLE
Combine conviction length details in results page

### DIFF
--- a/app/presenters/caution_result_presenter.rb
+++ b/app/presenters/caution_result_presenter.rb
@@ -3,6 +3,8 @@ class CautionResultPresenter < ResultsPresenter
     'results/caution'
   end
 
+  private
+
   def question_attributes
     [
       :kind,
@@ -12,8 +14,6 @@ class CautionResultPresenter < ResultsPresenter
       :conditional_end_date,
     ].freeze
   end
-
-  private
 
   def result_class
     CautionCheckResult

--- a/app/presenters/conviction_result_presenter.rb
+++ b/app/presenters/conviction_result_presenter.rb
@@ -3,6 +3,8 @@ class ConvictionResultPresenter < ResultsPresenter
     'results/conviction'
   end
 
+  private
+
   def question_attributes
     [
       :kind,
@@ -10,13 +12,21 @@ class ConvictionResultPresenter < ResultsPresenter
       :conviction_subtype,
       :under_age,
       :known_date,
-      :conviction_length,
-      :conviction_length_type,
+      [:conviction_length, i18n_conviction_length],
       :compensation_payment_date,
     ].freeze
   end
 
-  private
+  def i18n_conviction_length
+    type = disclosure_check.conviction_length_type
+    return unless type
+
+    I18n.translate!(
+      "conviction_length.answers.#{type}",
+      length: disclosure_check.conviction_length,
+      scope: to_partial_path
+    )
+  end
 
   def result_class
     ConvictionCheckResult

--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -17,8 +17,12 @@ class ResultsPresenter
   end
 
   def summary
-    question_attributes.map do |item|
-      QuestionAnswerRow.new(item, disclosure_check[item], scope: to_partial_path)
+    question_attributes.map do |item, value|
+      QuestionAnswerRow.new(
+        item,
+        value || disclosure_check[item],
+        scope: to_partial_path
+      )
     end.select(&:show?)
   end
 

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -115,13 +115,10 @@ en:
       question: Date of conviction
     conviction_length:
       question: Length of conviction
-    conviction_length_type:
-      question: Conviction length given in
       answers:
-        weeks: Weeks
-        months: Months
-        years: Years
+        weeks: '%{length} weeks'
+        months: '%{length} months'
+        years: '%{length} years'
         no_length: No length was given
     compensation_payment_date:
       question: Compensation payment date
-

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe CautionResultPresenter do
     it { expect(subject.to_partial_path).to eq('results/caution') }
   end
 
-  describe '#question_attributes' do
-    it { expect(subject.question_attributes).to eq([:kind, :caution_type, :under_age, :known_date, :conditional_end_date]) }
-  end
-
   describe '#summary' do
     let(:summary) { subject.summary }
 

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -7,19 +7,11 @@ RSpec.describe ConvictionResultPresenter do
     it { expect(subject.to_partial_path).to eq('results/conviction') }
   end
 
-  describe '#question_attributes' do
-    it {
-      expect(
-        subject.question_attributes
-      ).to eq([:kind, :conviction_type, :conviction_subtype, :under_age, :known_date, :conviction_length, :conviction_length_type, :compensation_payment_date])
-    }
-  end
-
   describe '#summary' do
     let(:summary) { subject.summary }
 
-    it 'return array of objects' do
-      expect(summary.size).to eq(7)
+    it 'returns the correct question-answer pairs' do
+      expect(summary.size).to eq(6)
 
       expect(summary[0].question).to eql(:kind)
       expect(summary[0].answer).to eql('conviction')
@@ -37,16 +29,26 @@ RSpec.describe ConvictionResultPresenter do
       expect(summary[4].answer).to eq('31/10/2018')
 
       expect(summary[5].question).to eql(:conviction_length)
-      expect(summary[5].answer).to eq(9)
+      expect(summary[5].answer).to eq('9 weeks')
+    end
 
-      expect(summary[6].question).to eql(:conviction_length_type)
-      expect(summary[6].answer).to eq('weeks')
+    context 'when no length given' do
+      let(:disclosure_check) {
+        build(:disclosure_check, :dto_conviction, conviction_length_type: ConvictionLengthType::NO_LENGTH)
+      }
+
+      it 'returns the correct question-answer pairs' do
+        expect(summary.size).to eq(6)
+
+        expect(summary[5].question).to eql(:conviction_length)
+        expect(summary[5].answer).to eq('No length was given')
+      end
     end
 
     context 'pay a victim compensation' do
       let(:disclosure_check) { build(:disclosure_check, :compensation) }
 
-      it 'return array of objects' do
+      it 'returns the correct question-answer pairs' do
         expect(summary.size).to eq(6)
 
         expect(summary[0].question).to eql(:kind)


### PR DESCRIPTION
The conviction length is split into two bits of information, the actual length (a number) and the metric (weeks, months, years or `no_length`).

Previously we had these separate in the summary table in the results page, but as part of the service review, it was decided to combine it into one line, if possible.

We do this by extending the functionality of the presenters, to be able to override the value of an attribute and use a custom method to build the one-liner.

Also, I've removed the individual test of the `#question_attributes` method, because it is tested more in-deep in the `describe '#summary'`, so it was redundant. This method is now private.

Before:
<img width="439" alt="Screen Shot 2019-07-16 at 10 22 08" src="https://user-images.githubusercontent.com/687910/61282726-22bcce80-a7bc-11e9-84a4-13d22aab42bf.png">

After:
<img width="418" alt="Screen Shot 2019-07-16 at 10 23 04" src="https://user-images.githubusercontent.com/687910/61282740-27818280-a7bc-11e9-9382-aa79891fb6e8.png">

When no date was given:
<img width="501" alt="Screen Shot 2019-07-16 at 10 22 39" src="https://user-images.githubusercontent.com/687910/61282756-2ea89080-a7bc-11e9-93ea-b21f7f6bdb61.png">
