### PR TITLE
Add embedded survey and update phase link

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -28,7 +28,7 @@ module AnalyticsHelper
   # We try to be as accurate as possible, but some transactions might
   # trigger before having reached the subtype step.
   def transaction_sku
-    return 'unknown' if current_disclosure_check.nil?
+    return 'unknown' unless current_disclosure_check&.kind
 
     current_disclosure_check.conviction_subtype ||
       current_disclosure_check.conviction_type ||

--- a/app/views/steps/check/results/shared/_feedback.en.html.erb
+++ b/app/views/steps/check/results/shared/_feedback.en.html.erb
@@ -1,0 +1,20 @@
+<hr>
+<h2 class="govuk-heading-m govuk-!-margin-top-5">
+  We’d like your feedback
+</h2>
+
+<p class="govuk-body">
+  This will help us to improve the service.
+</p>
+
+<!-- BEGIN survey monkey embedded satisfaction -->
+<style>
+  div.smcx-embed { border: 1px solid #ffffff; height: 720px; overflow: hidden; }
+</style>
+<script>
+  (function (t, e, s, n) {
+    var o, a, c;
+    t.SMCX = t.SMCX || [], e.getElementById(n) || (o = e.getElementsByTagName(s), a = o[o.length - 1], c = e.createElement(s), c.type = "text/javascript", c.async = !0, c.id = n, c.src = ["https:" === location.protocol ? "https://" : "http://", "widget.surveymonkey.com/collect/website/js/tRaiETqnLgj758hTBazgd_2Bo7LRXsbd1AcAFHQu4ukGzukG3bvIXELhbfUTio3i90.js"].join(""), a.parentNode.insertBefore(c, a))
+  })(window, document, "script", "smcx-sdk");
+</script>
+<!-- END survey monkey embedded satisfaction -->

--- a/app/views/steps/check/results/show.en.html.erb
+++ b/app/views/steps/check/results/show.en.html.erb
@@ -14,6 +14,8 @@
           If you need to change any information, or if you have another caution or conviction you’d like to
           check, <%= link_to 'use the service again', root_path, class: 'govuk-link ga-pageLink', data: { ga_category: 'results', ga_label: 'new check' } %>.
         </p>
+
+        <%= render partial: 'steps/check/results/shared/feedback' %>
       </div>
     </div>
   </main>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,8 +37,7 @@ module Disclosure
 
     config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 60).to_i
 
-    # TODO: change when we have the survey ID
-    config.x.surveys.feedback = 'https://www.surveymonkey.com/r/survey'.freeze
+    config.x.surveys.feedback = 'https://www.research.net/r/QW7JCHL'.freeze
 
     # Maintain `in_progress` checks for this number of days
     config.x.checks.incomplete_purge_after_days = 7

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe AnalyticsHelper, type: :helper do
-  let(:record) { DisclosureCheck.new }
+  let(:record) { DisclosureCheck.new(kind: kind) }
+  let(:kind) { CheckKind::CAUTION }
+
+  before do
+    allow(helper).to receive(:current_disclosure_check).and_return(record)
+  end
 
   describe '#analytics_tracking_id' do
     it 'retrieves the environment variable' do
@@ -14,7 +19,6 @@ RSpec.describe AnalyticsHelper, type: :helper do
     before do
       allow(record).to receive(:id).and_return('12345')
       allow(record).to receive(:kind).and_return('caution')
-      allow(helper).to receive(:current_disclosure_check).and_return(record)
     end
 
     it 'sets the transaction attributes to track' do
@@ -38,13 +42,7 @@ RSpec.describe AnalyticsHelper, type: :helper do
 
   describe '#transaction_sku' do
     before do
-      allow(record).to receive(attr_name).and_return(attr_name) if record
-      allow(helper).to receive(:current_disclosure_check).and_return(record)
-    end
-
-    context 'current_disclosure_check is not present' do
-      let(:record) { nil }
-      it { expect(helper.transaction_sku).to eq('unknown') }
+      allow(record).to receive(attr_name).and_return(attr_name)
     end
 
     context 'conviction_subtype is present' do
@@ -65,6 +63,18 @@ RSpec.describe AnalyticsHelper, type: :helper do
     context 'kind is present' do
       let(:attr_name) { 'kind' }
       it { expect(helper.transaction_sku).to eq(attr_name) }
+    end
+  end
+
+  describe '#transaction_sku when not enough steps have been completed' do
+    context '`current_disclosure_check` is not present' do
+      let(:record) { nil }
+      it { expect(helper.transaction_sku).to eq('unknown') }
+    end
+
+    context '`current_disclosure_check` is present, but `kind` is not present' do
+      let(:kind) { nil }
+      it { expect(helper.transaction_sku).to eq('unknown') }
     end
   end
 


### PR DESCRIPTION
We now have the "real" surveys.

Add the end of service embedded survey (like we did in C100) and update the link in the phase banner.

Ensure we propagate `check=unknown` to the survey if we don't have a current_disclosure_check record, or we have it, but it doesn't have the `kind` attribute yet.