### PR TITLE
Use a non-root nginx container

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,3 +1,10 @@
-FROM nginx:alpine
+FROM bitnami/nginx:latest
 
-COPY config/nginx.conf /etc/nginx/nginx.conf
+COPY config/nginx.conf /opt/bitnami/nginx/conf/nginx.conf
+
+# Fix permissions
+USER root
+RUN chmod -R g+rwX /opt/bitnami/nginx/
+
+# Switch back to default bitnami nginx user
+USER 1001

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -16,14 +16,14 @@ events {
 }
 
 http {
-  include /etc/nginx/mime.types;
+  include /opt/bitnami/nginx/conf/mime.types;
 
   upstream webapp {
     server webapp:3000;
   }
 
   server {
-    listen 80;
+    listen 8081;
 
     root /home/www/public;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,6 @@ services:
     links:
       - webapp
     ports:
-      - "8080:80"
+      - "8080:8081"
     volumes:
       - assets:/home/www/public


### PR DESCRIPTION
In order to replicate as much as possible the setup we have on kubernetes, where we can't run root containers, we are going to change the nginx image to the `bitnami` one and adapt the config so it works.

A similar approach to this, will be needed in our staging kubernetes environment.