### PR TITLE
 Add feature-flag mechanism for adults journey

### DIFF
--- a/app/controllers/concerns/bypass_under_age.rb
+++ b/app/controllers/concerns/bypass_under_age.rb
@@ -1,0 +1,7 @@
+module BypassUnderAge
+  private
+
+  def as_name
+    cookies[:adults_enabled].present? ? :bypass_under_age : :under_age
+  end
+end

--- a/app/controllers/experiments_controller.rb
+++ b/app/controllers/experiments_controller.rb
@@ -1,0 +1,21 @@
+class ExperimentsController < ApplicationController
+  before_action :check_permissions, :reset_disclosure_check_session
+
+  # :nocov:
+  def enable_adults
+    cookies.permanent[:adults_enabled] = 1
+    redirect_to root_path
+  end
+
+  def disable_adults
+    cookies.delete :adults_enabled
+    redirect_to root_path
+  end
+  # :nocov:
+
+  private
+
+  def check_permissions
+    raise 'For development use only' unless helpers.dev_tools_enabled?
+  end
+end

--- a/app/controllers/steps/caution/under_age_controller.rb
+++ b/app/controllers/steps/caution/under_age_controller.rb
@@ -1,12 +1,14 @@
 module Steps
   module Caution
     class UnderAgeController < Steps::CautionStepController
+      include BypassUnderAge
+
       def edit
         @form_object = UnderAgeForm.build(current_disclosure_check)
       end
 
       def update
-        update_and_advance(UnderAgeForm, as: :under_age)
+        update_and_advance(UnderAgeForm, as: as_name)
       end
     end
   end

--- a/app/controllers/steps/conviction/under_age_controller.rb
+++ b/app/controllers/steps/conviction/under_age_controller.rb
@@ -1,6 +1,8 @@
 module Steps
   module Conviction
     class UnderAgeController < Steps::ConvictionStepController
+      include BypassUnderAge
+
       def edit
         @form_object = UnderAgeForm.new(
           disclosure_check: current_disclosure_check,
@@ -9,7 +11,7 @@ module Steps
       end
 
       def update
-        update_and_advance(UnderAgeForm)
+        update_and_advance(UnderAgeForm, as: as_name)
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,4 +73,9 @@ module ApplicationHelper
 
     link_to text, url, class: 'govuk-link', rel: 'external', target: '_blank'
   end
+
+  # Use this to feature-flag code that should only run/show on test environments
+  def dev_tools_enabled?
+    Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')
+  end
 end

--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -32,4 +32,9 @@ class BaseDecisionTree
   def edit(step_controller, params = {})
     { controller: step_controller, action: :edit }.merge(params)
   end
+
+  # TODO: temporary feature-flag, to be removed when no needed
+  def under_age_or_bypass?
+    GenericYesNo.new(disclosure_check.under_age).yes? || step_name.eql?(:bypass_under_age)
+  end
 end

--- a/app/services/caution_decision_tree.rb
+++ b/app/services/caution_decision_tree.rb
@@ -4,7 +4,7 @@ class CautionDecisionTree < BaseDecisionTree
     return next_step if next_step
 
     case step_name
-    when :under_age
+    when :under_age, :bypass_under_age
       after_under_age
     when :caution_type
       edit(:known_date)
@@ -21,7 +21,7 @@ class CautionDecisionTree < BaseDecisionTree
   private
 
   def after_under_age
-    return edit(:caution_type) if GenericYesNo.new(step_value(:under_age)).yes?
+    return edit(:caution_type) if under_age_or_bypass?
 
     show('/steps/check/exit_over18')
   end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -6,7 +6,7 @@ class ConvictionDecisionTree < BaseDecisionTree
     return next_step if next_step
 
     case step_name
-    when :under_age
+    when :under_age, :bypass_under_age
       after_under_age
     when :conviction_type
       edit(:conviction_subtype)
@@ -29,7 +29,7 @@ class ConvictionDecisionTree < BaseDecisionTree
   private
 
   def after_under_age
-    return edit(:conviction_type) if GenericYesNo.new(disclosure_check.under_age).yes?
+    return edit(:conviction_type) if under_age_or_bypass?
 
     show('/steps/check/exit_over18')
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,10 @@ Rails.application.routes.draw do
 
   get 'warning/reset_session'
 
+  # Temporary routes to test adults journey
+  get 'enable_adults',  controller: :experiments
+  get 'disable_adults', controller: :experiments
+
   namespace :steps do
     namespace :check do
       edit_step :kind

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -169,4 +169,32 @@ RSpec.describe ApplicationHelper, type: :helper do
       )
     end
   end
