### PR TITLE
Calculate conviction length in months

### DIFF
--- a/app/services/base_calculator.rb
+++ b/app/services/base_calculator.rb
@@ -1,6 +1,9 @@
 class BaseCalculator
   class InvalidCalculation < RuntimeError; end
 
+  WEEKS_IN_A_MONTH = 52 / 12.0
+  MONTHS_IN_A_YEAR = 12
+
   attr_reader :disclosure_check
 
   def initialize(disclosure_check)
@@ -21,7 +24,18 @@ class BaseCalculator
     @conviction_end_date ||= disclosure_check.known_date.advance(conviction_length)
   end
 
-  def length_in_months(start_date, end_date)
+  def distance_in_months(start_date, end_date)
     (end_date.year - start_date.year) * 12 + end_date.month - start_date.month - (end_date.day >= start_date.day ? 0 : 1)
+  end
+
+  def sentence_length_in_months(length, conviction_length_type)
+    case conviction_length_type
+    when 'weeks'
+      length / WEEKS_IN_A_MONTH
+    when 'years'
+      length * MONTHS_IN_A_YEAR
+    when 'months'
+      length
+    end
   end
 end

--- a/app/services/calculators/conditional_caution_calculator.rb
+++ b/app/services/calculators/conditional_caution_calculator.rb
@@ -6,7 +6,7 @@ module Calculators
     CAUTION_EXTRA_SPENT_DURATION = { months: 3 }.freeze
 
     def expiry_date
-      return conditional_end_date if length_in_months(caution_date, conditional_end_date) < 3
+      return conditional_end_date if distance_in_months(caution_date, conditional_end_date) < 3
 
       caution_date.advance(CAUTION_EXTRA_SPENT_DURATION)
     end

--- a/app/services/calculators/sentence_calculator.rb
+++ b/app/services/calculators/sentence_calculator.rb
@@ -81,7 +81,7 @@ module Calculators
     end
 
     def conviction_length_in_months
-      @_conviction_length_in_months ||= length_in_months(conviction_start_date, conviction_end_date)
+      @_conviction_length_in_months ||= sentence_length_in_months(disclosure_check.conviction_length, disclosure_check.conviction_length_type)
     end
 
     def conviction_end_date

--- a/spec/services/base_calculator_spec.rb
+++ b/spec/services/base_calculator_spec.rb
@@ -14,33 +14,89 @@ RSpec.describe BaseCalculator do
   end
 
 
-  it 'length_in_months' do
-    expect(subject.length_in_months(Date.new(2017, 8, 12), Date.new(2017, 8, 12))).to eq 0
-    expect(subject.length_in_months(Date.new(1993, 8, 8), Date.new(1993, 8, 8))).to eq 0
-    expect(subject.length_in_months(Date.new(2001, 12, 4), Date.new(2002, 3, 12))).to eq 3
-    expect(subject.length_in_months(Date.new(2001, 12, 4), Date.new(2002, 2, 12))).to eq 2
-    expect(subject.length_in_months(Date.new(2019, 1, 1), Date.new(2019, 1, 1))).to eq 0
-    expect(subject.length_in_months(Date.new(2004, 2, 29), Date.new(2004, 3, 23))).to eq 0
-    expect(subject.length_in_months(Date.new(2004, 2, 29), Date.new(2004, 5, 28))).to eq 2
-    expect(subject.length_in_months(Date.new(2004, 2, 29), Date.new(2004, 6, 13))).to eq 3
-    expect(subject.length_in_months(Date.new(2019, 7, 13), Date.new(2019, 9, 11))).to eq 1
+  it 'distance_in_months' do
+    expect(subject.distance_in_months(Date.new(2017, 8, 12), Date.new(2017, 8, 12))).to eq 0
+    expect(subject.distance_in_months(Date.new(1993, 8, 8), Date.new(1993, 8, 8))).to eq 0
+    expect(subject.distance_in_months(Date.new(2001, 12, 4), Date.new(2002, 3, 12))).to eq 3
+    expect(subject.distance_in_months(Date.new(2001, 12, 4), Date.new(2002, 2, 12))).to eq 2
+    expect(subject.distance_in_months(Date.new(2019, 1, 1), Date.new(2019, 1, 1))).to eq 0
+    expect(subject.distance_in_months(Date.new(2004, 2, 29), Date.new(2004, 3, 23))).to eq 0
+    expect(subject.distance_in_months(Date.new(2004, 2, 29), Date.new(2004, 5, 28))).to eq 2
+    expect(subject.distance_in_months(Date.new(2004, 2, 29), Date.new(2004, 6, 13))).to eq 3
+    expect(subject.distance_in_months(Date.new(2019, 7, 13), Date.new(2019, 9, 11))).to eq 1
 
     # Overlapping february (28 days) still counts Feb as a full month
