### PR TITLE
Update and improve some markup

### DIFF
--- a/app/assets/javascripts/modules/ga-events.js
+++ b/app/assets/javascripts/modules/ga-events.js
@@ -4,60 +4,30 @@ moj.Modules.gaEvents = {
     radioFormClass: '.govuk-radios__item input[type="radio"]',
     dateFormClass: '.govuk-date-input input[type="number"]',
     linkClass: '.ga-pageLink',
-    clickActionClass: '.ga-clickAction',
     revealingLinkClass: '.govuk-details__summary span.govuk-details__summary-text',
-    submitFormClass: '.ga-submitForm',
-    submitButtons: 'button[type="submit"], input[type="submit"]',
 
     init: function () {
         var self = this;
 
         // don't bind anything if the GA object isn't defined
         if (typeof window.ga !== 'undefined') {
-            // Some pesky side effect of unbinding/triggering the submit event in some of
-            // the following functions, is the submit button value is lost from the params.
-            // We use this value to know when the `Save and come back later` submit button
-            // was used, instead of the normal `Continue` button.
-            // Non-javascript browsers have no issues, will always send the submit value.
-            if ($(self.submitButtons).length) {
-                self.addSubmitValueParamOnClick();
-            }
-
             if ($(self.radioFormClass).length) {
                 self.trackRadioForms();
             }
-
             if ($(self.dateFormClass).length) {
                 self.trackDateForms();
             }
-
             if ($(self.linkClass).length) {
                 self.trackLinks();
             }
             if ($(self.revealingLinkClass).length) {
                 self.trackRevealingLinks();
             }
-            if ($(self.clickActionClass).length) {
-                self.trackClickActions();
-            }
-            if ($(self.submitFormClass).length) {
-                self.trackSubmitForms();
-            }
             // External links, tracked as GA outbound events
             if ($("a[rel^=external]").length) {
                 self.trackExternalLinks();
             }
         }
-    },
-
-    addSubmitValueParamOnClick: function() {
-        $(this.submitButtons).on('click', function() {
-            if ($(this).attr('name')) {
-                $('<input>',
-                    {type: 'hidden', name: $(this).attr('name'), value: $(this).attr('value')}
-                ).appendTo($(this).closest('form'));
-            }
-        });
     },
 
     trackRadioForms: function () {
@@ -169,24 +139,6 @@ moj.Modules.gaEvents = {
         });
     },
 
-    trackClickActions: function() {
-        var self = this,
-            $elements = $(self.clickActionClass);
-
-        $elements.on('click', function() {
-            var $el = $(this),
-                eventData;
-
-            eventData = {
-                eventCategory: $el.data('ga-category'),
-                eventAction: $el.data('ga-action'),
-                eventLabel: $el.data('ga-label')
-            };
-
-            self.sendAnalyticsEvent(eventData, {});
-        });
-    },
-
     // This function will not send to GA the query string, as frequently
     // this may contain personal identification or secure tokens.
     trackExternalLinks: function() {
@@ -199,28 +151,6 @@ moj.Modules.gaEvents = {
             ga('send', 'event', 'outbound', 'click', event_url, {});
 
             e.preventDefault();
-        });
-    },
-
-    trackSubmitForms: function () {
-        var self = this,
-            $form = $(self.submitFormClass);
-
-        // submitting GA tracked forms is intercepted[1] until the GA event has
-        // been sent, by sending target to make a callback[2]
-        $form.on('submit', function (e) {
-            var eventData,
-                options;
-
-            e.preventDefault(); // [1]
-
-            eventData = self.getFormData($form);
-            options = {
-                actionType: 'form',
-                actionValue: $form // [2]
-            };
-
-            self.sendAnalyticsEvent(eventData, options);
         });
     },
 
@@ -278,20 +208,6 @@ moj.Modules.gaEvents = {
         });
 
         return eventDataArray;
