### PR TITLE
Add GA custom dimension (spent)

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,0 +1,59 @@
+module AnalyticsHelper
+  CUSTOM_DIMENSIONS_MAP ||= {
+    spent: :dimension1,
+  }.freeze
+
+  def analytics_tracking_id
+    ENV['GA_TRACKING_ID']
+  end
+
+  def track_transaction(attributes)
+    return unless current_disclosure_check.present?
+
+    dimensions = custom_dimensions(
+      attributes.delete(:dimensions)
+    )
+
+    content_for :transaction_data, {
+      id: current_disclosure_check.id,
+      sku: transaction_sku,
+      quantity: 1,
+    }.merge(
+      attributes
+    ).merge(
+      dimensions
+    ).to_json.html_safe
+  end
+
+  # We try to be as accurate as possible, but some transactions might
+  # trigger before having reached the subtype step.
+  def transaction_sku
+    current_disclosure_check.conviction_subtype ||
+      current_disclosure_check.conviction_type ||
+      current_disclosure_check.caution_type ||
+      current_disclosure_check.kind
+  end
+
+  # This value is used in a GA custom dimension (`spent - dimension1`)
+  def ga_spent?(date)
+    return 'no_date' unless date.instance_of?(Date)
+
+    date.past? ? 'yes' : 'no'
+  end
+
+  private
+
+  # Custom dimensions on Google Analytics are named `dimensionX` where X
+  # is an index from 1 to 20 (there is a limit of 20 per GA property).
+  # https://support.google.com/analytics/answer/2709828?hl=en
+  #
+  def custom_dimensions(hash)
+    dimensions = hash || {}
+
+    CUSTOM_DIMENSIONS_MAP.each do |key, name|
+      dimensions[name] = dimensions.delete(key) if dimensions.key?(key)
+    end
+
+    dimensions
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,29 +46,6 @@ module ApplicationHelper
     )
   end
 
-  def analytics_tracking_id
-    ENV['GA_TRACKING_ID']
-  end
-
-  def track_transaction(attributes)
-    return unless current_disclosure_check.present?
-
-    content_for :transaction_data, {
-      id: current_disclosure_check.id,
-      sku: transaction_sku,
-      quantity: 1,
-    }.merge(attributes).to_json.html_safe
-  end
-
-  # We try to be as accurate as possible, but some transactions might
-  # trigger before having reached the subtype step.
-  def transaction_sku
-    current_disclosure_check.conviction_subtype ||
-      current_disclosure_check.conviction_type ||
-      current_disclosure_check.caution_type ||
-      current_disclosure_check.kind
-  end
-
   def service_name
     t('service.name')
   end
@@ -84,11 +61,5 @@ module ApplicationHelper
     Raven.capture_exception(exception)
 
     title ''
-  end
-
-  def display_result(object)
-    return object unless object.instance_of?(Date)
-
-    I18n.l(object)
   end
 end

--- a/app/views/steps/check/results/_caution.en.html.erb
+++ b/app/views/steps/check/results/_caution.en.html.erb
@@ -1,4 +1,4 @@
-<% track_transaction name: 'Caution check completed', category: 'Completed checks' %>
+<% track_transaction name: 'Caution check completed', category: 'Completed checks', dimensions: { spent: ga_spent?(expiry_date) } %>
 
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">

--- a/app/views/steps/check/results/_conviction.en.html.erb
+++ b/app/views/steps/check/results/_conviction.en.html.erb
@@ -1,4 +1,4 @@
-<% track_transaction name: 'Conviction check completed', category: 'Completed checks' %>
+<% track_transaction name: 'Conviction check completed', category: 'Completed checks', dimensions: { spent: ga_spent?(expiry_date) } %>
 
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">

--- a/app/views/steps/check/results/show.en.html.erb
+++ b/app/views/steps/check/results/show.en.html.erb
@@ -1,4 +1,4 @@
-<% title '' %>
+<% title t('.page_title') %>
 
 <div class="govuk-width-container">
   <main class="govuk-main-wrapper" id="main-content">

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -47,6 +47,13 @@ en:
       endorsement: Endorsement
       penalty_points: Penalty points
 
