### PR TITLE
update length_in_months method

### DIFF
--- a/app/services/base_calculator.rb
+++ b/app/services/base_calculator.rb
@@ -19,10 +19,7 @@ class BaseCalculator
     @conviction_end_date ||= disclosure_check.known_date.advance(conviction_length)
   end
 
-  # TODO: this needs more testing as it's a bit of a work around.
   def length_in_months(start_date, end_date)
-    (start_date.beginning_of_month...end_date.beginning_of_month).select do |date|
-      date.day == 1
-    end.size
+    (end_date.year - start_date.year) * 12 + end_date.month - start_date.month - (end_date.day >= start_date.day ? 0 : 1)
   end
 end

--- a/spec/services/base_calculator_spec.rb
+++ b/spec/services/base_calculator_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe BaseCalculator do
+  subject { described_class.new(disclosure_check) }
+
+
+   let(:disclosure_check) { build(:disclosure_check,
+                                 known_date: known_date) }
+
+  let(:known_date) { Date.new(2018, 10, 31) }
+
+  before(:each) do
+    described_class.send(:public, *described_class.private_instance_methods)
+  end
+
+
+  it 'length_in_months' do
+    expect(subject.length_in_months(Date.new(2017, 8, 12), Date.new(2017, 8, 12))).to eq 0
+    expect(subject.length_in_months(Date.new(1993, 8, 8), Date.new(1993, 8, 8))).to eq 0
+    expect(subject.length_in_months(Date.new(2001, 12, 4), Date.new(2002, 3, 12))).to eq 3
+    expect(subject.length_in_months(Date.new(2001, 12, 4), Date.new(2002, 2, 12))).to eq 2
+    expect(subject.length_in_months(Date.new(2019, 1, 1), Date.new(2019, 1, 1))).to eq 0
+    expect(subject.length_in_months(Date.new(2004, 2, 29), Date.new(2004, 3, 23))).to eq 0
+    expect(subject.length_in_months(Date.new(2004, 2, 29), Date.new(2004, 5, 28))).to eq 2
+    expect(subject.length_in_months(Date.new(2004, 2, 29), Date.new(2004, 6, 13))).to eq 3
+    expect(subject.length_in_months(Date.new(2019, 7, 13), Date.new(2019, 9, 11))).to eq 1
+
+    # Overlapping february (28 days) still counts Feb as a full month
+    expect(subject.length_in_months(Date.new(2017, 1, 1), Date.new(2017, 3, 31))).to eq 2
+    expect(subject.length_in_months(Date.new(2017, 2, 10), Date.new(2017, 3, 9))).to eq 0
+
+    # Overlapping february (28 days) still counts Feb as a full month
+    expect(subject.length_in_months(Date.new(2019, 2, 28), Date.new(2020, 2, 29))).to eq 12
+
+    # Should be 11 full months as 2020 is a leap year
+    expect(subject.length_in_months(Date.new(2020, 2, 29), Date.new(2021, 2, 28))).to eq 11
+
+    # Leap year
+    expect(subject.length_in_months(Date.new(2016, 2, 1), Date.new(2016, 2, 29))).to eq 0
+    expect(subject.length_in_months(Date.new(2016, 2, 1), Date.new(2016, 3, 1))).to eq 1
+
+    # Non leap year
+    expect(subject.length_in_months(Date.new(2017, 2, 1), Date.new(2017, 2, 28))).to eq 0
+    expect(subject.length_in_months(Date.new(2017, 2, 1), Date.new(2017, 3, 1))).to eq 1
+  end
+end

--- a/spec/services/calculators/conditional_caution_calculator_spec.rb
+++ b/spec/services/calculators/conditional_caution_calculator_spec.rb
@@ -20,12 +20,62 @@ RSpec.describe Calculators::ConditionalCautionCalculator do
 
     context 'Difference between conditional end date and caution date greater than 3 months' do
       let(:conditional_end_date) { Date.new(2019, 5, 30) }
-      let(:result) { Date.new(2019, 4, 30)}
+      let(:result) { Date.new(2019, 4, 30) }
 
       it 'returns caution date plus 3 months' do
         expect(subject.expiry_date.to_s).to eq(result.to_s)
       end
     end
 
