### PR TITLE
Amend known date hint text

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -166,9 +166,9 @@ en:
         caution: Select your age when you got the caution, not when you committed the offence
         conviction: Select your age when you got convicted, not when you committed the offence
       steps_caution_conditional_end_date_form:
-        conditional_end_date: Enter the date you agreed the conditions would end. This might have included paying a fine or compensation. For example, 23 9 2018
+        conditional_end_date_html: "Enter the date you agreed the conditions would end. This might have included paying a fine or compensation. <span class='nowrap'>For example, 23 9 2018</span>"
       steps_conviction_known_date_form:
-        known_date: Enter the date you were convicted by a court. For example, 23 9 2018
+        known_date_html: "Enter the date your sentence or order started. This might be the day you were convicted in court or the first day you were held on remand. <span class='nowrap'>For example, 23 9 2018</span>"
       steps_conviction_compensation_payment_date_form:
         compensation_payment_date: For example, 23 9 2018
       radio_buttons:


### PR DESCRIPTION
And make sure the 'example' do not wrap if it doesn't fully fit in one line.

<img width="696" alt="Screen Shot 2019-08-19 at 16 56 01" src="https://user-images.githubusercontent.com/687910/63280216-518a0100-c2a2-11e9-98d5-70f0f1c04f79.png">
