### PR TITLE
Add youth `Prevention and reparation orders` category

### DIFF
--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -19,10 +19,11 @@ class ConvictionType < ValueObject
 
   VALUES = [
     YOUTH_PARENT_TYPES = [
-      COMMUNITY_ORDER     = new(:community_order),
-      CUSTODIAL_SENTENCE  = new(:custodial_sentence),
-      DISCHARGE           = new(:discharge),
-      FINANCIAL           = new(:financial),
+      COMMUNITY_ORDER                 = new(:community_order),
+      CUSTODIAL_SENTENCE              = new(:custodial_sentence),
+      DISCHARGE                       = new(:discharge),
+      FINANCIAL                       = new(:financial),
+      PREVENTION_AND_REPARATION_ORDER = new(:prevention_and_reparation_order),
     ].freeze,
 
     ADULT_PARENT_TYPES = [

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -8,6 +8,7 @@ en:
       custodial_sentence: Custodial sentence or hospital order
       discharge: Discharge
       financial: Financial penalty
+      prevention_and_reparation_order: Prevention and reparation orders
       # adults
       adult_community_order: Community order
       adult_discharge: Discharge
@@ -191,6 +192,7 @@ en:
           custodial_sentence: For example, a detention and training order (DTO) or a hospital order given under the Mental Health Act
           discharge: For example, a conditional discharge order or bind over
           financial: For example, paying a fine or compensation
+          prevention_and_reparation_order: (placeholder hint text)
           # adults
           adult_community_order: For example, a curfew or unpaid work. You might have been asked to wear a tag as part of your order
           adult_discharge: For example, a conditional discharge order or bind over

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -8,6 +8,7 @@ en:
       custodial_sentence: Custodial sentence or hospital order
       discharge: Discharge
       financial: Financial penalty
+      prevention_and_reparation_order: Prevention and reparation orders
       # adults
       adult_community_order: Community order
       adult_discharge: Discharge

--- a/spec/services/conviction_length_choices_spec.rb
+++ b/spec/services/conviction_length_choices_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ConvictionLengthChoices do
       ConvictionType.values.size - described_class::SUBTYPES_HIDE_NO_LENGTH_CHOICE.size
     }
 
-    it { expect(total).to eq(62) }
+    it { expect(total).to eq(63) }
   end
 
   describe '.choices' do

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ConvictionType do
         custodial_sentence
         discharge
         financial
+        prevention_and_reparation_order
       ))
     end
   end
@@ -116,6 +117,15 @@ RSpec.describe ConvictionType do
       end
     end
 
+    context 'Prevention and reparation orders' do
+      let(:conviction_type) { :prevention_and_reparation_order }
+
+      it 'returns subtypes of this conviction type' do
+        expect(values).to eq(%w(
+        ))
+      end
+    end
+
     context 'Adult Community order' do
       let(:conviction_type) { :adult_community_order }
 
@@ -160,7 +170,7 @@ RSpec.describe ConvictionType do
       end
     end
 
-    context 'Prevention and reparation orders' do
+    context 'Adult prevention and reparation orders' do
       let(:conviction_type) { :adult_prevention_and_reparation_order }
 
       it 'returns subtypes of this conviction type' do


### PR DESCRIPTION
For now this is empty until we start moving or adding convictions into this category.

Note: pending hint text copy. Will be added when we know it.