### PR TITLE
Use govuk-frontend v3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN bundle exec rake assets:precompile
 # Copy fonts and images (without digest) along with the digested ones,
 # as there are some hardcoded references in the `govuk-frontend` files
 # that will not be able to use the rails digest mechanism.
-RUN cp node_modules/govuk-frontend/assets/fonts/* public/assets/govuk-frontend/assets/fonts
-RUN cp node_modules/govuk-frontend/assets/images/* public/assets/govuk-frontend/assets/images
+RUN cp node_modules/govuk-frontend/govuk/assets/fonts/*  public/assets/govuk-frontend/govuk/assets/fonts
+RUN cp node_modules/govuk-frontend/govuk/assets/images/* public/assets/govuk-frontend/govuk/assets/images
 
 ARG APP_BUILD_DATE
 ENV APP_BUILD_DATE ${APP_BUILD_DATE}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ The application will be run in "production" mode, so will be as accurate as poss
 An nginx reverse proxy will also be run to serve the static assets and to fallback to a static error page if the
 upstream server (rails with puma) does not respond.
 
+If you make local changes to the assets (images, javascript or stylesheets), you need to remove the docker volume, as 
+otherwise old versions of these assets may persist.  
+In order to do this, please run: `docker volume rm disclosure-checker_assets`
+
 Please note, in production environments this is done in a slightly different way as we don't use docker-compose in those
 environments (kubernetes cluster). But the general ideal is the same (nginx reverse proxy).
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,19 +12,16 @@
 //
 //= require jquery
 //= require rails-ujs
+//
 // GOV.UK Frontend
 // https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md
 //
-//= require govuk-frontend/all
+//= require govuk-frontend/govuk/all
 
 //= require moj
 //= require_tree ./modules
 
 $(document).ready(function() {
-
-  // Initialize JS in /modules\
+  // Initialize custom modules
   moj.init();
 });
-
-
-

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,8 +1,8 @@
 // GOV.UK Frontend
 // https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md
 //
-$govuk-assets-path: '/assets/govuk-frontend/assets/';
-@import 'govuk-frontend/all';
+$govuk-assets-path: '/assets/govuk-frontend/govuk/assets/';
+@import 'govuk-frontend/govuk/all';
 
 // Local CSS
 @import 'local/custom';

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -32,7 +32,12 @@
             on when cautions and convictions become spent</a>.
         </p>
 
-        <%= link_to 'Start now', edit_steps_check_kind_path, class: 'govuk-button govuk-button--start', role: 'button', draggable: false %>
+        <%= link_to edit_steps_check_kind_path, class: 'govuk-button govuk-button--start govuk-!-margin-top-2', data: { module: 'govuk-button' }, role: 'button', draggable: false do %>
+          Start now
+          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+          </svg>
+        <% end %>
       </div>
     </div>
   </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,16 +1,7 @@
 <% content_for?(:page_title) ? yield(:page_title) : fallback_title %>
 
 <% content_for(:head) do %>
-  <!--[if !IE 8]><!-->
-  <%= stylesheet_link_tag 'application', media: 'all', integrity: true, crossorigin: 'anonymous' %>
-  <!--<![endif]-->
-
-  <!--[if IE 8]>
-  <%= stylesheet_link_tag '/assets/govuk-frontend/all-ie8.css', media: 'all', integrity: true, crossorigin: 'anonymous' %>
-  <![endif]-->
-
   <%= render partial: 'layouts/analytics' if analytics_tracking_id.present? %>
-
 <% end %>
 
 <% content_for(:service_name) do %>
@@ -27,11 +18,6 @@
 
 <% content_for(:footer_links) do %>
   <% render partial: 'layouts/footer_links' %>
-<% end %>
-
-<% content_for(:body_end) do %>
-  <%= javascript_include_tag 'application', integrity: true, crossorigin: 'anonymous' %>
-  <script>window.GOVUKFrontend.initAll();</script>
 <% end %>
 
 <%= render file: 'layouts/govuk_template' %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -1,28 +1,36 @@
 <%= yield :top_of_page %>
 <!DOCTYPE html>
-<html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>" class="govuk-template ">
+<html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>" class="govuk-template app-html-class">
 
 <head>
   <meta charset="utf-8"/>
   <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="theme-color" content="#0b0c0c"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="blue"/>
 
   <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 
-  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_path '/assets/govuk-frontend/assets/images/favicon.ico' %>" type="image/x-icon"/>
-  <link rel="mask-icon" href="<%= asset_path '/assets/govuk-frontend/assets/images/govuk-mask-icon.svg' %>" color="#0b0c0c">
-  <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path '/assets/govuk-frontend/assets/images/govuk-apple-touch-icon-180x180.png' %>">
-  <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_path '/assets/govuk-frontend/assets/images/govuk-apple-touch-icon-167x167.png' %>">
-  <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path '/assets/govuk-frontend/assets/images/govuk-apple-touch-icon-152x152.png' %>">
-  <link rel="apple-touch-icon" href="<%= asset_path '/assets/govuk-frontend/assets/images/govuk-apple-touch-icon.png' %>">
+  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/favicon.ico' %>" type="image/x-icon"/>
+  <link rel="mask-icon" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-mask-icon.svg' %>" color="blue">
+  <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png' %>">
+  <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png' %>">
+  <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png' %>">
+  <link rel="apple-touch-icon" href="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png' %>">
+
+  <!--[if !IE 8]><!-->
+  <%= stylesheet_link_tag 'application', media: 'all', integrity: true, crossorigin: 'anonymous' %>
+  <!--<![endif]-->
+
+  <!--[if IE 8]>
+  <%= stylesheet_link_tag '/assets/govuk-frontend/govuk/all-ie8.css', media: 'all', integrity: true, crossorigin: 'anonymous' %>
+  <![endif]-->
+
+  <meta property="og:image" content="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-opengraph-image.png' %>">
 
   <%= yield :head %>
-
-  <meta property="og:image" content="<%= asset_path "/assets/govuk-frontend/assets/images/govuk-opengraph-image.png" %>">
 </head>
 
-<body class="govuk-template__body ">
+<body class="govuk-template__body app-body-class">
 <script>
   document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>
@@ -31,22 +39,22 @@
   <%= content_for?(:skip_link_message) ? yield(:skip_link_message) : 'Skip to main content' %>
 </a>
 
-<header class="govuk-header " role="banner" data-module="header">
+<header class="govuk-header" role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
-
     <div class="govuk-header__logo">
-      <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-          <span class="govuk-header__logotype">
-            <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
-              <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-              <image src="<%= asset_path '/assets/govuk-frontend/assets/images/govuk-logotype-crown.png' %>" class="govuk-header__logotype-crown-fallback-image"></image>
-            </svg>
-            <span class="govuk-header__logotype-text">
-              GOV.UK
-            </span>
+      <a href="https://www.gov.uk" class="govuk-header__link govuk-header__link--homepage">
+        <span class="govuk-header__logotype">
+          <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="30" width="36">
+            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+            <image src="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-logotype-crown.png' %>" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
           </span>
+        </span>
       </a>
     </div>
+
     <div class="govuk-header__content">
       <%= yield(:service_name) %>
     </div>
@@ -61,7 +69,7 @@
   <%= yield(:content) %>
 </div>
 
-<footer class="govuk-footer " role="contentinfo">
+<footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container ">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
@@ -71,17 +79,19 @@
           <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"/>
         </svg>
         <span class="govuk-footer__licence-description">
-            All content is available under the
-            <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-          </span>
+          All content is available under the
+          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
       </div>
       <div class="govuk-footer__meta-item">
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">©
-          Crown copyright</a>
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
       </div>
     </div>
   </div>
 </footer>
+
+<%= javascript_include_tag 'application', integrity: true, crossorigin: 'anonymous' %>
+<script>window.GOVUKFrontend.initAll();</script>
 
 <%= yield :body_end %>
 </body>

--- a/app/views/steps/caution/conditional_end_date/edit.html.erb
+++ b/app/views/steps/caution/conditional_end_date/edit.html.erb
@@ -12,7 +12,7 @@
         <%= step_form @form_object do |f| %>
           <%= f.gov_uk_date_field :conditional_end_date %>
 
-          <details class="govuk-details">
+          <details class="govuk-details" data-module="govuk-details">
             <summary class="govuk-details__summary">
               <span class="govuk-details__summary-text" data-ga-category="explanations" data-ga-label="conditions not ended">
                 <%= t ".conditions_not_ended_title" %>

--- a/features/adults/community_order.feature
+++ b/features/adults/community_order.feature
@@ -1,5 +1,5 @@
 Feature: Conviction
-  Scenario Outline: Community or youth rehabilitation order (YRO)
+  Scenario Outline: Adult community order
   Given I am completing a basic 18 or over "Community order" conviction
   Then I should see "What was your community order?"
 
@@ -23,7 +23,7 @@ Feature: Conviction
     | Curfew                                                         | When were you given the curfew?                | Was the length of the curfew given in weeks, months or years?                | What was the length of the curfew?                | /steps/check/results |
     | Drug rehabilitation, treatment or testing                      | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
     | Electronic monitoring requirement                              | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
-    | Exclusion requirement                                          | When were you given the exclusion requirement? | Was the length of the exclusion requirement given in weeks, months or years? | What was the length of the exclusion requirement? | /steps/check/results |
+    #| Exclusion requirement                                          | When were you given the exclusion requirement? | Was the length of the exclusion requirement given in weeks, months or years? | What was the length of the exclusion requirement? | /steps/check/results |
     | Mental health treatment                                        | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
     | Prohibition                                                    | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |
     | Rehabilitation activity requirement (RAR)                      | When were you given the order?                 | Was the length of the order given in weeks, months or years?                 | What was the length of the order?                 | /steps/check/results |

--- a/lib/govuk_components/error_helpers.rb
+++ b/lib/govuk_components/error_helpers.rb
@@ -14,7 +14,7 @@ module GovukComponents
         attrs = {
           class: 'govuk-error-summary',
           aria: { labelledby: 'error-summary-title' },
-          data: { module: 'error-summary' },
+          data: { module: 'govuk-error-summary' },
           role: 'alert',
           tabindex: '-1',
         }.freeze

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "^2.13.0"
+    "govuk-frontend": "^3.0.0"
   }
 }

--- a/spec/fixtures/files/error_summary.html
+++ b/spec/fixtures/files/error_summary.html
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" data-module="error-summary" role="alert" tabindex="-1">
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" data-module="govuk-error-summary" role="alert" tabindex="-1">
     <h2 id="error-summary-title" class="govuk-error-summary__title">
         There is an error
     </h2>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,7 @@
 # yarn lockfile v1
 
 
-govuk-frontend@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-2.13.0.tgz#0273f7c92070abd6450c73a006ebb3ddc793463a"
+govuk-frontend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.0.0.tgz#27e4751592c0587ec925c637dcd1a2582429afe4"
+  integrity sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A==


### PR DESCRIPTION
Individual commits for easier review.

Bump the version of the `govuk-frontend` modules to the latest one (**v3.0.0**)

There are some breaking changes (mainly in the paths), that we had to update, and also some markup changes or improvements, as per Changelog here:

https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0

Most of the changes (at least the breaking ones) are implemented as part of this PR but there are other markup refinements that will be incorporated as separate PRs, as well as we are aware the contrast in a link in the results page is not great and will be changed once we have a decision from the content designer.