### PR TITLE
Add sentence length validation

### DIFF
--- a/app/forms/steps/conviction/conviction_length_form.rb
+++ b/app/forms/steps/conviction/conviction_length_form.rb
@@ -5,6 +5,7 @@ module Steps
       delegate :conviction_length_type, to: :disclosure_check
 
       validates_numericality_of :conviction_length, greater_than: 0, only_integer: true
+      validates :conviction_length, sentence_length: true, if: :disclosure_check
 
       private
 

--- a/app/services/calculators/sentence_calculator.rb
+++ b/app/services/calculators/sentence_calculator.rb
@@ -15,6 +15,17 @@ module Calculators
       REHABILITATION_3 = { months: 42 }.freeze
     end
 
+    # If conviction length is 6 months or less: start date + length + 18 months
+    # If conviction length is over 6 months and less than or equal to 24 months: start date + length + 2 years
+    # If conviction length is over 24 months, it is considered invalid
+    #
+    class DetentionTraining < SentenceCalculator
+      UPPER_LIMIT = 24
+
+      REHABILITATION_1 = { months: 18 }.freeze
+      REHABILITATION_2 = { months: 24 }.freeze
+    end
+
     # If conviction length is 6 months or less: start date + length + 2 years
     # If conviction length is over 6 months and less than or equal to 30 months: start date + length + 4 years
     # If conviction length is over 30 months and less than or equal to 4 years: start date + length + 7 years