-    expect(subject.length_in_months(Date.new(2017, 1, 1), Date.new(2017, 3, 31))).to eq 2
-    expect(subject.length_in_months(Date.new(2017, 2, 10), Date.new(2017, 3, 9))).to eq 0
+    expect(subject.distance_in_months(Date.new(2017, 1, 1), Date.new(2017, 3, 31))).to eq 2
+    expect(subject.distance_in_months(Date.new(2017, 2, 10), Date.new(2017, 3, 9))).to eq 0
 
     # Overlapping february (28 days) still counts Feb as a full month
-    expect(subject.length_in_months(Date.new(2019, 2, 28), Date.new(2020, 2, 29))).to eq 12
+    expect(subject.distance_in_months(Date.new(2019, 2, 28), Date.new(2020, 2, 29))).to eq 12
 
     # Should be 11 full months as 2020 is a leap year
-    expect(subject.length_in_months(Date.new(2020, 2, 29), Date.new(2021, 2, 28))).to eq 11
+    expect(subject.distance_in_months(Date.new(2020, 2, 29), Date.new(2021, 2, 28))).to eq 11
 
     # Leap year
-    expect(subject.length_in_months(Date.new(2016, 2, 1), Date.new(2016, 2, 29))).to eq 0
-    expect(subject.length_in_months(Date.new(2016, 2, 1), Date.new(2016, 3, 1))).to eq 1
+    expect(subject.distance_in_months(Date.new(2016, 2, 1), Date.new(2016, 2, 29))).to eq 0
+    expect(subject.distance_in_months(Date.new(2016, 2, 1), Date.new(2016, 3, 1))).to eq 1
 
     # Non leap year
-    expect(subject.length_in_months(Date.new(2017, 2, 1), Date.new(2017, 2, 28))).to eq 0
-    expect(subject.length_in_months(Date.new(2017, 2, 1), Date.new(2017, 3, 1))).to eq 1
+    expect(subject.distance_in_months(Date.new(2017, 2, 1), Date.new(2017, 2, 28))).to eq 0
+    expect(subject.distance_in_months(Date.new(2017, 2, 1), Date.new(2017, 3, 1))).to eq 1
+  end
+
+
+  context '#sentence_distance_in_months' do
+    it 'in weeks' do
+      expect(subject.sentence_length_in_months(4, 'weeks')).to be < 1
+      expect(subject.sentence_length_in_months(5, 'weeks')).to be >= 1
+      expect(subject.sentence_length_in_months(8, 'weeks')).to be < 2
+      expect(subject.sentence_length_in_months(9, 'weeks')).to be >= 2
+
+      # 3 months
+      expect(subject.sentence_length_in_months(12, 'weeks')).to be < 3
+      expect(subject.sentence_length_in_months(13, 'weeks')).to be >= 3
+
+      # 6 months
+      expect(subject.sentence_length_in_months(25, 'weeks')).to be < 6
+      expect(subject.sentence_length_in_months(26, 'weeks')).to be >= 6
+
+
+      # 25 months
+      expect(subject.sentence_length_in_months(108, 'weeks')).to be < 25
+      expect(subject.sentence_length_in_months(109, 'weeks')).to be >= 25
+
+      # 30 months
+      expect(subject.sentence_length_in_months(129, 'weeks')).to be < 30
+      expect(subject.sentence_length_in_months(130, 'weeks')).to be >= 30
+    end
+
+
+    it 'in months' do
+       # 3 months
+      expect(subject.sentence_length_in_months(3, 'months')).to eq 3
+
+      # 6 months
+      expect(subject.sentence_length_in_months(6, 'months')).to eq 6
+
+      # 25 months
+     expect(subject.sentence_length_in_months(25, 'months')).to eq 25
+
+      # 30 months
+      expect(subject.sentence_length_in_months(30, 'months')).to eq 30
+    end
+
+    it 'in years' do
+       # 1 year = 12 months
+      expect(subject.sentence_length_in_months(1, 'years')).to eq 12
+
+      # 2 years = 24 months
+      expect(subject.sentence_length_in_months(2, 'years')).to eq 24
+
+      # 10 years = 120 months
+      expect(subject.sentence_length_in_months(10, 'years')).to eq 120
+
+      # 25 years = 300 months
+      expect(subject.sentence_length_in_months(25, 'years')).to eq 300
+    end
   end
 end


### PR DESCRIPTION
As conviction length is given in several different format (weeks, months, years) we need to convert the different types of lengths into months i.e

- weeks to months = length * (52/12)
- years to month = length * 12
- months just return the length