### PR TITLE
Improve prevention/reparation value-object naming

### DIFF
--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -19,21 +19,21 @@ class ConvictionType < ValueObject
 
   VALUES = [
     YOUTH_PARENT_TYPES = [
-      COMMUNITY_ORDER                 = new(:community_order),
-      CUSTODIAL_SENTENCE              = new(:custodial_sentence),
-      DISCHARGE                       = new(:discharge),
-      FINANCIAL                       = new(:financial),
-      PREVENTION_AND_REPARATION_ORDER = new(:prevention_and_reparation_order),
+      COMMUNITY_ORDER       = new(:community_order),
+      CUSTODIAL_SENTENCE    = new(:custodial_sentence),
+      DISCHARGE             = new(:discharge),
+      FINANCIAL             = new(:financial),
+      PREVENTION_REPARATION = new(:prevention_reparation),
     ].freeze,
 
     ADULT_PARENT_TYPES = [
-      ADULT_COMMUNITY_ORDER                  = new(:adult_community_order),
-      ADULT_DISCHARGE                        = new(:adult_discharge),
-      ADULT_FINANCIAL                        = new(:adult_financial),
-      ADULT_MILITARY                         = new(:adult_military),
-      ADULT_MOTORING                         = new(:adult_motoring),
-      ADULT_PREVENTION_AND_REPARATION_ORDER  = new(:adult_prevention_and_reparation_order),
-      ADULT_CUSTODIAL_SENTENCE               = new(:adult_custodial_sentence),
+      ADULT_COMMUNITY_ORDER       = new(:adult_community_order),
+      ADULT_DISCHARGE             = new(:adult_discharge),
+      ADULT_FINANCIAL             = new(:adult_financial),
+      ADULT_MILITARY              = new(:adult_military),
+      ADULT_MOTORING              = new(:adult_motoring),
+      ADULT_PREVENTION_REPARATION = new(:adult_prevention_reparation),
+      ADULT_CUSTODIAL_SENTENCE    = new(:adult_custodial_sentence),
     ].freeze,
 
     # Quick way of enabling/disabling convictions. These will not show in the interface to users.
@@ -67,9 +67,9 @@ class ConvictionType < ValueObject
     FINE                               = new(:fine,                             parent: FINANCIAL, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
     COMPENSATION_TO_A_VICTIM           = new(:compensation_to_a_victim,         parent: FINANCIAL, compensation: true, calculator_class: Calculators::CompensationCalculator),
 
-    REPARATION_ORDER                   = new(:reparation_order,                 parent: PREVENTION_AND_REPARATION_ORDER, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
-    RESTRAINING_ORDER                  = new(:restraining_order,                parent: PREVENTION_AND_REPARATION_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
-    SEXUAL_HARM_PREVENTION_ORDER       = new(:sexual_harm_prevention_order,     parent: PREVENTION_AND_REPARATION_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    REPARATION_ORDER                   = new(:reparation_order,                 parent: PREVENTION_REPARATION, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
+    RESTRAINING_ORDER                  = new(:restraining_order,                parent: PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    SEXUAL_HARM_PREVENTION_ORDER       = new(:sexual_harm_prevention_order,     parent: PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 
     ######################
     # Adults convictions #
@@ -103,11 +103,11 @@ class ConvictionType < ValueObject
     ADULT_ENDORSEMENT                   = new(:adult_endorsement,                  parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::StartPlusFiveYears),
     ADULT_PENALTY_POINTS                = new(:adult_penalty_points,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::StartPlusThreeYears),
 
-    ADULT_ATTENDANCE_CENTRE_ORDER       = new(:adult_attendance_centre_order,      parent: ADULT_PREVENTION_AND_REPARATION_ORDER, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
-    ADULT_REPARATION_ORDER              = new(:adult_reparation_order,             parent: ADULT_PREVENTION_AND_REPARATION_ORDER, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
-    ADULT_RESTRAINING_ORDER             = new(:adult_restraining_order,            parent: ADULT_PREVENTION_AND_REPARATION_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
-    ADULT_SEXUAL_HARM_PREVENTION_ORDER  = new(:adult_sexual_harm_prevention_order, parent: ADULT_PREVENTION_AND_REPARATION_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
-    ADULT_SUPERVISION_ORDER             = new(:adult_supervision_order,            parent: ADULT_PREVENTION_AND_REPARATION_ORDER, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    ADULT_ATTENDANCE_CENTRE_ORDER       = new(:adult_attendance_centre_order,      parent: ADULT_PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
+    ADULT_REPARATION_ORDER              = new(:adult_reparation_order,             parent: ADULT_PREVENTION_REPARATION, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
+    ADULT_RESTRAINING_ORDER             = new(:adult_restraining_order,            parent: ADULT_PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    ADULT_SEXUAL_HARM_PREVENTION_ORDER  = new(:adult_sexual_harm_prevention_order, parent: ADULT_PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    ADULT_SUPERVISION_ORDER             = new(:adult_supervision_order,            parent: ADULT_PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 
     ADULT_HOSPITAL_ORDER                = new(:adult_hospital_order,               parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_SUSPENDED_PRISON_SENTENCE     = new(:adult_suspended_prison_sentence,    parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::SuspendedPrison),

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -8,14 +8,14 @@ en:
       custodial_sentence: Custody or hospital order
       discharge: Discharge
       financial: Financial penalty
-      prevention_and_reparation_order: Prevention or reparation order
+      prevention_reparation: Prevention or reparation order
       # adults
       adult_community_order: Community order
       adult_discharge: Discharge
       adult_financial: Financial penalty
       adult_military: Military convictions
       adult_motoring: Motoring
-      adult_prevention_and_reparation_order: Prevention or reparation order
+      adult_prevention_reparation: Prevention or reparation order
       adult_custodial_sentence: Prison sentence or hospital order
 
     CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
@@ -39,11 +39,11 @@ en:
       # financial
       fine: A fine
       compensation_to_a_victim: Compensation to a victim
-      # prevention_and_reparation_order
+      # prevention_reparation
       reparation_order: Reparation order
       restraining_order: Restraining order
       sexual_harm_prevention_order: Sexual harm prevention order (sexual offence prevention order)
-      # adult_prevention_and_reparation_order
+      # adult_prevention_reparation
       adult_alcohol_abstinence_treatment: Alcohol abstinence or treatment
       adult_behavioural_change_prog: Behavioural change programme
       adult_curfew: Curfew
@@ -55,7 +55,7 @@ en:
       adult_rehab_activity_requirement: Rehabilitation activity requirement (RAR)
       adult_residence_requirement: Residence requirement
       adult_unpaid_work: Unpaid work
-      # adult_prevention_and_reparation_order
+      # adult_prevention_reparation
       adult_attendance_centre_order: Attendance centre order
       adult_reparation_order: Reparation order
       adult_restraining_order: Restraining order
@@ -187,14 +187,14 @@ en:
           custodial_sentence: For example, a detention and training order (DTO) or a hospital order given under the Mental Health Act
           discharge: For example, a conditional discharge order or bind over
           financial: For example, paying a fine or compensation
-          prevention_and_reparation_order: For example, a restraining order or sexual harm prevention order
+          prevention_reparation: For example, a restraining order or sexual harm prevention order
           # adults
           adult_community_order: For example, a curfew or unpaid work. You might have been asked to wear a tag as part of your order
           adult_discharge: For example, a conditional discharge order or bind over
           adult_financial: For example, paying a fine or compensation
           adult_military: (placeholder hint text)
           adult_motoring: (placeholder hint text)
-          adult_prevention_and_reparation_order: For example, a restraining order or sexual harm prevention order
+          adult_prevention_reparation: For example, a restraining order or sexual harm prevention order
           adult_custodial_sentence: (placeholder hint text)
         conviction_subtype:
           # armed_forces
@@ -217,11 +217,11 @@ en:
           # financial
           fine: ""
           compensation_to_a_victim: ""
-          # prevention_and_reparation_order
+          # prevention_reparation
           reparation_order: You were given help understanding the effect your crime had on someone
           restraining_order: You were ordered not to do something, such as approach or contact a certain person
           sexual_harm_prevention_order: A court ruled that you pose a risk of causing sexual harm
-          #adult_prevention_and_reparation_order
+          # adult_prevention_reparation
           adult_alcohol_abstinence_treatment: You were ordered not to drink, or were given help to stop you drinking
           adult_behavioural_change_prog: You were helped to change any dangerous or unwanted behaviour
           adult_curfew: You were ordered to stay indoors at certain times
@@ -233,7 +233,7 @@ en:
           adult_rehab_activity_requirement: You were given activities to help with your rehabilitation
           adult_residence_requirement: You were ordered to live somewhere for a certain length of time
           adult_unpaid_work: You were ordered to do community work without being paid
-          # adult_prevention_and_reparation_order
+          # adult_prevention_reparation
           adult_attendance_centre_order: You were ordered to go to an attendance centre for a set number of hours
           adult_reparation_order: You were given help understanding the effect your crime had on someone
           adult_restraining_order: You were ordered not to do something, such as approach or contact a certain person

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -8,14 +8,14 @@ en:
       custodial_sentence: Custody or hospital order
       discharge: Discharge
       financial: Financial penalty
-      prevention_and_reparation_order: Prevention or reparation order
+      prevention_reparation: Prevention or reparation order
       # adults
       adult_community_order: Community order
       adult_discharge: Discharge
       adult_financial: Financial penalty
       adult_military: Military convictions
       adult_motoring: Motoring
-      adult_prevention_and_reparation_order: Prevention or reparation order
+      adult_prevention_reparation: Prevention or reparation order
       adult_custodial_sentence: Prison sentence or hospital order
 
     CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
@@ -39,11 +39,11 @@ en:
       # financial
       fine: A fine
       compensation_to_a_victim: Compensation to a victim
-      # prevention_and_reparation_order
+      # prevention_reparation
       reparation_order: Reparation order
       restraining_order: Restraining order
       sexual_harm_prevention_order: Sexual harm prevention order (sexual offence prevention order)
-      # adult_prevention_and_reparation_order
+      # adult_prevention_reparation
       adult_alcohol_abstinence_treatment: Alcohol abstinence or treatment
       adult_behavioural_change_prog: Behavioural change programme
       adult_curfew: Curfew
@@ -55,7 +55,7 @@ en:
       adult_rehab_activity_requirement: Rehabilitation activity requirement (RAR)
       adult_residence_requirement: Residence requirement
       adult_unpaid_work: Unpaid work
-      # adult_prevention_and_reparation_order
+      # adult_prevention_reparation
       adult_attendance_centre_order: Attendance centre order
       adult_reparation_order: Reparation order
       adult_restraining_order: Restraining order

--- a/features/adults/prevention_reparation.feature
+++ b/features/adults/prevention_reparation.feature
@@ -1,6 +1,6 @@
 Feature: Conviction
-  Scenario Outline: Prevention and reparation orders
-  Given I am completing a basic under 18 "Prevention or reparation order" conviction
+  Scenario Outline: Prevention or reparation order
+  Given I am completing a basic 18 or over "Prevention or reparation order" conviction
   Then I should see "What type of order were you given?"
 
   When I choose "<subtype>"
@@ -18,12 +18,14 @@ Feature: Conviction
 
   Examples:
     | subtype                                                        | known_date_header                              | length_type_header                                                           | length_header                                     | result               |
+    | Attendance centre order                                        | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
     | Restraining order                                              | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
     | Sexual harm prevention order (sexual offence prevention order) | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
+    | Supervision order                                              | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
 
 
-  Scenario: Prevention and reparation orders - Reparation order
-  Given I am completing a basic under 18 "Prevention or reparation order" conviction
+  Scenario: Prevention or reparation order - Reparation order
+  Given I am completing a basic 18 or over "Prevention or reparation order" conviction
   Then I should see "What type of order were you given?"
 
   When I choose "Reparation order"

--- a/features/youth/conviction_prevention_reparation.feature
+++ b/features/youth/conviction_prevention_reparation.feature
@@ -1,6 +1,6 @@
 Feature: Conviction
-  Scenario Outline: Prevention and reparation order
-  Given I am completing a basic 18 or over "Prevention or reparation order" conviction
+  Scenario Outline: Prevention or reparation order
+  Given I am completing a basic under 18 "Prevention or reparation order" conviction
   Then I should see "What type of order were you given?"
 
   When I choose "<subtype>"
@@ -18,14 +18,12 @@ Feature: Conviction
 
   Examples:
     | subtype                                                        | known_date_header                              | length_type_header                                                           | length_header                                     | result               |
-    | Attendance centre order                                        | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
     | Restraining order                                              | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
     | Sexual harm prevention order (sexual offence prevention order) | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
-    | Supervision order                                              | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
 
 
-  Scenario: Prevention and reparation order - Reparation order
-  Given I am completing a basic 18 or over "Prevention or reparation order" conviction
+  Scenario: Prevention or reparation order - Reparation order
+  Given I am completing a basic under 18 "Prevention or reparation order" conviction
   Then I should see "What type of order were you given?"
 
   When I choose "Reparation order"

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ConvictionType do
         custodial_sentence
         discharge
         financial
-        prevention_and_reparation_order
+        prevention_reparation
       ))
     end
   end
@@ -25,7 +25,7 @@ RSpec.describe ConvictionType do
         adult_financial
         adult_military
         adult_motoring
-        adult_prevention_and_reparation_order
+        adult_prevention_reparation
         adult_custodial_sentence
       ))
     end
@@ -105,7 +105,7 @@ RSpec.describe ConvictionType do
     end
 
     context 'Prevention and reparation orders' do
-      let(:conviction_type) { :prevention_and_reparation_order }
+      let(:conviction_type) { :prevention_reparation }
 
       it 'returns subtypes of this conviction type' do
         expect(values).to eq(%w(
@@ -173,7 +173,7 @@ RSpec.describe ConvictionType do
     end
 
     context 'Adult prevention and reparation orders' do
-      let(:conviction_type) { :adult_prevention_and_reparation_order }
+      let(:conviction_type) { :adult_prevention_reparation }
 
       it 'returns subtypes of this conviction type' do
         expect(values).to eq(%w(
@@ -538,7 +538,7 @@ RSpec.describe ConvictionType do
       it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::StartPlusThreeYears) }
     end
 
-    # ADULT_PREVENTION_AND_REPARATION_ORDER
+    # ADULT_PREVENTION_REPARATION
     #
     context 'ADULT_ATTENDANCE_CENTRE_ORDER' do
       let(:subtype) { 'adult_attendance_centre_order' }


### PR DESCRIPTION
Just an internal renaming, for consistency and to avoid confusion, not affecting user interface.

The previous name apart from being too long, gave the impression it was an order in itself, instead of a "group" of orders, or category (the `and` was changed to `or` in the user interface as per PR #197).