### PR TITLE
Update adult copy

### DIFF
--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -110,8 +110,8 @@ class ConvictionType < ValueObject
     ADULT_SUPERVISION_ORDER             = new(:adult_supervision_order,            parent: ADULT_PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 
     ADULT_HOSPITAL_ORDER                = new(:adult_hospital_order,               parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
-    ADULT_SUSPENDED_PRISON_SENTENCE     = new(:adult_suspended_prison_sentence,    parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::SuspendedPrison),
     ADULT_PRISON_SENTENCE               = new(:adult_prison_sentence,              parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::Prison),
+    ADULT_SUSPENDED_PRISON_SENTENCE     = new(:adult_suspended_prison_sentence,    parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::SuspendedPrison),
   ].flatten.freeze
 
   # :nocov:

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -28,12 +28,12 @@ class ConvictionType < ValueObject
 
     ADULT_PARENT_TYPES = [
       ADULT_COMMUNITY_ORDER       = new(:adult_community_order),
+      ADULT_CUSTODIAL_SENTENCE    = new(:adult_custodial_sentence),
       ADULT_DISCHARGE             = new(:adult_discharge),
       ADULT_FINANCIAL             = new(:adult_financial),
       ADULT_MILITARY              = new(:adult_military),
       ADULT_MOTORING              = new(:adult_motoring),
       ADULT_PREVENTION_REPARATION = new(:adult_prevention_reparation),
-      ADULT_CUSTODIAL_SENTENCE    = new(:adult_custodial_sentence),
     ].freeze,
 
     # Quick way of enabling/disabling convictions. These will not show in the interface to users.

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -13,10 +13,10 @@ en:
       adult_community_order: Community order
       adult_discharge: Discharge
       adult_financial: Financial penalty
-      adult_military: Military convictions
+      adult_military: Military
       adult_motoring: Motoring
       adult_prevention_reparation: Prevention or reparation order
-      adult_custodial_sentence: Prison sentence or hospital order
+      adult_custodial_sentence: Custody or hospital order
 
     CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
       # armed_forces
@@ -70,7 +70,7 @@ en:
       adult_service_community_order: Service community order
       adult_service_detention: Service detention
       # adult_motoring
-      adult_disqualification: Disqualification
+      adult_disqualification: Disqualification (driving ban)
       adult_endorsement: Endorsement
       adult_penalty_points: Penalty points
       # adult_discharge
@@ -192,10 +192,10 @@ en:
           adult_community_order: For example, a curfew or unpaid work. You might have been asked to wear a tag as part of your order
           adult_discharge: For example, a conditional discharge order or bind over
           adult_financial: For example, paying a fine or compensation
-          adult_military: (placeholder hint text)
-          adult_motoring: (placeholder hint text)
+          adult_military: For example, a dismissal or service detention
+          adult_motoring: For example, penalty points or a driving ban
           adult_prevention_reparation: For example, a restraining order or sexual harm prevention order
-          adult_custodial_sentence: (placeholder hint text)
+          adult_custodial_sentence: For example, a prison sentence or a hospital order given under the Mental Health Act
         conviction_subtype:
           # armed_forces
           dismissal: ""
@@ -243,12 +243,12 @@ en:
           adult_fine: ""
           adult_compensation_to_a_victim: ""
           # adult_military
-          adult_dismissal: (placeholder hint text)
-          adult_overseas_community_order: (placeholder hint text)
-          adult_service_community_order: (placeholder hint text)
-          adult_service_detention: (placeholder hint text)
+          adult_dismissal: ""
+          adult_overseas_community_order: ""
+          adult_service_community_order: ""
+          adult_service_detention: ""
           # adult_motoring
-          adult_disqualification: (placeholder hint text)
+          adult_disqualification: You were banned from driving for a certain period of time.
           adult_endorsement: (placeholder hint text)
           adult_penalty_points: (placeholder hint text)
           # adult_discharge
@@ -256,9 +256,9 @@ en:
           adult_absolute_discharge: You were found guilty of a crime but did not get sentenced
           adult_conditional_discharge: You were not sentenced, as long as you didn't commit
           # adult_custodial_sentence
-          adult_hospital_order: ""
-          adult_suspended_prison_sentence: ""
-          adult_prison_sentence: ""
+          adult_hospital_order: You were given a hospital order instead of a prison sentence because of mental health concerns
+          adult_suspended_prison_sentence: You were given a prison sentence that was suspended unless you breached the terms
+          adult_prison_sentence: You were sent to prison (also known as being taken into custody)
 
     label:
       steps_check_kind_form:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -248,7 +248,7 @@ en:
           adult_service_community_order: ""
           adult_service_detention: ""
           # adult_motoring
-          adult_disqualification: You were banned from driving for a certain period of time.
+          adult_disqualification: You were banned from driving for a certain period of time
           adult_endorsement: (placeholder hint text)
           adult_penalty_points: (placeholder hint text)
           # adult_discharge

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -11,12 +11,13 @@ en:
       prevention_reparation: Prevention or reparation order
       # adults
       adult_community_order: Community order
+      adult_custodial_sentence: Custody or hospital order
       adult_discharge: Discharge
       adult_financial: Financial penalty
-      adult_military: Military convictions
+      adult_military: Military
       adult_motoring: Motoring
       adult_prevention_reparation: Prevention or reparation order
-      adult_custodial_sentence: Prison sentence or hospital order
+
 
     CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
       # armed_forces
@@ -70,7 +71,7 @@ en:
       adult_service_community_order: Service community order
       adult_service_detention: Service detention
       # adult_motoring
-      adult_disqualification: Disqualification
+      adult_disqualification: Disqualification (driving ban)
       adult_endorsement: Endorsement
       adult_penalty_points: Penalty points
       # adult_discharge
@@ -81,6 +82,8 @@ en:
       adult_hospital_order: Hospital order
       adult_suspended_prison_sentence: Suspended prison sentence
       adult_prison_sentence: Prison sentence
+
+
 
   steps:
     check:

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -18,7 +18,6 @@ en:
       adult_motoring: Motoring
       adult_prevention_reparation: Prevention or reparation order
 
-
     CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
       # armed_forces
       dismissal: Dismissal
@@ -83,14 +82,11 @@ en:
       adult_suspended_prison_sentence: Suspended prison sentence
       adult_prison_sentence: Prison sentence
 
-
-
   steps:
     check:
       results:
         show:
           page_title: When your caution or conviction is spent
-
 
   results/caution:
     title:

--- a/features/adults/conviction_custodial_sentence.feature
+++ b/features/adults/conviction_custodial_sentence.feature
@@ -1,6 +1,6 @@
 Feature: Conviction
   Scenario Outline: Prison sentence or hospital order
-  When I am completing a basic 18 or over "Prison sentence or hospital order" conviction
+  When I am completing a basic 18 or over "Custody or hospital order" conviction
   Then I should see "What sentence were you given?"
 
   When I choose "<subtype>"

--- a/features/adults/conviction_military.feature
+++ b/features/adults/conviction_military.feature
@@ -2,7 +2,7 @@ Feature: Conviction
 
   @happy_path
   Scenario Outline: Adult military convictions with length
-    Given I am completing a basic 18 or over "Military convictions" conviction
+    Given I am completing a basic 18 or over "Military" conviction
     Then I should see "What was your military conviction?"
 
     When I choose "<subtype>"
@@ -25,7 +25,7 @@ Feature: Conviction
 
   @happy_path
   Scenario Outline: Adult military convictions without length
-    Given I am completing a basic 18 or over "Military convictions" conviction
+    Given I am completing a basic 18 or over "Military" conviction
     Then I should see "What was your military conviction?"
 
     When I choose "<subtype>"

--- a/features/adults/conviction_motoring.feature
+++ b/features/adults/conviction_motoring.feature
@@ -19,8 +19,8 @@ Feature: Conviction
     And I should be on "<result>"
 
     Examples:
-      | subtype          | known_date_header                         | length_type_header                                                      | length_header                                | result               |
-      | Disqualification | When were you given the disqualification? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | /steps/check/results |
+      | subtype                        | known_date_header                         | length_type_header                                                      | length_header                                | result               |
+      | Disqualification (driving ban) | When were you given the disqualification? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | /steps/check/results |
 
   @happy_path
   Scenario Outline: Motoring convictions without length

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe ConvictionType do
     it 'returns top level adult convictions' do
       expect(values).to eq(%w(
         adult_community_order
+        adult_custodial_sentence
         adult_discharge
         adult_financial
         adult_military
         adult_motoring
         adult_prevention_reparation
-        adult_custodial_sentence
       ))
     end
   end


### PR DESCRIPTION
You can find the pivotal ticket [here](https://www.pivotaltracker.com/n/projects/2311302/stories/167849617)

CONVICTION TYPES changes 
```
Military [can delete 'convictions']
For example, a dismissal or service detention

Custody or hospital order [will need to be moved to alpha order]
For example, a prison sentence or a hospital order given under the Mental Health Act

Motoring
For example, penalty points or a driving ban
```
![Screen Shot 2019-08-21 at 12 02 31](https://user-images.githubusercontent.com/22822829/63426800-9d0bee80-c40b-11e9-9874-69a39fd0cb72.png)

Adult military conviction sub type no hint text
![Screen Shot 2019-08-21 at 12 04 26](https://user-images.githubusercontent.com/22822829/63426918-db091280-c40b-11e9-85e2-690203afbe09.png)


Change the order of adult custodial sentence sub type to alpha and update hint text

```
Hospital order
You were given a hospital order instead of a prison sentence because of mental health concerns

Prison sentence
You were sent to prison (also known as being taken into custody)

Suspended prison sentence
You were given a prison sentence that was suspended unless you breached the terms
```
![Screen Shot 2019-08-21 at 12 08 12](https://user-images.githubusercontent.com/22822829/63427175-71d5cf00-c40c-11e9-9e5f-9846d2971bd1.png)

Update hint text  for adult motoring conviction
```
Disqualification (driving ban)
You were banned from driving for a certain period of time.

Penalty points with a court endorsement
You were given a number of penalty points, which were ‘endorsed’ by a court

[remove penalty points without endorsement for the time being]
```
* **please note: the merging of motoring conviction types has not been done in this PR.**

![Screen Shot 2019-08-21 at 12 12 01](https://user-images.githubusercontent.com/22822829/63427405-f4f72500-c40c-11e9-8ded-cb75c7a5d4fd.png)


