### PR TITLE
Fix markup and styling of cookies page

### DIFF
--- a/app/views/about/cookies.en.html.erb
+++ b/app/views/about/cookies.en.html.erb
@@ -16,8 +16,10 @@
         <p class="govuk-body">Cookies aren't used to identify you personally.</p>
         <p class="govuk-body">You'll normally see a message on the site before we store a cookie on your device.</p>
         <p class="govuk-body">Find out more about <a class="govuk-link" rel="external" target="_blank" href="https://www.aboutcookies.org">how to manage cookies</a>.</p>
-        <h2 class="govuk-heading-m">How cookies are used on <%= service_name -%></h2>
-        <p class="govuk-body"><strong>Our introductory message</strong></p>
+
+        <h2 class="govuk-heading-l">How cookies are used on <%= service_name -%></h2>
+
+        <h3 class="govuk-heading-m">Our introductory message</h3>
         <p class="govuk-body">You may see a pop-up welcome message when you first visit the site. We'll store a cookie so that your device knows you've seen it and knows not to show it again.</p>
         
         <table class="govuk-table">
@@ -30,14 +32,14 @@
           </thead>
           <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell">seen_cookie_message</td>
+              <th class="govuk-table__header">seen_cookie_message</th>
               <td class="govuk-table__cell">Saves a message to let us know that you've seen our cookie message</td>
               <td class="govuk-table__cell">1 month</td>
             </tr>
           </tbody>
         </table>
-        
-        <h2 class="govuk-heading-m">Remembering your progress</h2>
+
+        <h3 class="govuk-heading-m">Remembering your progress</h3>
         <p class="govuk-body">We will store a cookie to remember your progress on this device and to expire your session after <%= session_expire_in_minutes %> minutes of inactivity or when you close your browser.</p>
         
         <table class="govuk-table">
@@ -50,14 +52,14 @@
           </thead>
           <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell">_disclosure_checker_session</td>
+              <th class="govuk-table__header">_disclosure_checker_session</th>
               <td class="govuk-table__cell">Saves your current progress on this device and tracks inactivity periods</td>
               <td class="govuk-table__cell">After <%= session_expire_in_minutes %> minutes of inactivity or when you close your browser</td>
             </tr>
           </tbody>
         </table>
         
-        <h2 class="govuk-heading-m">Measuring website usage (Google Analytics)</h2>
+        <h3 class="govuk-heading-m">Measuring website usage (Google Analytics)</h3>
         <p class="govuk-body">We use Google Analytics software to collect information about how you use <%= service_name -%>. We do this to help make sure the site is meeting the needs of its users and to help us make improvements, for example <a class="govuk-link" rel="external" target="_blank" href="https://insidegovuk.blog.gov.uk/2015/03/26/new-tool-to-see-trending-searches/">improving site search</a>.</p>
         <p class="govuk-body">Google Analytics stores information about:</p>
         
@@ -82,42 +84,46 @@
           </thead>
           <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell">_ga</td>
+              <th class="govuk-table__header">_ga</th>
               <td class="govuk-table__cell">This helps us count how many people visit <%= service_name -%> by tracking if you've visited before</td>
               <td class="govuk-table__cell">2 years</td>
             </tr>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell">_gid</td>
+              <th class="govuk-table__header">_gid</th>
               <td class="govuk-table__cell">This helps us count how many people visit <%= service_name -%> by tracking if you've visited before</td>
               <td class="govuk-table__cell">24 hours</td>
             </tr>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell">_gat</td>
+              <th class="govuk-table__header">_gat</th>
               <td class="govuk-table__cell">Used to manage the rate at which page view requests are made</td>
               <td class="govuk-table__cell">10 minutes</td>
             </tr>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell">_utma</td>
+              <th class="govuk-table__header">_utma</th>
               <td class="govuk-table__cell">Like _ga, this lets us know if you've visited before, so we can count how many of our visitors are new to <%= service_name -%> or to a certain page </td>
-              <td>2 years</td>
+              <td class="govuk-table__cell">2 years</td>
             </tr>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell">_utmb</td>
+              <th class="govuk-table__header">_utmb</th>
               <td class="govuk-table__cell">This works with _utmc to calculate the average length of time you spend on <%= service_name -%></td>
               <td class="govuk-table__cell">30 minutes</td>
             </tr>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell">_utmc</td>
+              <th class="govuk-table__header">_utmc</th>
               <td class="govuk-table__cell">This works with _utmb to calculate when you close your browser</td>
               <td class="govuk-table__cell">when you close your browser</td>
             </tr>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell">_utmz</td>
+              <th class="govuk-table__header">_utmz</th>
               <td class="govuk-table__cell">This tells us how you reached <%= service_name -%> (for example from another website or a search engine)</td>
               <td class="govuk-table__cell">6 months</td>
             </tr>
           </tbody>
         </table>
+
+        <p class="govuk-body">
+          You can <a href="https://tools.google.com/dlpage/gaoptout" class="govuk-link" rel="external" target="_blank">opt out of Google Analytics cookies</a>.
+        </p>
       </div>
     </div>
   </main>


### PR DESCRIPTION
The sections header size were inconsistent and, in the table, some classes were wrong or missing.

Added the link to opt-out of GA.