### PR TITLE
Bump nokogiri from 1.10.3 to 1.10.4 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
     multi_test (0.1.2)
     multipart-post (2.1.1)
     nio4r (2.4.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     parser (2.6.3.0)


### PR DESCRIPTION
Bump nokogiri from 1.10.3 to [1.10.4](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md)