### PR TITLE
update start page copy

### DIFF
--- a/app/views/about/terms_and_conditions.en.html.erb
+++ b/app/views/about/terms_and_conditions.en.html.erb
@@ -30,7 +30,7 @@
         <p class="govuk-body">Some organisations will still need to know about cautions and convictions that have expired, depending on the application that’s being made.</p>
 
 
-        <h2 class="govuk-heading-m" id="using-guidance">Using the guidance the service gives you</h2>
+        <h2 class="govuk-heading-m" id="using-guidance">How to use the information this service gives you</h2>
 
         <p class="govuk-body">As the service does not ask for specific details about users’ criminal records, it can only give general guidance on when cautions or convictions become spent in England and Wales.</p>
 

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -23,7 +23,7 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>which type of caution or conviction you were given</li>
           <li>the date your caution or conviction began</li>
-          <li><%= link_to 'how to use the information this service gives you', about_terms_and_conditions_path(anchor: "using-guidance"), class: 'govuk-link ga-pageLink', data: {ga_category: 'home', ga_label: 'how to use the information this service gives you'} %></li>
+          <li><%= link_to 'how to use the information this service gives you', about_terms_and_conditions_path(anchor: "using-guidance"), class: 'govuk-link ga-pageLink', data: {ga_category: 'home', ga_label: 'terms and conditions'} %></li>
         </ul>
 
         <p class="govuk-body">

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -23,7 +23,7 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>which type of caution or conviction you were given</li>
           <li>the date your caution or conviction began</li>
-          <li><%= link_to 'how to use the guidance this service gives you', about_terms_and_conditions_path(anchor: "using-guidance"), class: 'govuk-link ga-pageLink', data: {ga_category: 'home', ga_label: 'how to use the guidance this service gives you'} %></li>
+          <li><%= link_to 'how to use the information this service gives you', about_terms_and_conditions_path(anchor: "using-guidance"), class: 'govuk-link ga-pageLink', data: {ga_category: 'home', ga_label: 'how to use the information this service gives you'} %></li>
         </ul>
 
         <p class="govuk-body">


### PR DESCRIPTION
Need to change "how to use the guidance this service gives you" bullet to:

"how to use the information this service gives you"

(and same change to header in T&Cs).


Start page change
<img width="721" alt="Screen Shot 2019-08-19 at 14 33 00" src="https://user-images.githubusercontent.com/22822829/63270771-b6d4f680-c290-11e9-8559-a5c7b8b1c49e.png">


T&C change
<img width="717" alt="Screen Shot 2019-08-19 at 14 32 47" src="https://user-images.githubusercontent.com/22822829/63270776-b76d8d00-c290-11e9-990c-d5cacc0ea70b.png">