+  steps:
+    check:
+      results:
+        show:
+          page_title: When your caution or conviction is spent
+
+
   results/caution:
     title:
       past_html: Your caution was spent on <span class="nowrap">%{date}</span>

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe AnalyticsHelper, type: :helper do
+  let(:record) { DisclosureCheck.new }
+
+  describe '#analytics_tracking_id' do
+    it 'retrieves the environment variable' do
+      expect(ENV).to receive(:[]).with('GA_TRACKING_ID')
+      helper.analytics_tracking_id
+    end
+  end
+
+  describe '#track_transaction' do
+    before do
+      allow(record).to receive(:id).and_return('12345')
+      allow(record).to receive(:kind).and_return('caution')
+      allow(helper).to receive(:current_disclosure_check).and_return(record)
+    end
+
+    it 'sets the transaction attributes to track' do
+      helper.track_transaction(name: 'whatever')
+
+      expect(
+        helper.content_for(:transaction_data)
+      ).to eq("{\"id\":\"12345\",\"sku\":\"caution\",\"quantity\":1,\"name\":\"whatever\"}")
+    end
+
+    context 'custom dimensions' do
+      it 'sets the transaction attributes to track' do
+        helper.track_transaction(name: 'whatever', dimensions: { spent: 'yes' } )
+
+        expect(
+          helper.content_for(:transaction_data)
+        ).to match(/"name":"whatever","dimension1":"yes"/)
+      end
+    end
+  end
+
+  describe '#transaction_sku' do
+    before do
+      allow(record).to receive(attr_name).and_return(attr_name)
+      allow(helper).to receive(:current_disclosure_check).and_return(record)
+    end
+
+    context 'conviction_subtype is present' do
+      let(:attr_name) { 'conviction_subtype' }
+      it { expect(helper.transaction_sku).to eq(attr_name) }
+    end
+
+    context 'conviction_type is present' do
+      let(:attr_name) { 'conviction_type' }
+      it { expect(helper.transaction_sku).to eq(attr_name) }
+    end
+
+    context 'caution_type is present' do
+      let(:attr_name) { 'caution_type' }
+      it { expect(helper.transaction_sku).to eq(attr_name) }
+    end
+
+    context 'kind is present' do
+      let(:attr_name) { 'kind' }
+      it { expect(helper.transaction_sku).to eq(attr_name) }
+    end
+  end
+
+  describe '#ga_spent?' do
+    context 'for a date in the past' do
+      let(:date) { 1.year.ago.to_date }
+      it { expect(helper.ga_spent?(date)).to eq('yes') }
+    end
+
+    context 'for a date in the present' do
+      let(:date) { Date.current }
+      it { expect(helper.ga_spent?(date)).to eq('no') }
+    end
+
+    context 'for a date in the future' do
+      let(:date) { 1.year.from_now.to_date }
+      it { expect(helper.ga_spent?(date)).to eq('no') }
+    end
+
+    context 'when the argument is not a date' do
+      let(:date) { 'foobar' }
+      it { expect(helper.ga_spent?(date)).to eq('no_date') }
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -98,56 +98,6 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#analytics_tracking_id' do
-    it 'retrieves the environment variable' do
-      expect(ENV).to receive(:[]).with('GA_TRACKING_ID')
-      helper.analytics_tracking_id
-    end
-  end
-
-  describe '#track_transaction' do
-    before do
-      allow(record).to receive(:id).and_return('12345')
-      allow(record).to receive(:kind).and_return('caution')
-      allow(helper).to receive(:current_disclosure_check).and_return(record)
-    end
-
-    it 'sets the transaction attributes to track' do
-      helper.track_transaction(name: 'whatever')
-
-      expect(
-        helper.content_for(:transaction_data)
-      ).to eq("{\"id\":\"12345\",\"sku\":\"caution\",\"quantity\":1,\"name\":\"whatever\"}")
-    end
-  end
-
-  describe '#transaction_sku' do
-    before do
-      allow(record).to receive(attr_name).and_return(attr_name)
-      allow(helper).to receive(:current_disclosure_check).and_return(record)
-    end
-
-    context 'conviction_subtype is present' do
-      let(:attr_name) { 'conviction_subtype' }
-      it { expect(helper.transaction_sku).to eq(attr_name) }
-    end
-
-    context 'conviction_type is present' do
-      let(:attr_name) { 'conviction_type' }
-      it { expect(helper.transaction_sku).to eq(attr_name) }
-    end
-
-    context 'caution_type is present' do
-      let(:attr_name) { 'caution_type' }
-      it { expect(helper.transaction_sku).to eq(attr_name) }
-    end
-
-    context 'kind is present' do
-      let(:attr_name) { 'kind' }
-      it { expect(helper.transaction_sku).to eq(attr_name) }
-    end
-  end
-
   describe 'capture missing translations' do
     before do
       ActionView::Base.raise_on_missing_translations = false
@@ -201,24 +151,6 @@ RSpec.describe ApplicationHelper, type: :helper do
     it 'should call #title with a blank value' do
       expect(helper).to receive(:title).with('')
       helper.fallback_title
-    end
-  end
-
-  describe '#display_result' do
-    let(:display_result) { helper.display_result(value) }
-
-    context 'is a date' do
-      let(:value) { Date.new(2019, 1, 1) }
-      it 'returns a formatted date' do
-        expect(display_result).to eq(I18n.l(value))
-      end
-    end
-
-    context 'is not a date' do
-      let(:value) { Faker::TvShows::SiliconValley.quote }
-      it 'returns a string' do
-        expect(display_result).to eq(value)
-      end
     end
   end
 end


### PR DESCRIPTION
Add to the completed transaction an extra bit of information whether the caution or the conviction is spent (yes/no values).
This is done with custom dimensions.

A bit of refactor and moving code related to GA to a separate helper `analytics_helper.rb`

Removed the unused method `#display_result`

Fixed the results page title.