### PR TITLE
Add a few i18n sanity check tests

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -1,6 +1,12 @@
 ---
 en:
   dictionary:
+    CAUTION_TYPES: &CAUTION_TYPES
+      youth_simple_caution: Youth caution
+      youth_conditional_caution: Youth conditional caution
+      adult_simple_caution: Simple caution
+      adult_conditional_caution: Conditional caution
+
     CONVICTION_TYPES: &CONVICTION_TYPES
       # youth
       armed_forces: Armed forces
@@ -279,10 +285,7 @@ en:
         year: Year
       steps_caution_caution_type_form:
         caution_type:
-          adult_simple_caution: Simple caution
-          adult_conditional_caution: Conditional caution
-          youth_simple_caution: Youth caution
-          youth_conditional_caution: Youth conditional caution
+          <<: *CAUTION_TYPES
       steps_conviction_known_date_form:
         day: Day
         month: Month

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -1,6 +1,12 @@
 ---
 en:
   dictionary:
+    CAUTION_TYPES: &CAUTION_TYPES
+      youth_simple_caution: Youth caution
+      youth_conditional_caution: Youth conditional caution
+      adult_simple_caution: Simple caution
+      adult_conditional_caution: Conditional caution
+
     CONVICTION_TYPES: &CONVICTION_TYPES
       # youth
       armed_forces: Armed forces
@@ -116,10 +122,7 @@ en:
     caution_type:
       question: Type of caution
       answers:
-        adult_simple_caution: Simple caution
-        adult_conditional_caution: Conditional caution
-        youth_simple_caution: Youth caution
-        youth_conditional_caution: Youth conditional caution
+        <<: *CAUTION_TYPES
 
   results/conviction:
     title:

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -9,4 +9,34 @@ RSpec.describe 'I18n' do
     expect(missing_keys).to be_empty,
                             "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
   end
+
+  # Note: The following sanity checks will ensure we have the same keys and values in both places,
+  # so we don't inadvertently update just once place and not the other.
+  # It doesn't matter the order of the keys in the locales, what matters is the content.
+  #
+  context 'shared dictionaries sanity checks' do
+    it 'caution types in `helpers.yml` matches caution types in `results.yml`' do
+      expect(
+        i18n.tree('en.helpers.label.steps_caution_caution_type_form.caution_type').to_hash
+      ).to eq(
+        i18n.tree('en.results/caution.caution_type.answers').to_hash
+      )
+    end
+
+    it 'convictions types in `helpers.yml` matches convictions types in `results.yml`' do
+      expect(
+        i18n.tree('en.helpers.label.steps_conviction_conviction_type_form.conviction_type').to_hash
+      ).to eq(
+        i18n.tree('en.results/conviction.conviction_type.answers').to_hash
+      )
+    end
+
+    it 'convictions subtypes in `helpers.yml` matches convictions subtypes in `results.yml`' do
+      expect(
+        i18n.tree('en.helpers.label.steps_conviction_conviction_subtype_form.conviction_subtype').to_hash
+      ).to eq(
+        i18n.tree('en.results/conviction.conviction_subtype.answers').to_hash
+      )
+    end
+  end
 end


### PR DESCRIPTION
It was easy to change some copy in one place and miss another place.

With these simple tests we will have at least an early warning to ensure we don't forget to update the locales in all the right places.