--- a/app/validators/sentence_length_validator.rb
+++ b/app/validators/sentence_length_validator.rb
@@ -1,0 +1,32 @@
+class SentenceLengthValidator < ActiveModel::EachValidator
+  DEFAULT_OPTIONS ||= {
+    only: [
+      ConvictionType::DETENTION_TRAINING_ORDER,
+      ConvictionType::ADULT_SUSPENDED_PRISON_SENTENCE,
+    ],
+  }.freeze
+
+  def initialize(options)
+    super
+    @_conviction_subtypes = options[:only] || DEFAULT_OPTIONS[:only]
+  end
+
+  def validate_each(record, attribute, value)
+    return unless value.present? &&
+                  @_conviction_subtypes.include?(record.conviction_subtype)
+
+    record.errors.add(attribute, :invalid_sentence) unless valid_calculation?(record, value)
+  end
+
+  private
+
+  def valid_calculation?(record, length)
+    calculator = record.conviction_subtype.calculator_class
+    disclosure_check = record.disclosure_check
+
+    # We set the new length value, otherwise a stale, previous length prevail
+    disclosure_check.conviction_length = length
+
+    calculator.new(disclosure_check).valid?
+  end
+end

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -56,7 +56,7 @@ class ConvictionType < ValueObject
     SUPERVISION_ORDER                  = new(:supervision_order,                parent: COMMUNITY_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     YOUTH_REHABILITATION_ORDER         = new(:youth_rehabilitation_order,       parent: COMMUNITY_ORDER, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
 
-    DETENTION_TRAINING_ORDER           = new(:detention_training_order,         parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::Detention),
+    DETENTION_TRAINING_ORDER           = new(:detention_training_order,         parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::DetentionTraining),
     DETENTION                          = new(:detention,                        parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::Detention),
     HOSPITAL_ORDER                     = new(:hospital_order,                   parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -43,6 +43,7 @@ en:
               greater_than: The length must be 1 or more
               not_a_number: The length must be a number, like 3
               not_an_integer: The length must be a whole number, like 4
+              invalid_sentence: The length of the sentence is invalid for this conviction
         steps/conviction/compensation_payment_date_form:
           attributes:
             compensation_payment_date:

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -34,5 +34,14 @@ FactoryBot.define do
       caution_type { CautionType::YOUTH_CONDITIONAL_CAUTION }
       conditional_end_date { Date.new(2018, 12, 25) }
     end
+
+    trait :suspended_prison_sentence do
+      under_age { GenericYesNo::NO }
+      kind { CheckKind::CONVICTION }
+      conviction_type { ConvictionType::ADULT_CUSTODIAL_SENTENCE }
+      conviction_subtype { ConvictionType::ADULT_SUSPENDED_PRISON_SENTENCE }
+      conviction_length_type { ConvictionLengthType::MONTHS }
+      conviction_length { 15 }
+    end
   end
 end

--- a/spec/forms/steps/conviction/conviction_length_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_form_spec.rb
@@ -5,7 +5,14 @@ RSpec.describe Steps::Conviction::ConvictionLengthForm do
     disclosure_check: disclosure_check,
     conviction_length: conviction_length
   } }
-  let(:disclosure_check) { instance_double(DisclosureCheck, conviction_length_type: 'months') }
+
+  let(:disclosure_check) {
+    instance_double(
+      DisclosureCheck,
+      conviction_length_type: 'months',
+      conviction_subtype: ConvictionType::YOUTH_REHABILITATION_ORDER.to_s
+  ) }
+
   let(:conviction_length) { '3' }
 
   subject { described_class.new(arguments) }
@@ -19,7 +26,6 @@ RSpec.describe Steps::Conviction::ConvictionLengthForm do
 
   describe '#save' do
     context 'when form is valid' do
-
       it 'saves the record' do
         expect(disclosure_check).to receive(:update).with(
           conviction_length: conviction_length
@@ -31,15 +37,97 @@ RSpec.describe Steps::Conviction::ConvictionLengthForm do
 
     context 'Validation' do
       context 'when conviction_length is invalid' do
-        let(:conviction_length) { 'sss' }
+        context 'length is not a number' do
+          let(:conviction_length) { 'sss' }
 
-        it 'returns false' do
-          expect(subject.save).to be(false)
+          it 'returns false' do
+            expect(subject.save).to be(false)
+          end
+
+          it 'has a validation error on the field' do
+            expect(subject).to_not be_valid
+            expect(subject.errors.details[:conviction_length][0][:error]).to eq(:not_a_number)
+          end
         end
 
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors.include?(:conviction_length)).to eq(true)
+        context 'length is not greater than 0' do
+          let(:conviction_length) { 0 }
+
+          it 'returns false' do
+            expect(subject.save).to be(false)
+          end
+
+          it 'has a validation error on the field' do
+            expect(subject).to_not be_valid
+            expect(subject.errors.details[:conviction_length][0][:error]).to eq(:greater_than)
+          end
+        end
+
+        context 'length is not an whole number' do
+          let(:conviction_length) { 1.5 }
+
+          it 'returns false' do
+            expect(subject.save).to be(false)
+          end
+
+          it 'has a validation error on the field' do
+            expect(subject).to_not be_valid
+            expect(subject.errors.details[:conviction_length][0][:error]).to eq(:not_an_integer)
+          end
+        end
+
+        context 'length upper limit validation for a Suspended prison sentence' do
+          let(:disclosure_check) {
+            build(:disclosure_check, :suspended_prison_sentence, conviction_length_type: 'months')
+          }
+
+          context 'upper limit is valid' do
+            let(:conviction_length) { 24 }
+
+            it 'returns true' do
+              expect(subject.save).to be(true)
+            end
+          end
+
+          context 'upper limit is not valid' do
+            let(:conviction_length) { 25 }
+
+            it 'returns false' do
+              expect(subject.save).to be(false)
+            end
+
+            it 'has a validation error on the field' do
+              expect(subject).to_not be_valid
+              expect(subject.errors.details[:conviction_length][0][:error]).to eq(:invalid_sentence)
+            end
+          end
+        end
+
+        context 'length upper limit validation for a DTO sentence' do
+          let(:disclosure_check) {
+            build(:disclosure_check, :dto_conviction, conviction_length_type: 'months')
+          }
+
+          context 'upper limit is valid' do
+            let(:conviction_length) { 24 }
+
+            it 'returns true' do
+              expect(subject.save).to be(true)
+            end
+          end
+
+          context 'upper limit is not valid' do
+            let(:conviction_length) { 25 }
+
+            it 'returns false' do
+              expect(subject.save).to be(false)
+            end
+
+            it 'has a validation error on the field' do
+              expect(subject).to_not be_valid
+              expect(subject.errors.details[:conviction_length][0][:error]).to eq(:invalid_sentence)
+            end
+          end
         end
       end
     end

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe ConvictionType do
 
       it { expect(conviction_type.skip_length?).to eq(false) }
       it { expect(conviction_type.compensation?).to eq(false) }
-      it { expect(conviction_type.calculator_class).to eq(Calculators::SentenceCalculator::Detention) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::SentenceCalculator::DetentionTraining) }
     end
 
     context 'DETENTION' do


### PR DESCRIPTION
This affected DTO and suspended prison convictions.
These can only go up to a maximum sentence length (24 months currently) and, if over, the user will receive a validation error (same kind of validation as when they enter a non numeric value, etc.)