+
+  describe 'dev_tools_enabled?' do
+    before do
+      allow(Rails).to receive_message_chain(:env, :development?).and_return(development_env)
+      allow(ENV).to receive(:key?).with('DEV_TOOLS_ENABLED').and_return(dev_tools_enabled)
+    end
+
+    context 'for development envs' do
+      let(:development_env) { true }
+      let(:dev_tools_enabled) { nil }
+
+      it { expect(helper.dev_tools_enabled?).to eq(true) }
+    end
+
+    context 'for envs that declare the `DEV_TOOLS_ENABLED` env variable' do
+      let(:development_env) { false }
+      let(:dev_tools_enabled) { true }
+
+      it { expect(helper.dev_tools_enabled?).to eq(true) }
+    end
+
+    context 'for envs without `DEV_TOOLS_ENABLED` env variable' do
+      let(:development_env) { false }
+      let(:dev_tools_enabled) { false }
+
+      it { expect(helper.dev_tools_enabled?).to eq(false) }
+    end
+  end
 end

--- a/spec/services/caution_decision_tree_spec.rb
+++ b/spec/services/caution_decision_tree_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe CautionDecisionTree do
   let(:disclosure_check) do
     instance_double(
       DisclosureCheck,
-      caution_type: caution_type
+      caution_type: caution_type,
+      under_age: under_age,
     )
   end
 
   let(:caution_type) { nil }
+  let(:under_age)    { nil }
   let(:step_params)  { double('Step') }
   let(:next_step)    { nil }
   let(:as)           { nil }
@@ -28,6 +30,13 @@ RSpec.describe CautionDecisionTree do
     context 'and answer is `no`' do
       let(:under_age) { GenericYesNo::NO }
       it { is_expected.to have_destination('/steps/check/exit_over18', :show) }
+    end
+
+    # TODO: temporary feature-flag, to be removed when no needed
+    context 'and answer is `no` but we are bypassing' do
+      let(:under_age) { GenericYesNo::NO }
+      let(:as) { :bypass_under_age }
+      it { is_expected.to have_destination(:caution_type, :edit) }
     end
   end
 

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -24,16 +24,25 @@ RSpec.describe ConvictionDecisionTree do
 
   it_behaves_like 'a decision tree'
 
-  context 'when the step is `under_age_conviction`' do
-    let(:under_age)  { GenericYesNo::YES }
+  describe 'when the step is `under_age`' do
     let(:step_params) { { under_age: under_age } }
-    it { is_expected.to have_destination(:conviction_type, :edit) }
-  end
 
-  context 'when the step is `under_age_conviction` equal no' do
-    let(:under_age)  { GenericYesNo::NO }
-    let(:step_params) { { under_age: under_age } }
-    it { is_expected.to have_destination('/steps/check/exit_over18', :show) }
+    context 'and answer is `yes`' do
+      let(:under_age) { GenericYesNo::YES }
+      it { is_expected.to have_destination(:conviction_type, :edit) }
+    end
+
+    context 'and answer is `no`' do
+      let(:under_age) { GenericYesNo::NO }
+      it { is_expected.to have_destination('/steps/check/exit_over18', :show) }
+    end
+
+    # TODO: temporary feature-flag, to be removed when no needed
+    context 'and answer is `no` but we are bypassing' do
+      let(:under_age) { GenericYesNo::NO }
+      let(:as) { :bypass_under_age }
+      it { is_expected.to have_destination(:conviction_type, :edit) }
+    end
   end
 
   context 'when the step is `known_date` ' do


### PR DESCRIPTION
This is a simple mechanism to drop a cookie (or delete the cookie) so the adults journey can be enabled, while undergoing development/test, without affecting users accessing the service.

Individual commits for more context.
