### PR TITLE
Enable GA ecommerce transaction tracking

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,6 +50,25 @@ module ApplicationHelper
     ENV['GA_TRACKING_ID']
   end
 
+  def track_transaction(attributes)
+    return unless current_disclosure_check.present?
+
+    content_for :transaction_data, {
+      id: current_disclosure_check.id,
+      sku: transaction_sku,
+      quantity: 1,
+    }.merge(attributes).to_json.html_safe
+  end
+
+  # We try to be as accurate as possible, but some transactions might
+  # trigger before having reached the subtype step.
+  def transaction_sku
+    current_disclosure_check.conviction_subtype ||
+      current_disclosure_check.conviction_type ||
+      current_disclosure_check.caution_type ||
+      current_disclosure_check.kind
+  end
+
   def service_name
     t('service.name')
   end

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -9,4 +9,9 @@
   ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
 
+  <% if content_for?(:transaction_data) %>
+  ga('require', 'ecommerce');
+  ga('ecommerce:addItem', <%= yield(:transaction_data) %>);
+  ga('ecommerce:send');
+  <% end %>
 </script>

--- a/app/views/steps/check/exit_over18/show.en.html.erb
+++ b/app/views/steps/check/exit_over18/show.en.html.erb
@@ -1,4 +1,5 @@
 <% title "Sorry, you can't use this service yet" %>
+<% track_transaction name: 'Over 18', category: 'Kickouts' %>
 
 <div class="govuk-width-container">
   <%= step_header %>

--- a/app/views/steps/check/results/_caution.en.html.erb
+++ b/app/views/steps/check/results/_caution.en.html.erb
@@ -1,3 +1,5 @@
+<% track_transaction name: 'Caution check completed', category: 'Completed checks' %>
+
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">
     <%= title_string(expiry_date, 'caution') %>

--- a/app/views/steps/check/results/_conviction.en.html.erb
+++ b/app/views/steps/check/results/_conviction.en.html.erb
@@ -1,3 +1,5 @@
+<% track_transaction name: 'Conviction check completed', category: 'Completed checks' %>
+
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">
     <%= title_string(expiry_date, 'conviction') %>

--- a/app/views/steps/conviction/compensation_not_paid/show.en.html.erb
+++ b/app/views/steps/conviction/compensation_not_paid/show.en.html.erb
@@ -1,4 +1,5 @@
 <% title 'Sorry, we cannot tell you when your conviction is spent' %>
+<% track_transaction name: 'Compensation not paid', category: 'Kickouts' %>
 
 <div class="govuk-width-container">
   <%= step_header %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -105,6 +105,49 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#track_transaction' do
+    before do
+      allow(record).to receive(:id).and_return('12345')
+      allow(record).to receive(:kind).and_return('caution')
+      allow(helper).to receive(:current_disclosure_check).and_return(record)
+    end
+
+    it 'sets the transaction attributes to track' do
+      helper.track_transaction(name: 'whatever')
+
+      expect(
+        helper.content_for(:transaction_data)
+      ).to eq("{\"id\":\"12345\",\"sku\":\"caution\",\"quantity\":1,\"name\":\"whatever\"}")
+    end
+  end
+
+  describe '#transaction_sku' do
+    before do
+      allow(record).to receive(attr_name).and_return(attr_name)
+      allow(helper).to receive(:current_disclosure_check).and_return(record)
+    end
+
+    context 'conviction_subtype is present' do
+      let(:attr_name) { 'conviction_subtype' }
+      it { expect(helper.transaction_sku).to eq(attr_name) }
+    end
+
+    context 'conviction_type is present' do
+      let(:attr_name) { 'conviction_type' }
+      it { expect(helper.transaction_sku).to eq(attr_name) }
+    end
+
+    context 'caution_type is present' do
+      let(:attr_name) { 'caution_type' }
+      it { expect(helper.transaction_sku).to eq(attr_name) }
+    end
+
+    context 'kind is present' do
+      let(:attr_name) { 'kind' }
+      it { expect(helper.transaction_sku).to eq(attr_name) }
+    end
+  end
+
   describe 'capture missing translations' do
     before do
       ActionView::Base.raise_on_missing_translations = false


### PR DESCRIPTION
Goals will only track 1 event per session, so for example a user checking several cautions or convictions one after another, would only track as 1 completed check, the first one, even if they did 10 different checks.

This implementation was created for another service in the past with good results:

https://github.com/ministryofjustice/tax-tribunals-datacapture/pull/547

Some small changes to cater to this service.