### PR TITLE
Add type number and pattern to input text

### DIFF
--- a/app/views/steps/conviction/conviction_length/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length/edit.html.erb
@@ -19,7 +19,7 @@
         <%= step_form @form_object do |f| %>
           <%= f.text_field :conviction_length,
                            i18n_attribute: @form_object.conviction_length_type,
-                           input_options: { class: 'govuk-input--width-3' },
+                           input_options: { class: 'govuk-input--width-3', type: :number, pattern: '[0-9]*' },
                            label_options: { page_heading: false, size: 's' } %>
 
           <%= f.continue_button %>


### PR DESCRIPTION
So mobile devices automatically show the number pad, and to also do an early validation at browser level.

This is already added automatically to the date elements so no need to do the same there.