### PR TITLE
Copy amendments in YRO orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,9 @@ The features can be run manually (these are not part of the default rake task) i
 
 * `bundle exec cucumber features`
 * `bundle exec cucumber features/caution.feature`
-* `bundle exec cucumber features/conviction.feature`
-* `bundle exec cucumber features/conviction_custodial_sentence.feature`
-* `bundle exec cucumber features/conviction_discharge.feature`
-* `bundle exec cucumber features/conviction_financial.feature`
-* `bundle exec cucumber features/conviction_hospital_guardianship_order.feature`
-* `bundle exec cucumber features/conviction_youth_rehabilitation_order.feature`
 * `bundle exec cucumber features/caution.feature -t @happy_path`
+
+Any of the files in the [features](features) directory can be run individually.
 
 By default cucumber will start a local server on a random port, run features against that server, and kill the server once the features have finished.
 

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -130,7 +130,7 @@ en:
           youth_conditional_caution: You agreed to certain conditions, such as paying a fine or learning about the effects of drugs
         conviction_type:
           armed_forces: ""
-          community_order: For example, curfew or unpaid work
+          community_order: For example, curfew or unpaid work. You might have been asked to wear a tag as part of your order
           custodial_sentence: For example, a detention and training order (DTO) or a hospital order given under the Mental Health Act
           discharge: For example, a conditional discharge order or bind over
           financial: For example, paying a fine or compensation
@@ -155,22 +155,20 @@ en:
           rehab_activity_requirement: You were given activities to help with your rehabilitation
           reparation_order: You were given help understanding the effect your crime had on someone
           residence_requirement: You were ordered to live somewhere for a certain length of time
-          restraining_order: --- copy to be confirmed ---
+          restraining_order: You were ordered not to do something, such as approach or contact a certain person
           sexual_harm_prevention_order: A court ruled that you pose a risk of causing sexual harm
           supervision_order: You were ordered to be supervised by a youth offending team after loitering, soliciting or 'breaching a civil injunction'
           unpaid_work: You were ordered to do community work without being paid
           # custodial_sentence
           detention_training_order: ""
           detention: ""
+          hospital_order: ""
           # discharge
           absolute_discharge: You were found guilty of a crime but did not get sentenced
           conditional_discharge: You were not sentenced, as long as you didn't commit another crime
           # financial
           fine: ""
           compensation_to_a_victim: ""
-          # hospital_guard_order
-          hospital_order: ""
-          guardianship_order: ""
 
     label:
       steps_check_kind_form:


### PR DESCRIPTION
Adding some hint texts.

Unrelated, but removed `conviction_hospital_guardianship_order.feature` from the README, as we don't have this anymore, and simplified a bit this section so we don't have to remember to maintain it when we add/remove features.