### PR TITLE
Rename adult cautions for consistency

### DIFF
--- a/app/forms/steps/caution/caution_type_form.rb
+++ b/app/forms/steps/caution/caution_type_form.rb
@@ -7,9 +7,9 @@ module Steps
 
       def choices
         if under_age?
-          CautionType::YOUTH_VALUES
+          CautionType::YOUTH_TYPES
         else
-          CautionType::NON_YOUTH_VALUES
+          CautionType::ADULT_TYPES
         end.map(&:to_s)
       end
 

--- a/app/value_objects/caution_type.rb
+++ b/app/value_objects/caution_type.rb
@@ -1,25 +1,21 @@
 class CautionType < ValueObject
   VALUES = [
-    YOUTH_VALUES = [
+    YOUTH_TYPES = [
       YOUTH_SIMPLE_CAUTION = new(:youth_simple_caution),
       YOUTH_CONDITIONAL_CAUTION = new(:youth_conditional_caution),
     ].freeze,
 
-    NON_YOUTH_VALUES = [
-      SIMPLE_CAUTION = new(:simple_caution),
-      CONDITIONAL_CAUTION = new(:conditional_caution),
+    ADULT_TYPES = [
+      ADULT_SIMPLE_CAUTION = new(:adult_simple_caution),
+      ADULT_CONDITIONAL_CAUTION = new(:adult_conditional_caution),
     ].freeze
   ].flatten.freeze
 
   def conditional?
     [
-      CONDITIONAL_CAUTION,
+      ADULT_CONDITIONAL_CAUTION,
       YOUTH_CONDITIONAL_CAUTION
     ].include?(self)
-  end
-
-  def youth?
-    YOUTH_VALUES.include?(self)
   end
 
   def self.values

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -158,8 +158,8 @@ en:
           caution: You were given an official warning by the police
           conviction: You were found guilty of a crime in court
         caution_type:
-          simple_caution: You did not have to agree to any conditions
-          conditional_caution: You agreed to certain conditions, such as paying a fine or learning about the effects of drugs
+          adult_simple_caution: You did not have to agree to any conditions
+          adult_conditional_caution: You agreed to certain conditions, such as paying a fine or learning about the effects of drugs
           youth_simple_caution: You did not have to agree to any conditions
           youth_conditional_caution: You agreed to certain conditions, such as paying a fine or learning about the effects of drugs
         conviction_type:
@@ -251,8 +251,8 @@ en:
         year: Year
       steps_caution_caution_type_form:
         caution_type:
-          simple_caution: Simple caution
-          conditional_caution: Conditional caution
+          adult_simple_caution: Simple caution
+          adult_conditional_caution: Conditional caution
           youth_simple_caution: Youth caution
           youth_conditional_caution: Youth conditional caution
       steps_conviction_known_date_form:

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -108,8 +108,8 @@ en:
     caution_type:
       question: Type of caution
       answers:
-        simple_caution: Simple caution
-        conditional_caution: Conditional caution
+        adult_simple_caution: Simple caution
+        adult_conditional_caution: Conditional caution
         youth_simple_caution: Youth caution
         youth_conditional_caution: Youth conditional caution
 

--- a/spec/forms/steps/caution/caution_type_form_spec.rb
+++ b/spec/forms/steps/caution/caution_type_form_spec.rb
@@ -30,15 +30,15 @@ RSpec.describe Steps::Caution::CautionTypeForm do
 
       it 'shows only the relevant choices' do
         expect(subject.choices).to eq(%w(
-          simple_caution
-          conditional_caution
+          adult_simple_caution
+          adult_conditional_caution
         ))
       end
     end
   end
 
   describe '#save' do
-    it_behaves_like 'a value object form', attribute_name: :caution_type, example_value: 'simple_caution'
+    it_behaves_like 'a value object form', attribute_name: :caution_type, example_value: 'youth_simple_caution'
 
     context 'when form is valid' do
       let(:caution_type) { 'youth_simple_caution' }

--- a/spec/services/caution_decision_tree_spec.rb
+++ b/spec/services/caution_decision_tree_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe CautionDecisionTree do
     let(:step_params) { { known_date: 'anything' } }
 
     context 'and type is `simple caution`' do
-      let(:caution_type) { CautionType::SIMPLE_CAUTION }
+      let(:caution_type) { CautionType::ADULT_SIMPLE_CAUTION }
       it { is_expected.to have_destination('/steps/check/results', :show) }
     end
 
     context 'and type is `conditional caution`' do
-      let(:caution_type)  { CautionType::CONDITIONAL_CAUTION }
+      let(:caution_type)  { CautionType::ADULT_CONDITIONAL_CAUTION }
       it { is_expected.to have_destination(:conditional_end_date, :edit) }
     end
   end

--- a/spec/value_objects/caution_type_spec.rb
+++ b/spec/value_objects/caution_type_spec.rb
@@ -1,13 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe CautionType do
+  describe 'YOUTH_TYPES' do
+    let(:values) { described_class::YOUTH_TYPES.map(&:to_s) }
+
+    it 'returns youth cautions' do
+      expect(values).to eq(%w(
+        youth_simple_caution
+        youth_conditional_caution
+      ))
+    end
+  end
+
+  describe 'ADULT_TYPES' do
+    let(:values) { described_class::ADULT_TYPES.map(&:to_s) }
+
+    it 'returns youth cautions' do
+      expect(values).to eq(%w(
+        adult_simple_caution
+        adult_conditional_caution
+      ))
+    end
+  end
+
   describe '.values' do
     let(:values) do
       %w(
         youth_simple_caution
         youth_conditional_caution
-        simple_caution
-        conditional_caution
+        adult_simple_caution
+        adult_conditional_caution
       )
     end
 
@@ -19,36 +41,24 @@ RSpec.describe CautionType do
   describe '.conditional?' do
     subject { described_class.new(value).conditional? }
 
-    context 'Caution type is conditional' do
-      let(:value) { :conditional_caution }
-      it 'returns true' do 
-        expect(subject).to eq true
-      end
+    context 'youth_conditional_caution' do
+      let(:value) { :youth_conditional_caution }
+      it { expect(subject).to eq(true) }
     end
 
-    context 'Caution type is simple' do
-      let(:value) { :simple_caution }
-      it 'returns false' do 
-        expect(subject).to eq false
-      end
+    context 'adult_conditional_caution' do
+      let(:value) { :adult_conditional_caution }
+      it { expect(subject).to eq(true) }
     end
-  end
 
-  describe '.youth?' do
-    subject { described_class.new(value).youth? }
-
-    context 'Caution type is youth' do
+    context 'youth_simple_caution' do
       let(:value) { :youth_simple_caution }
-      it 'returns true' do 
-        expect(subject).to eq true
-      end
+      it { expect(subject).to eq(false) }
     end
 
-    context 'Caution type is not youth' do
-      let(:value) { :simple_caution }
-      it 'returns false' do 
-        expect(subject).to eq false
-      end
+    context 'adult_simple_caution' do
+      let(:value) { :adult_simple_caution }
+      it { expect(subject).to eq(false) }
     end
   end
 end


### PR DESCRIPTION
To make these consistent with the adult convictions, we are going to rename the adult cautions value-objects, previously `simple_caution` and `conditional_caution`, to be prefixed with `adult`

Updated the spec to test more thoroughly.