### PR TITLE
Remove superfluous hint text

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -158,10 +158,6 @@ en:
         known_date: Enter the date you were convicted by a court. For example, 23 9 2018
       steps_conviction_compensation_payment_date_form:
         compensation_payment_date: For example, 23 9 2018
-      steps_conviction_conviction_length_form:
-        weeks: Number of weeks
-        months: Number of months
-        years: Number of years
       radio_buttons:
         kind:
           caution: You were given an official warning by the police


### PR DESCRIPTION
There was a duplication in the input label and in the hint.
Remove the hint text as it is redundant.

Before:
<img width="259" alt="Screen Shot 2019-08-08 at 10 53 23" src="https://user-images.githubusercontent.com/687910/62694045-7f7e6400-b9cb-11e9-9f6f-5e5283d87ee9.png">

After:
<img width="229" alt="Screen Shot 2019-08-08 at 10 53 40" src="https://user-images.githubusercontent.com/687910/62694060-84431800-b9cb-11e9-9e07-0da344605d73.png">
