### PR TITLE
Disable SQL logs in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,16 +83,6 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 


### PR DESCRIPTION
We are already using Logstash, with log level of `:info` but this extra code, was making the production logs also output the SQL queries (debug).

We don't need this, as it is very verbose.