-    },
-
-    getFormData: function ($form) {
-        var category = $form.data('ga-category'),
-            label = $form.data('ga-label'),
-            eventData;
-
-        eventData = {
-            eventCategory: category,
-            eventAction: 'submit_form',
-            eventLabel: label
-        };
-
-        return eventData;
     },
 
     sendAnalyticsEvent: function (eventData, opts) {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,7 +71,7 @@ module ApplicationHelper
 
     url = [Rails.configuration.x.surveys.feedback, query].join('?')
 
-    link_to text, url, class: 'govuk-link', rel: 'external', target: '_blank'
+    link_to text, url, class: 'govuk-link govuk-link--no-visited-state', rel: 'external', target: '_blank'
   end
 
   def link_button(text, href, attributes = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,6 +74,13 @@ module ApplicationHelper
     link_to text, url, class: 'govuk-link', rel: 'external', target: '_blank'
   end
 
+  def link_button(text, href, attributes = {})
+    link_to t("helpers.buttons.#{text}"), href, {
+      class: 'govuk-button',
+      data: { module: 'govuk-button' },
+    }.merge(attributes)
+  end
+
   # Use this to feature-flag code that should only run/show on test environments
   def dev_tools_enabled?
     Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')

--- a/app/views/errors/check_completed.html.erb
+++ b/app/views/errors/check_completed.html.erb
@@ -10,10 +10,7 @@
         <p class="govuk-body"><%=t '.lead_text' %></p>
         <p class="govuk-body"><%= link_to t('.results_page'), steps_check_results_path, class: 'govuk-link' %></p>
 
-        <div class="form-submit">
-          <%= link_to t('.start_again'), root_path, class: 'govuk-button' %>
-        </div>
-
+        <%= link_button :start_again, root_path %>
       </div>
     </div>
 

--- a/app/views/errors/invalid_session.html.erb
+++ b/app/views/errors/invalid_session.html.erb
@@ -10,10 +10,7 @@
         <p class="govuk-body"><%=t '.lead_text', session_timeout: session_expire_in_minutes %></p>
         <p class="govuk-body"><%=t '.more_text' %></p>
 
-        <div class="form-submit">
-          <%= link_to t('.start_again'), root_path, class: 'govuk-button' %>
-        </div>
-
+        <%= link_button :start_again, root_path %>
       </div>
     </div>
 

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -9,10 +9,7 @@
 
         <p class="govuk-body"><%=t '.lead_text' %></p>
 
-        <div class="form-submit">
-          <%= link_to t('.start_again'), root_path, class: 'govuk-button' %>
-        </div>
-
+        <%= link_button :start_again, root_path %>
       </div>
     </div>
 

--- a/app/views/errors/unhandled.html.erb
+++ b/app/views/errors/unhandled.html.erb
@@ -11,10 +11,7 @@
 
         <p class="govuk-body"><%=t '.lead_text' %></p>
 
-        <div class="form-submit">
-          <%= link_to t('.start_again'), root_path, class: 'govuk-button' %>
-        </div>
-
+        <%= link_button :start_again, root_path %>
       </div>
     </div>
 

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -8,7 +8,7 @@
           <%= service_name %>
         </h1>
 
-        <p class="govuk-body">
+        <p class="govuk-body-l">
           Use this service to check when a caution or conviction becomes spent in England and Wales.
         </p>
 

--- a/app/views/steps/check/results/shared/_feedback.en.html.erb
+++ b/app/views/steps/check/results/shared/_feedback.en.html.erb
@@ -1,4 +1,5 @@
-<hr>
+<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
 <h2 class="govuk-heading-m govuk-!-margin-top-5">
   We’d like your feedback
 </h2>

--- a/app/views/steps/check/results/shared/_summary.en.html.erb
+++ b/app/views/steps/check/results/shared/_summary.en.html.erb
@@ -4,5 +4,5 @@
 
 <p class="govuk-body">
   If you need to change any information, you
-  can <%= link_to 'use the service again', root_path, class: 'govuk-link ga-pageLink', data: { ga_category: 'results', ga_label: 'new check' } %>.
+  can <%= link_to 'use the service again', root_path, class: 'govuk-link govuk-link--no-visited-state ga-pageLink', data: { ga_category: 'results', ga_label: 'new check' } %>.
 </p>

--- a/app/views/warning/reset_session.html.erb
+++ b/app/views/warning/reset_session.html.erb
@@ -8,10 +8,10 @@
         <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
         <%= link_button :resume_check, previous_step_path, class: 'govuk-button govuk-!-margin-right-3 ga-pageLink',
-                        data: { ga_category: 'in progress warning', ga_label: 'resume check' } %>
+                        data: { module: 'govuk-button', ga_category: 'in progress warning', ga_label: 'resume check' } %>
 
         <%= link_button :restart_check, root_path(new: 'y'), class: 'govuk-button govuk-button--secondary ga-pageLink',
-                        data: { ga_category: 'in progress warning', ga_label: 'new check' } %>
+                        data: { module: 'govuk-button', ga_category: 'in progress warning', ga_label: 'new check' } %>
 
       </div>
     </div>

--- a/app/views/warning/reset_session.html.erb
+++ b/app/views/warning/reset_session.html.erb
@@ -7,13 +7,11 @@
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-        <div class="form-submit">
-          <%= link_to t('.resume_link'), previous_step_path, class: 'govuk-button govuk-!-margin-right-3 ga-pageLink',
-                      data: { ga_category: 'in progress warning', ga_label: 'resume check' } %>
+        <%= link_button :resume_check, previous_step_path, class: 'govuk-button govuk-!-margin-right-3 ga-pageLink',
+                        data: { ga_category: 'in progress warning', ga_label: 'resume check' } %>
 
-          <%= link_to t('.restart_link'), root_path(new: 'y'), class: 'govuk-button govuk-button--secondary ga-pageLink',
-                      data: { ga_category: 'in progress warning', ga_label: 'new check' } %>
-        </div>
+        <%= link_button :restart_check, root_path(new: 'y'), class: 'govuk-button govuk-button--secondary ga-pageLink',
+                        data: { ga_category: 'in progress warning', ga_label: 'new check' } %>
 
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,5 +11,3 @@ en:
     reset_session:
       page_title: Check in progress
       heading: It looks like you already have a check in progress
-      resume_link: Resume check
-      restart_link: Start a new check

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -75,20 +75,16 @@ en:
       heading: You have already completed this check
       lead_text: If you want to make changes you will need to start a new check.
       results_page: Go to results page
-      start_again: New check
     invalid_session:
       page_title: Sorry, you'll have to start again
       heading: Sorry, you'll have to start again
       lead_text: Your session automatically ends if you don't use the service for %{session_timeout} minutes.
       more_text: We do this for your security. Any unsaved details will be deleted.
-      start_again: New check
     not_found:
       page_title: Page not found
       heading: Page not found
       lead_text: If you copied a web address, please check it’s correct.
-      start_again: New check
     unhandled:
       page_title: Unexpected error
       heading: Sorry, something went wrong with our service
       lead_text: You can go back and retry, or start again.
-      start_again: New check

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -94,8 +94,11 @@ en:
       <<: *CONVICTION_SUBTYPES
 
   helpers:
-    submit:
+    buttons:
       continue: Continue
+      start_again: New check
+      resume_check: Resume check
+      restart_check: Start a new check
     fieldset:
       steps_check_kind_form:
         kind: Were you cautioned or convicted?

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -27,7 +27,7 @@ When(/^I click the "([^"]*)" link$/) do |text|
 end
 
 When(/^I click the "([^"]*)" button$/) do |text|
