### PR TITLE
Rename `unpaid work`

### DIFF
--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -56,7 +56,7 @@ class ConvictionType < ValueObject
     RESTRAINING_ORDER                  = new(:restraining_order,                parent: COMMUNITY_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     SEXUAL_HARM_PREVENTION_ORDER       = new(:sexual_harm_prevention_order,     parent: COMMUNITY_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     SUPERVISION_ORDER                  = new(:supervision_order,                parent: COMMUNITY_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
-    UNPAID_WORK                        = new(:unpaid_work,                      parent: COMMUNITY_ORDER, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
+    YOUTH_REHABILITATION_ORDER         = new(:youth_rehabilitation_order,       parent: COMMUNITY_ORDER, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
 
     DETENTION_TRAINING_ORDER           = new(:detention_training_order,         parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::DetentionCalculator),
     DETENTION                          = new(:detention,                        parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::DetentionCalculator),

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -29,7 +29,7 @@ en:
       restraining_order: Restraining order
       sexual_harm_prevention_order: Sexual harm prevention order (sexual offence prevention order)
       supervision_order: Supervision order
-      unpaid_work: Unpaid work
+      youth_rehabilitation_order: Youth rehabilitation order
       # custodial_sentence
       detention_training_order: Detention and training order (DTO)
       detention: Detention
@@ -195,7 +195,7 @@ en:
           restraining_order: You were ordered not to do something, such as approach or contact a certain person
           sexual_harm_prevention_order: A court ruled that you pose a risk of causing sexual harm
           supervision_order: You were ordered to be supervised by a youth offending team after loitering, soliciting or 'breaching a civil injunction'
-          unpaid_work: You were ordered to do community work without being paid
+          youth_rehabilitation_order: This may have included one or more requirements, such as electronic monitoring, education, attendance centres, activity or programme requirements
           # custodial_sentence
           detention_training_order: "The first half of your sentence was spent in custody and the second half was spent in the community, supervised by the Youth Offending Team"
           detention: "You were sentenced to custody in a young offender institution or secure training centre"

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -23,13 +23,13 @@ en:
       service_detention: Service detention
       service_community_order: Service community order
       overseas_community_order: Overseas community order
-    # community_order
+      # community_order
       referral_order: Referral order
       reparation_order: Reparation order
       restraining_order: Restraining order
       sexual_harm_prevention_order: Sexual harm prevention order (sexual offence prevention order)
       supervision_order: Supervision order
-      unpaid_work: Unpaid work
+      youth_rehabilitation_order: Youth rehabilitation order
       # custodial_sentence
       detention_training_order: Detention and training order (DTO)
       detention: Detention

--- a/features/youth/conviction_youth_rehabilitation_order.feature
+++ b/features/youth/conviction_youth_rehabilitation_order.feature
@@ -22,7 +22,7 @@ Feature: Conviction
     | Restraining order                                              | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
     | Sexual harm prevention order (sexual offence prevention order) | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
     | Supervision order                                              | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
-    | Unpaid work                                                    | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
+    | Youth rehabilitation order                                     | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
 
 
   Scenario: Community or youth rehabilitation order - Reparation order

--- a/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Steps::Conviction::ConvictionLengthTypeForm do
 
   let(:disclosure_check) { instance_double(DisclosureCheck, conviction_type: conviction_type, conviction_subtype: conviction_subtype, conviction_length_type: nil) }
   let(:conviction_type) { ConvictionType::COMMUNITY_ORDER.to_s }
-  let(:conviction_subtype) { ConvictionType::UNPAID_WORK.to_s }
+  let(:conviction_subtype) { ConvictionType::YOUTH_REHABILITATION_ORDER.to_s }
   let(:conviction_length_type) { 'weeks' }
 
   subject { described_class.new(arguments) }
@@ -17,10 +17,10 @@ RSpec.describe Steps::Conviction::ConvictionLengthTypeForm do
   # the spec `spec/services/conviction_length_choices_spec.rb`
   #
   describe '#choices' do
-    context 'for a community order conviction (`unpaid_work`)' do
+    context 'for a `Youth rehabilitation order`' do
       it 'includes `no_length` in the choices' do
         expect(ConvictionLengthChoices).to receive(:choices).with(
-          conviction_subtype: ConvictionType::UNPAID_WORK
+          conviction_subtype: ConvictionType::YOUTH_REHABILITATION_ORDER
         ).and_call_original
 
         expect(subject.choices).to eq(%w(

--- a/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Steps::Conviction::ConvictionSubtypeForm do
   # in the value-object spec `spec/value_objects/conviction_type_spec.rb`
   describe '#choices' do
     it 'returns the relevant choices (children of the conviction type)' do
-      expect(subject.choices).to include('referral_order', 'sexual_harm_prevention_order', 'unpaid_work')
+      expect(subject.choices).to include('referral_order', 'sexual_harm_prevention_order', 'youth_rehabilitation_order')
     end
   end
 

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ConvictionType do
           restraining_order
           sexual_harm_prevention_order
           supervision_order
-          unpaid_work
+          youth_rehabilitation_order
         ))
       end
     end
@@ -289,8 +289,8 @@ RSpec.describe ConvictionType do
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
-    context 'UNPAID_WORK' do
-      let(:subtype) { 'unpaid_work' }
+    context 'YOUTH_REHABILITATION_ORDER' do
+      let(:subtype) { 'youth_rehabilitation_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
       it { expect(conviction_type.compensation?).to eq(false) }


### PR DESCRIPTION
This is now named `youth rehabilitation order` but follows same rules and calculation as `unpaid work` and remains in same category.