### PR TITLE
Stop conviction_length_form from accepting a non-integer number

### DIFF
--- a/app/forms/steps/conviction/conviction_length_form.rb
+++ b/app/forms/steps/conviction/conviction_length_form.rb
@@ -1,7 +1,7 @@
 module Steps
   module Conviction
     class ConvictionLengthForm < BaseForm
-      attribute :conviction_length, Integer
+      attribute :conviction_length, String
       delegate :conviction_length_type, to: :disclosure_check
 
       validates_numericality_of :conviction_length, greater_than: 0, only_integer: true

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -42,6 +42,7 @@ en:
             conviction_length:
               greater_than: The length must be 1 or more
               not_a_number: The length must be a number, like 3
+              not_an_integer: The length must be a whole number, like 4
         steps/conviction/compensation_payment_date_form:
           attributes:
             compensation_payment_date:

--- a/spec/forms/steps/conviction/conviction_length_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Steps::Conviction::ConvictionLengthForm do
     conviction_length: conviction_length
   } }
   let(:disclosure_check) { instance_double(DisclosureCheck, conviction_length_type: 'months') }
-  let(:conviction_length) { 3 }
+  let(:conviction_length) { '3' }
 
   subject { described_class.new(arguments) }
 


### PR DESCRIPTION
Change conviction_length attribute from Integer to string as it was bypassing only_integer validation.
i.e before the user entered `1.5` it was casting the user string to an integer `1` and would bypass validation. 
