### PR TITLE
Add adult Prevention and reparation orders convictions journey

### DIFF
--- a/app/services/calculators/addition_calculator.rb
+++ b/app/services/calculators/addition_calculator.rb
@@ -20,6 +20,15 @@ module Calculators
       end
     end
 
+    # If length is given: conviction end date + 12 months
+    # If no length is given: conviction start date + 24 months
+    #
+    class PlusTwelveMonths < AdditionCalculator
+      def added_time
+        { months: 12 }
+      end
+    end
+
     # Only a possibility: start date + 6 months
     #
     class StartPlusSixMonths < AdditionCalculator

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -26,8 +26,9 @@ class ConvictionType < ValueObject
     ].freeze,
 
     ADULT_PARENT_TYPES = [
-      ADULT_COMMUNITY_ORDER = new(:adult_community_order),
-      ADULT_FINANCIAL       = new(:adult_financial),
+      ADULT_COMMUNITY_ORDER                  = new(:adult_community_order),
+      ADULT_FINANCIAL                        = new(:adult_financial),
+      ADULT_PREVENTION_AND_REPARATION_ORDER  = new(:adult_prevention_and_reparation_order),
     ].freeze,
 
     # Quick way of enabling/disabling convictions. These will not show in the interface to users.
@@ -79,9 +80,14 @@ class ConvictionType < ValueObject
     # Adults convictions #
     ######################
 
-    ADULT_FINE                               = new(:adult_fine,                     parent: ADULT_FINANCIAL, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusTwelveMonths),
-    ADULT_COMPENSATION_TO_A_VICTIM           = new(:adult_compensation_to_a_victim, parent: ADULT_FINANCIAL, compensation: true, calculator_class: Calculators::CompensationCalculator),
+    ADULT_FINE                        = new(:adult_fine,                          parent: ADULT_FINANCIAL, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusTwelveMonths),
+    ADULT_COMPENSATION_TO_A_VICTIM    = new(:adult_compensation_to_a_victim,      parent: ADULT_FINANCIAL, compensation: true, calculator_class: Calculators::CompensationCalculator),
 
