### PR TITLE
Simplify nginx config (docker-compose only)

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,10 +1,3 @@
 FROM bitnami/nginx:latest
 
-COPY config/nginx.conf /opt/bitnami/nginx/conf/nginx.conf
-
-# Fix permissions
-USER root
-RUN chmod -R g+rwX /opt/bitnami/nginx/
-
-# Switch back to default bitnami nginx user
-USER 1001
+COPY config/nginx.conf /opt/bitnami/nginx/conf/server_blocks/nginx_server_block.conf

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -11,65 +11,58 @@
 # environment (but of course, without a kubernetes cluster).
 #############################################################################
 
-events {
-  worker_connections 1024;
+upstream webapp {
+  server webapp:3000;
 }
 
-http {
-  include /opt/bitnami/nginx/conf/mime.types;
+server {
+  listen 8081;
+  server_name localhost;
 
-  upstream webapp {
-    server webapp:3000;
+  root /home/www/public;
+
+  # http://nginx.org/en/docs/http/ngx_http_core_module.html#try_files
+  #
+  # Tries URIs in sequence until one is found.
+  # First we try to serve static files directly from nginx.
+  # The rails application is the last alternative.
+  #
+  # /maintenance.html can be symlinked into public/ to stop requests
+  # before they reach the rails app (e.g. while updating the DB).
+  # When it does not exist (normally), it's quickly skipped.
+  #
+  try_files /maintenance.html $uri $uri/index.html @webapp;
+
+  # If upstream is not available, fallback to static error page.
+  error_page 502 503 504 /503.html;
+
+  location /assets/ping.json {
+    return 200 "{}";
   }
 
-  server {
-    listen 8081;
+  location ^~ /assets/ {
+    access_log  off;
+    gzip_static on;
 
-    root /home/www/public;
-
-    # http://nginx.org/en/docs/http/ngx_http_core_module.html#try_files
+    # Rails automatically appends digest fingerprints to asset file names,
+    # so we don't need to worry about expiring them.
     #
-    # Tries URIs in sequence until one is found.
-    # First we try to serve static files directly from nginx.
-    # The rails application is the last alternative.
-    #
-    # /maintenance.html can be symlinked into public/ to stop requests
-    # before they reach the rails app (e.g. while updating the DB).
-    # When it does not exist (normally), it's quickly skipped.
-    #
-    try_files /maintenance.html $uri $uri/index.html @webapp;
+    expires max;
+    add_header Cache-Control public;
 
-    # If upstream is not available, fallback to static error page.
-    error_page 502 503 504 /503.html;
+    try_files $uri @webapp;
+  }
 
-    location /assets/ping.json {
-      return 200 "{}";
-    }
+  location @webapp {
+    proxy_redirect  off;
+    proxy_pass      http://webapp;
 
-    location ^~ /assets/ {
-      access_log  off;
-      gzip_static on;
+    proxy_next_upstream     error timeout invalid_header;
+    proxy_connect_timeout   1;
 
-      # Rails automatically appends digest fingerprints to asset file names,
-      # so we don't need to worry about expiring them.
-      #
-      expires max;
-      add_header Cache-Control public;
-
-      try_files $uri @webapp;
-    }
-
-    location @webapp {
-      proxy_redirect  off;
-      proxy_pass      http://webapp;
-
-      proxy_next_upstream     error timeout invalid_header;
-      proxy_connect_timeout   1;
-
-      proxy_set_header   X-Real-IP          $HTTP_X_REAL_IP;
-      proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
-      proxy_set_header   X-Forwarded-Proto  $HTTP_X_FORWARDED_PROTO;
-      proxy_set_header   Host               $http_host;
-    }
+    proxy_set_header   X-Real-IP          $HTTP_X_REAL_IP;
+    proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto  $HTTP_X_FORWARDED_PROTO;
+    proxy_set_header   Host               $http_host;
   }
 }


### PR DESCRIPTION
This way we don't need to fix permissions, and is the same approach we use on kubernetes.