### PR TITLE
Prepare conviction types for adults

### DIFF
--- a/app/forms/steps/caution/caution_type_form.rb
+++ b/app/forms/steps/caution/caution_type_form.rb
@@ -16,7 +16,7 @@ module Steps
       private
 
       def under_age?
-        disclosure_check.under_age == 'yes'
+        disclosure_check.under_age.inquiry.yes?
       end
 
       def changed?

--- a/app/forms/steps/conviction/conviction_type_form.rb
+++ b/app/forms/steps/conviction/conviction_type_form.rb
@@ -3,12 +3,21 @@ module Steps
     class ConvictionTypeForm < BaseForm
       attribute :conviction_type, String
 
-      def self.choices
-        ConvictionType::PARENT_TYPES.map(&:to_s)
+      validates_inclusion_of :conviction_type, in: :choices, if: :disclosure_check
+
+      def choices
+        if under_age?
+          ConvictionType::YOUTH_PARENT_TYPES
+        else
+          ConvictionType::ADULT_PARENT_TYPES
+        end.map(&:to_s)
       end
-      validates_inclusion_of :conviction_type, in: choices
 
       private
+
+      def under_age?
+        disclosure_check.under_age.inquiry.yes?
+      end
 
       def changed?
         disclosure_check.conviction_type != conviction_type

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -18,11 +18,15 @@ class ConvictionType < ValueObject
   alias compensation? compensation
 
   VALUES = [
-    PARENT_TYPES = [
+    YOUTH_PARENT_TYPES = [
       COMMUNITY_ORDER     = new(:community_order),
       CUSTODIAL_SENTENCE  = new(:custodial_sentence),
       DISCHARGE           = new(:discharge),
       FINANCIAL           = new(:financial),
+    ].freeze,
+
+    ADULT_PARENT_TYPES = [
+      ADULT_COMMUNITY_ORDER = new(:adult_community_order),
     ].freeze,
 
     # Quick way of enabling/disabling convictions. These will not show in the interface to users.
@@ -32,6 +36,10 @@ class ConvictionType < ValueObject
       ARMED_FORCES = new(:armed_forces),
     ].freeze,
 
+    #####################
+    # Youth convictions #
+    #####################
+    #
     DISMISSAL                          = new(:dismissal,                        parent: ARMED_FORCES, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
     SERVICE_DETENTION                  = new(:service_detention,                parent: ARMED_FORCES, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
     SERVICE_COMMUNITY_ORDER            = new(:service_community_order,          parent: ARMED_FORCES, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
@@ -66,6 +74,10 @@ class ConvictionType < ValueObject
     FINE                               = new(:fine,                             parent: FINANCIAL, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
     COMPENSATION_TO_A_VICTIM           = new(:compensation_to_a_victim,         parent: FINANCIAL, compensation: true, calculator_class: Calculators::CompensationCalculator),
 
+    ######################
+    # Adults convictions #
+    ######################
+    #
   ].flatten.freeze
 
   # :nocov:

--- a/app/views/steps/conviction/conviction_type/edit.html.erb
+++ b/app/views/steps/conviction/conviction_type/edit.html.erb
@@ -9,7 +9,7 @@
       <div class="govuk-grid-column-two-thirds">
         <%= error_summary %>
         <%= step_form @form_object do |f| %>
-          <%= f.radio_button_fieldset :conviction_type, choices: Steps::Conviction::ConvictionTypeForm.choices, radio_hint: true %>
+          <%= f.radio_button_fieldset :conviction_type, choices: @form_object.choices, radio_hint: true %>
           <%= f.continue_button %>
         <% end %>
       </div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -2,11 +2,14 @@
 en:
   dictionary:
     CONVICTION_TYPES: &CONVICTION_TYPES
+      # youth
       armed_forces: Armed forces
       community_order: Community or youth rehabilitation order (YRO)
       custodial_sentence: Custodial sentence or hospital order
       discharge: Discharge
       financial: Financial penalty
+      # adults
+      adult_community_order: Community order
     CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
       # armed_forces
       dismissal: Dismissal
@@ -87,6 +90,7 @@ en:
         custodial_sentence: What type of sentence were you given?
         discharge: What discharge were you given?
         financial: What were you ordered to pay?
+        adult_community_order: What was your community order?
       steps_conviction_conviction_length_type_form:
         # default key
         conviction_length_type: Was the length of the order given in weeks, months or years?
@@ -129,11 +133,14 @@ en:
           youth_simple_caution: You did not have to agree to any conditions
           youth_conditional_caution: You agreed to certain conditions, such as paying a fine or learning about the effects of drugs
         conviction_type:
+          # youth
           armed_forces: ""
           community_order: For example, a curfew or referral order. You might have been asked to wear a tag as part of your order
           custodial_sentence: For example, a detention and training order (DTO) or a hospital order given under the Mental Health Act
           discharge: For example, a conditional discharge order or bind over
           financial: For example, paying a fine or compensation
+          # adults
+          adult_community_order: For example, a curfew or referral order. You might have been asked to wear a tag as part of your order
         conviction_subtype:
           # armed_forces
           dismissal: ""

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -2,11 +2,14 @@
 en:
   dictionary:
     CONVICTION_TYPES: &CONVICTION_TYPES
+      # youth
       armed_forces: Armed forces
       community_order: Community or youth rehabilitation order (YRO)
       custodial_sentence: Custodial sentence or hospital order
       discharge: Discharge
       financial: Financial penalty
+      # adults
+      adult_community_order: Community order
     CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
       # armed_forces
       dismissal: Dismissal

--- a/spec/forms/steps/conviction/conviction_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_type_form_spec.rb
@@ -8,14 +8,27 @@ RSpec.describe Steps::Conviction::ConvictionTypeForm do
     }
   end
 
-  let(:disclosure_check) { instance_double(DisclosureCheck, conviction_type: nil) }
+  let(:disclosure_check) { instance_double(DisclosureCheck, conviction_type: nil, under_age: under_age) }
   let(:conviction_type) { nil }
+  let(:under_age) { 'yes' }
 
   subject { described_class.new(arguments) }
 
-  describe '.choices' do
-    it 'returns the parent types' do
-      expect(described_class.choices).to eq(ConvictionType::PARENT_TYPES.map(&:to_s))
+  describe '#choices' do
+    context 'when under 18' do
+      let(:under_age) { 'yes' }
+
+      it 'shows only the relevant choices' do
+        expect(subject.choices).to eq(ConvictionType::YOUTH_PARENT_TYPES.map(&:to_s))
+      end
+    end
+
+    context 'when over 18' do
+      let(:under_age) { 'no' }
+
+      it 'shows only the relevant choices' do
+        expect(subject.choices).to eq(ConvictionType::ADULT_PARENT_TYPES.map(&:to_s))
+      end
     end
   end
 
@@ -36,7 +49,9 @@ RSpec.describe Steps::Conviction::ConvictionTypeForm do
       end
 
       context 'when conviction_type is already the same on the model' do
-        let(:disclosure_check) { instance_double(DisclosureCheck, conviction_type: conviction_type) }
+        let(:disclosure_check) {
+          instance_double(DisclosureCheck, conviction_type: conviction_type, under_age: 'yes')
+        }
         let(:conviction_type)  { 'community_order' }
 
         it 'does not save the record but returns true' do

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -1,15 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe ConvictionType do
-  describe 'PARENT_TYPES' do
-    let(:values) { described_class::PARENT_TYPES.map(&:to_s) }
+  describe 'YOUTH_PARENT_TYPES' do
+    let(:values) { described_class::YOUTH_PARENT_TYPES.map(&:to_s) }
 
-    it 'returns top level conviction' do
+    it 'returns top level youth convictions' do
       expect(values).to eq(%w(
         community_order
         custodial_sentence
         discharge
         financial
+      ))
+    end
+  end
+
+  describe 'ADULT_PARENT_TYPES' do
+    let(:values) { described_class::ADULT_PARENT_TYPES.map(&:to_s) }
+
+    it 'returns top level adult convictions' do
+      expect(values).to eq(%w(
+        adult_community_order
       ))
     end
   end


### PR DESCRIPTION
Some changes to the form object, in the same way we did for cautions.

Separate parent types for youth and adults in the value object.

In essence, all new parent types, and their children, must have different names (even if they are identical to the youth ones) so we can customise the copy, they can have different calculators, and they track differently in GA, etc.