+    ADULT_ATTENDANCE_CENTRE_ORDER      = new(:adult_attendance_centre_order,      parent: ADULT_PREVENTION_AND_REPARATION_ORDER, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
+    ADULT_REPARATION_ORDER             = new(:adult_reparation_order,             parent: ADULT_PREVENTION_AND_REPARATION_ORDER, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
+    ADULT_RESTRAINING_ORDER            = new(:adult_restraining_order,            parent: ADULT_PREVENTION_AND_REPARATION_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    ADULT_SEXUAL_HARM_PREVENTION_ORDER = new(:adult_sexual_harm_prevention_order, parent: ADULT_PREVENTION_AND_REPARATION_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    ADULT_SUPERVISION_ORDER            = new(:adult_supervision_order,            parent: ADULT_PREVENTION_AND_REPARATION_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
   ].flatten.freeze
 
   # :nocov:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -11,6 +11,8 @@ en:
       # adults
       adult_community_order: Community order
       adult_financial: Financial penalty
+      adult_prevention_and_reparation_order: Prevention and reparation orders
+
     CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
       # armed_forces
       dismissal: Dismissal
@@ -47,9 +49,17 @@ en:
       fine: A fine
       compensation_to_a_victim: Compensation to a victim
 
+      # adult_prevention_and_reparation_order
+      adult_attendance_centre_order: Attendance centre order
+      adult_reparation_order: Reparation order
+      adult_restraining_order: Restraining order
+      adult_sexual_harm_prevention_order: Sexual harm prevention order (sexual offence prevention order)
+      adult_supervision_order: Supervision order
       # adult_financial
       adult_fine: A fine
       adult_compensation_to_a_victim: Compensation to a victim
+
+
 
   shared:
     back_link: Back
@@ -145,6 +155,8 @@ en:
           # adults
           adult_community_order: For example, a curfew or referral order. You might have been asked to wear a tag as part of your order
           adult_financial: For example, paying a fine or compensation
+          adult_prevention_and_reparation_order: ""
+
         conviction_subtype:
           # armed_forces
           dismissal: ""
@@ -180,7 +192,12 @@ en:
           # financial
           fine: ""
           compensation_to_a_victim: ""
-
+          # adult_prevention_and_reparation_order
+          adult_attendance_centre_order: You were ordered to go to an attendance centre for a set number of hours
+          adult_reparation_order: You were given help understanding the effect your crime had on someone
+          adult_restraining_order: You were ordered not to do something, such as approach or contact a certain person
+          adult_sexual_harm_prevention_order: A court ruled that you pose a risk of causing sexual harm
+          adult_supervision_order: You were ordered to be supervised by a youth offending team after loitering, soliciting or 'breaching a civil injunction'
           # adult_financial
           adult_fine: ""
           adult_compensation_to_a_victim: ""

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -11,6 +11,7 @@ en:
       # adults
       adult_community_order: Community order
       adult_financial: Financial penalty
+      adult_prevention_and_reparation_order: Prevention and reparation orders
     CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
       # armed_forces
       dismissal: Dismissal
@@ -50,6 +51,12 @@ en:
       disqualification: Disqualification
       endorsement: Endorsement
       penalty_points: Penalty points
+      # adult_prevention_and_reparation_order
+      adult_attendance_centre_order: Attendance centre order
+      adult_reparation_order: Reparation order
+      adult_restraining_order: Restraining order
+      adult_sexual_harm_prevention_order: Sexual harm prevention order (sexual offence prevention order)
+      adult_supervision_order: Supervision order
 
       # adult_financial
       adult_fine: A fine

--- a/features/adults/prevention_and_reparation_order.feature
+++ b/features/adults/prevention_and_reparation_order.feature
@@ -1,0 +1,35 @@
+Feature: Conviction
+  Scenario Outline: CPrevention and reparation orders
+  Given I am completing a basic 18 or over "Prevention and reparation orders" conviction
+  Then I should see "What type of order were you given?"
+
+  When I choose "<subtype>"
+  Then I should see "<known_date_header>"
+
+  And I enter a valid date
+  Then I should see "<length_type_header>"
+
+  And  I choose "Weeks"
+  Then I should see "<length_header>"
+  And I fill in "Number of weeks" with "10"
+
+  Then I click the "Continue" button
+  And I should be on "<result>"
+
+  Examples:
+    | subtype                                                        | known_date_header                              | length_type_header                                                           | length_header                                     | result               |
+    | Attendance centre order                                        | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
+    | Restraining order                                              | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
+    | Sexual harm prevention order (sexual offence prevention order) | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
+    | Supervision order                                              | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
+
+
+  Scenario: Prevention and reparation orders - Reparation order
+  Given I am completing a basic 18 or over "Prevention and reparation orders" conviction
+  Then I should see "What type of order were you given?"
+
+  When I choose "Reparation order"
+  Then I should see "When were you given the order?"
+
+  And I enter a valid date
+  Then I should be on "/steps/check/results"

--- a/spec/services/calculators/addition_calculator_spec.rb
+++ b/spec/services/calculators/addition_calculator_spec.rb
@@ -43,6 +43,21 @@ RSpec.describe Calculators::AdditionCalculator do
     end
   end
 
+  describe Calculators::AdditionCalculator::PlusTwelveMonths do
+    context '#expiry_date' do
+      context 'without a conviction length' do
+        it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
+      end
+
+      context 'with a conviction length' do
+        let(:conviction_length) { 5 }
+        let(:conviction_length_type) { 'years' }
+
+        it { expect(subject.expiry_date.to_s).to eq('2024-10-31') }
+      end
+    end
+  end
+
   describe Calculators::AdditionCalculator::StartPlusSixMonths do
     context '#expiry_date' do
       it { expect(subject.expiry_date.to_s).to eq('2019-04-30') }

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ConvictionType do
       expect(values).to eq(%w(
         adult_community_order
         adult_financial
+        adult_prevention_and_reparation_order
       ))
     end
   end
@@ -120,6 +121,20 @@ RSpec.describe ConvictionType do
         expect(values).to eq(%w(
           adult_fine
           adult_compensation_to_a_victim
+        ))
+      end
+    end
+
+    context 'Prevention and reparation orders' do
+      let(:conviction_type) { :adult_prevention_and_reparation_order }
+
+      it 'returns subtypes of this conviction type' do
+        expect(values).to eq(%w(
+          adult_attendance_centre_order
+          adult_reparation_order
+          adult_restraining_order
+          adult_sexual_harm_prevention_order
+          adult_supervision_order
         ))
       end
     end
@@ -393,6 +408,46 @@ RSpec.describe ConvictionType do
       it { expect(conviction_type.skip_length?).to eq(false) }
       it { expect(conviction_type.compensation?).to eq(true) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::CompensationCalculator) }
+    end
+
+    context 'ADULT_ATTENDANCE_CENTRE_ORDER' do
+      let(:subtype) { 'adult_attendance_centre_order' }
+
+      it { expect(conviction_type.skip_length?).to eq(false) }
+      it { expect(conviction_type.compensation?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusTwelveMonths) }
+    end
+
+    context 'ADULT_REPARATION_ORDER' do
+      let(:subtype) { 'adult_reparation_order' }
+
+      it { expect(conviction_type.skip_length?).to eq(true) }
+      it { expect(conviction_type.compensation?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::ImmediatelyCalculator) }
+    end
+
+    context 'ADULT_RESTRAINING_ORDER' do
+      let(:subtype) { 'adult_restraining_order' }
+
+      it { expect(conviction_type.skip_length?).to eq(false) }
+      it { expect(conviction_type.compensation?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
+    end
+
+    context 'ADULT_SEXUAL_HARM_PREVENTION_ORDER' do
+      let(:subtype) { 'adult_sexual_harm_prevention_order' }
+
+      it { expect(conviction_type.skip_length?).to eq(false) }
+      it { expect(conviction_type.compensation?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
+    end
+
+    context 'ADULT_SUPERVISION_ORDER' do
+      let(:subtype) { 'adult_supervision_order' }
+
+      it { expect(conviction_type.skip_length?).to eq(false) }
+      it { expect(conviction_type.compensation?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
   end
 end


### PR DESCRIPTION
Create adult prevention and reparation orders convictions journey with the following

- add prevention and reparation orders conviction type
- add prevention and reparation orders conviction sub types
- add plus twelve months calculator
- add adult prevention and reparation order convictions feature