### PR TITLE
Add missing attributes to a few links

### DIFF
--- a/app/views/about/terms_and_conditions.en.html.erb
+++ b/app/views/about/terms_and_conditions.en.html.erb
@@ -34,7 +34,7 @@
         <section class="moj-Section about-section" data-block-name="terms-conditions-phase">
           <h2 class="govuk-heading-m">Information about you and your visits</h2>
           <div class="Section__content govuk-govspeak gv-s-prose">
-            <p class="govuk-body">We collect information about you in accordance with our <%= link_to 'privacy policy', about_privacy_path, class: 'ga-pageLink', data: {ga_category: 'footer', ga_label: 'privacy'} %> and our <%= link_to 'cookie policy', about_cookies_path, class: 'ga-pageLink', data: {ga_category: 'footer', ga_label: 'cookies'} %>. By using this service you agree to us collecting this information and confirm that any data you provide is accurate.</p>
+            <p class="govuk-body">We collect information about you in accordance with our <%= link_to 'privacy policy', about_privacy_path, class: 'govuk-link ga-pageLink', data: {ga_category: 'footer', ga_label: 'privacy'} %> and our <%= link_to 'cookie policy', about_cookies_path, class: 'govuk-link ga-pageLink', data: {ga_category: 'footer', ga_label: 'cookies'} %>. By using this service you agree to us collecting this information and confirm that any data you provide is accurate.</p>
           </div>
         </section>
 

--- a/app/views/errors/check_completed.html.erb
+++ b/app/views/errors/check_completed.html.erb
@@ -8,7 +8,7 @@
         <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
         <p class="govuk-body"><%=t '.lead_text' %></p>
-        <p class="govuk-body"><%= link_to t('.results_page'), steps_check_results_path %></p>
+        <p class="govuk-body"><%= link_to t('.results_page'), steps_check_results_path, class: 'govuk-link' %></p>
 
         <div class="form-submit">
           <%= link_to t('.start_again'), root_path, class: 'govuk-button' %>

--- a/app/views/steps/check/exit_over18/show.en.html.erb
+++ b/app/views/steps/check/exit_over18/show.en.html.erb
@@ -8,7 +8,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Sorry, you cannot use this service yet</h1>
-        <p class="govuk-body">This service is currently in <a href="https://www.gov.uk/help/beta" class="govuk-link">beta</a>. It can only be used by people who were under 18 when they were cautioned or convicted.</p>
+        <p class="govuk-body">This service is currently in <a href="https://www.gov.uk/help/beta" rel="external" class="govuk-link">beta</a>. It can only be used by people who were under 18 when they were cautioned or convicted.</p>
         <p class="govuk-body">The service will be available to over-18s later this year.</p>
       </div>
     </div>

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -54,11 +54,11 @@ en:
       no_date_html: The caution date was not provided
     statement:
       past_html: |
-        You do not need to tell anyone about this caution unless you're applying for a job where a <a class="govuk-link" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#standard-dbs">standard</a> or <a class="govuk-link" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#enhanced-dbs">enhanced</a> criminal record check is needed.
+        You do not need to tell anyone about this caution unless you're applying for a job where a <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#standard-dbs">standard</a> or <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#enhanced-dbs">enhanced</a> criminal record check is needed.
       present_html: |
-        After this date you will not need to tell anyone about this caution unless you're applying for a job where a <a class="govuk-link" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#standard-dbs">standard</a> or <a class="govuk-link" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#enhanced-dbs">enhanced</a> criminal record check is needed.
+        After this date you will not need to tell anyone about this caution unless you're applying for a job where a <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#standard-dbs">standard</a> or <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#enhanced-dbs">enhanced</a> criminal record check is needed.
       no_date_html: |
-        You do not need to tell anyone about this caution unless you're applying for a job where a <a class="govuk-link" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#standard-dbs">standard</a> or <a class="govuk-link" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#enhanced-dbs">enhanced</a> criminal record check is needed.
+        You do not need to tell anyone about this caution unless you're applying for a job where a <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#standard-dbs">standard</a> or <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#enhanced-dbs">enhanced</a> criminal record check is needed.
     kind:
       question: Criminal record type
       answers:
@@ -87,9 +87,9 @@ en:
       no_date_html: Your conviction will never be spent
     statement:
       past_html: |
-        You do not need to tell anyone about this conviction unless you're applying for a job where a <a class="govuk-link" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#standard-dbs">standard</a> or <a class="govuk-link" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#enhanced-dbs">enhanced</a> criminal record check is needed.
+        You do not need to tell anyone about this conviction unless you're applying for a job where a <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#standard-dbs">standard</a> or <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#enhanced-dbs">enhanced</a> criminal record check is needed.
       present_html: |
-        After this date you will not need to tell anyone about this conviction unless you're applying for a job where a <a class="govuk-link" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#standard-dbs">standard</a> or <a class="govuk-link" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#enhanced-dbs">enhanced</a> criminal record check is needed.
+        After this date you will not need to tell anyone about this conviction unless you're applying for a job where a <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#standard-dbs">standard</a> or <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#enhanced-dbs">enhanced</a> criminal record check is needed.
       no_date_html: |
         If asked, you will always have to tell people about this conviction.
     kind:


### PR DESCRIPTION
* Add the missing `govuk-link` class to some links.
* Add `rel="external"` to the external links so these are tracked as outbound on GA.