### PR TITLE
Add callout in results page

### DIFF
--- a/app/presenters/conviction_result_presenter.rb
+++ b/app/presenters/conviction_result_presenter.rb
@@ -1,6 +1,15 @@
 class ConvictionResultPresenter < ResultsPresenter
+  include ValueObjectMethods
+
   def to_partial_path
     'results/conviction'
+  end
+
+  def custodial_sentence?
+    [
+      ConvictionType::CUSTODIAL_SENTENCE,
+      ConvictionType::ADULT_CUSTODIAL_SENTENCE,
+    ].include?(conviction_type)
   end
 
   private

--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -30,6 +30,10 @@ class ResultsPresenter
     result_service.expiry_date
   end
 
+  def check_kind
+    disclosure_check.kind
+  end
+
   private
 
   def result_service

--- a/app/views/steps/check/results/_caution.en.html.erb
+++ b/app/views/steps/check/results/_caution.en.html.erb
@@ -1,13 +1,7 @@
-<% track_transaction name: 'Caution check completed', category: 'Completed checks', dimensions: { spent: ga_spent?(expiry_date) } %>
+<% track_transaction name: 'Caution check completed', category: 'Completed checks',
+                     dimensions: { spent: ga_spent?(result.expiry_date) } %>
 
-<div class="govuk-panel govuk-panel--confirmation">
-  <h1 class="govuk-panel__title">
-    <%= title_string(expiry_date, 'caution') %>
-  </h1>
-  <div class="govuk-panel__body">
-    <%= statement_string(expiry_date, 'caution') %>
-  </div>
-</div>
+<%= render partial: 'steps/check/results/shared/panel', locals: { result: result } %>
 
 <h2 class="govuk-heading-m govuk-!-margin-top-5">How this date has been worked out</h2>
 

--- a/app/views/steps/check/results/_conviction.en.html.erb
+++ b/app/views/steps/check/results/_conviction.en.html.erb
@@ -1,13 +1,14 @@
-<% track_transaction name: 'Conviction check completed', category: 'Completed checks', dimensions: { spent: ga_spent?(expiry_date) } %>
+<% track_transaction name: 'Conviction check completed', category: 'Completed checks',
+                     dimensions: { spent: ga_spent?(result.expiry_date) } %>
 
-<div class="govuk-panel govuk-panel--confirmation">
-  <h1 class="govuk-panel__title">
-    <%= title_string(expiry_date, 'conviction') %>
-  </h1>
-  <div class="govuk-panel__body">
-    <%= statement_string(expiry_date, 'conviction') %>
+<%= render partial: 'steps/check/results/shared/panel', locals: { result: result } %>
+
+<% if result.custodial_sentence? %>
+  <div class="govuk-inset-text">
+    This result is correct if you followed all the conditions you were given when you were released from custody. If you
+    broke the rules of your conditions or licence period, your conviction may not be spent.
   </div>
-</div>
+<% end %>
 
 <h2 class="govuk-heading-m govuk-!-margin-top-5">How this date has been worked out</h2>
 

--- a/app/views/steps/check/results/shared/_panel.html.erb
+++ b/app/views/steps/check/results/shared/_panel.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-panel govuk-panel--confirmation">
+  <h1 class="govuk-panel__title">
+    <%= title_string(result.expiry_date, result.check_kind) %>
+  </h1>
+  <div class="govuk-panel__body">
+    <%= statement_string(result.expiry_date, result.check_kind) %>
+  </div>
+</div>

--- a/app/views/steps/check/results/show.en.html.erb
+++ b/app/views/steps/check/results/show.en.html.erb
@@ -4,7 +4,7 @@
   <main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <%= render partial: @presenter, locals: { expiry_date: @presenter.expiry_date } %>
+        <%= render partial: @presenter, locals: { result: @presenter } %>
 
         <dl class="govuk-summary-list">
           <%= render @presenter.summary %>

--- a/features/youth/conviction_custodial_sentence.feature
+++ b/features/youth/conviction_custodial_sentence.feature
@@ -18,6 +18,8 @@ Feature: Conviction
 
     Then I click the "Continue" button
     And I should be on "/steps/check/results"
+    # Following step just as a smoke test. No need to add it to all the scenarios.
+    And I should see "This result is correct if you followed all the conditions"
 
   @happy_path
   Scenario: Custodial sentence or hospital order - Detention

--- a/features/youth/conviction_financial.feature
+++ b/features/youth/conviction_financial.feature
@@ -8,6 +8,8 @@ Feature: Conviction
     Then I should see "When were you given the order?"
     When I enter a valid date
     Then I should be on "/steps/check/results"
+    # Following step just as a smoke test. No need to add it to all the scenarios.
+    And I should not see "This result is correct if you followed all the conditions"
 
   @happy_path
   Scenario: Conviction Financial penalty - Compensation paid in full

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe CautionResultPresenter do
     it { expect(subject.to_partial_path).to eq('results/caution') }
   end
 
+  describe '#check_kind' do
+    it { expect(subject.check_kind).to eq('caution') }
+  end
+
   describe '#summary' do
     let(:summary) { subject.summary }
 

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -7,6 +7,29 @@ RSpec.describe ConvictionResultPresenter do
     it { expect(subject.to_partial_path).to eq('results/conviction') }
   end
 
+  describe '#check_kind' do
+    it { expect(subject.check_kind).to eq('conviction') }
+  end
+
+  describe '#custodial_sentence?' do
+    let(:disclosure_check) { instance_double(DisclosureCheck, conviction_type: conviction_type) }
+
+    context 'for a youth `CUSTODIAL_SENTENCE` conviction type' do
+      let(:conviction_type) { ConvictionType::CUSTODIAL_SENTENCE.to_s }
+      it { expect(subject.custodial_sentence?).to eq(true) }
+    end
+
+    context 'for an adult `ADULT_CUSTODIAL_SENTENCE` conviction type' do
+      let(:conviction_type) { ConvictionType::ADULT_CUSTODIAL_SENTENCE.to_s }
+      it { expect(subject.custodial_sentence?).to eq(true) }
+    end
+
+    context 'for a `DISCHARGE` conviction type' do
+      let(:conviction_type) { ConvictionType::DISCHARGE.to_s }
+      it { expect(subject.custodial_sentence?).to eq(false) }
+    end
+  end
+
   describe '#summary' do
     let(:summary) { subject.summary }
 


### PR DESCRIPTION
Only for custodial sentences (youth and adults).

A bit of refactor to make this more DRY and to prepare for the possibility of having to add more bits of information depending on the caution or conviction type, etc.

<img width="764" alt="Screen Shot 2019-08-12 at 11 51 33" src="https://user-images.githubusercontent.com/687910/62860720-03e92380-bcf9-11e9-9ceb-bdfcd9f79504.png">