+    context 'Difference between conditional end date and caution date is 2 months x days' do
+      let(:known_date) { Date.new(2001, 12, 4) }
+      let(:conditional_end_date) { Date.new(2002, 3, 3) }
+
+      it 'returns conditional end date' do
+        expect(subject.expiry_date.to_s).to eq(conditional_end_date.to_s)
+      end
+    end
+
+    context 'Leap year' do
+      context 'Difference between conditional end date and caution date less than 3 months' do
+        let(:known_date) { Date.new(2004, 2, 29) }
+        let(:conditional_end_date) { Date.new(2004, 5, 28) }
+
+        it 'returns conditional end date' do
+          expect(subject.expiry_date.to_s).to eq(conditional_end_date.to_s)
+        end
+      end
+
+      context 'Difference between conditional end date and caution date greater than 3 months' do
+        let(:known_date) { Date.new(2004, 2, 29) }
+        let(:conditional_end_date) { Date.new(2004, 6, 13) }
+        let(:result) { Date.new(2004, 5, 29) }
+
+        it 'returns caution date plus 3 months' do
+          expect(subject.expiry_date.to_s).to eq(result.to_s)
+        end
+      end
+    end
+
+    context 'Future date' do
+      let(:known_date) { Date.new(2019, 7, 13) }
+
+      context 'Difference between conditional end date and caution date less than 3 months' do
+          let(:conditional_end_date) { Date.new(2019, 9, 11) }
+        let(:result) { Date.new(2004, 5, 29) }
+        it 'returns conditional end date' do
+          expect(subject.expiry_date.to_s).to eq(conditional_end_date.to_s)
+        end
+      end
+
+      context 'Difference between conditional end date and caution date greater than 3 months' do
+        let(:conditional_end_date) { Date.new(2019, 11, 11) }
+        let(:result) { Date.new(2019, 10, 13) }
+
+        it 'returns caution date plus 3 months' do
+          expect(subject.expiry_date.to_s).to eq(result.to_s)
+        end
+      end
+    end
   end
 end

--- a/spec/services/calculators/detention_calculator_spec.rb
+++ b/spec/services/calculators/detention_calculator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Calculators::DetentionCalculator do
       let(:result) { false }
       context 'conviction length in weeks' do
         let(:conviction_length_type) { 'weeks' }
-        let(:conviction_length) { 212 }
+        let(:conviction_length) { 218 }
         it { expect(subject.expiry_date).to eq(result) }
       end
 
@@ -56,8 +56,8 @@ RSpec.describe Calculators::DetentionCalculator do
     context 'Spent duration for conviction length of 7 to 30 months' do
       context 'conviction length in weeks' do
         let(:conviction_length_type) { 'weeks' }
-        let(:conviction_length) { 29 }
-        it { expect(subject.expiry_date.to_s).to eq('2019-05-11') }
+        let(:conviction_length) { 31 }
+        it { expect(subject.expiry_date.to_s).to eq('2019-05-25') }
       end
 
       context 'conviction length in months' do

--- a/spec/services/calculators/prison_sentence_calculator_spec.rb
+++ b/spec/services/calculators/prison_sentence_calculator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Calculators::PrisonSentenceCalculator do
       let(:result) { false }
       context 'conviction length in weeks' do
         let(:conviction_length_type) { 'weeks' }
-        let(:conviction_length) { 212 }
+        let(:conviction_length) { 214 }
         it { expect(subject.expiry_date).to eq(result) }
       end
 
@@ -56,8 +56,8 @@ RSpec.describe Calculators::PrisonSentenceCalculator do
     context 'Spent duration for conviction length of 7 to 30 months' do
       context 'conviction length in weeks' do
         let(:conviction_length_type) { 'weeks' }
-        let(:conviction_length) { 29 }
-        it { expect(subject.expiry_date.to_s).to eq('2021-05-11') }
+        let(:conviction_length) { 31 }
+        it { expect(subject.expiry_date.to_s).to eq('2021-05-25') }
       end
 
       context 'conviction length in months' do


### PR DESCRIPTION
Fix how the difference between two dates is calculated in months.

For example:

before 29/4/2004 to 28/5/2005 would return 3 months,  now the method will return 2 months

before 1/1/2019 to 31/1/2019 would return 1 month, now  the method will return 0 months