-  find("input[value='#{text}']").click
+  click_button(text)
 end
 
 When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |field, value|
@@ -40,13 +40,13 @@ end
 
 When(/^I choose "([^"]*)"$/) do |text|
   step %[I click the radio button "#{text}"]
-  find('[name=commit]').click
+  step %[I click the "Continue" button]
 end
 
 And(/^I choose "([^"]*)" and fill in "([^"]*)" with "([^"]*)"$/) do |text, field, value|
   step %[I click the radio button "#{text}"]
   step %[I fill in "#{field}" with "#{value}"]
-  find('[name=commit]').click
+  step %[I click the "Continue" button]
 end
 
 When(/^I am completing a basic under 18 "([^"]*)" conviction$/) do |value|

--- a/lib/govuk_components/form_builder.rb
+++ b/lib/govuk_components/form_builder.rb
@@ -4,7 +4,7 @@ module GovukComponents
     delegate :t, :concat, to: :@template
 
     def continue_button(value: :continue, options: {})
-      button t("helpers.submit.#{value}"), {
+      button t("helpers.buttons.#{value}"), {
         name: nil,
         class: 'govuk-button',
         data: { module: 'govuk-button', 'prevent-double-click': true },

--- a/lib/govuk_components/form_builder.rb
+++ b/lib/govuk_components/form_builder.rb
@@ -4,7 +4,11 @@ module GovukComponents
     delegate :t, :concat, to: :@template
 
     def continue_button(value: :continue, options: {})
-      submit t("helpers.submit.#{value}"), {class: 'govuk-button'}.merge(options)
+      button t("helpers.submit.#{value}"), {
+        name: nil,
+        class: 'govuk-button',
+        data: { module: 'govuk-button', 'prevent-double-click': true },
+      }.merge(options)
     end
 
     # Methods below overrides the one from the original gem, and reimplement them

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(
         helper.link_to_feedback('click here')
       ).to eq(
-        '<a class="govuk-link" rel="external" target="_blank"' + \
+        '<a class="govuk-link govuk-link--no-visited-state" rel="external" target="_blank"' + \
         ' href="https://example.com?check=conviction&amp;page=%2Fsteps%2Ffoo%2Fbar">click here</a>'
       )
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -170,6 +170,14 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#link_button' do
+    it 'builds the link markup styled as a button' do
+      expect(
+        helper.link_button(:start_again, root_path)
+      ).to eq('<a class="govuk-button" data-module="govuk-button" href="/">New check</a>')
+    end
+  end
+
   describe 'dev_tools_enabled?' do
     before do
       allow(Rails).to receive_message_chain(:env, :development?).and_return(development_env)

--- a/spec/lib/govuk_components/form_builder_spec.rb
+++ b/spec/lib/govuk_components/form_builder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GovukComponents::FormBuilder do
     it 'outputs the continue button' do
       expect(
         html_output
-      ).to eq('<input type="submit" name="commit" value="Continue" class="govuk-button" data-disable-with="Continue" />')
+      ).to eq('<button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Continue</button>')
     end
   end
 


### PR DESCRIPTION
Individual commits for easier review.

Some of the markup was old, from a time before the new design system.
Other was just oversights.

I've updated most of what I could find, mainly around links and buttons. Also I've done a big cleanup of unused GA javascript (most of it a copy of the C100) as we don't have or track the kind of HTML elements we were tracking on C100.