### PR TITLE
Bump to `gov_uk_date_fields` gem (inputmode)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.6.3'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'govuk_elements_form_builder', '~> 1.3.0'
-gem 'gov_uk_date_fields', '~> 4.0.1'
+gem 'gov_uk_date_fields', '~> 4.1.0'
 gem 'jquery-rails'
 gem 'pg', '~> 1.1.0'
 gem 'puma', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,8 +123,8 @@ GEM
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    gov_uk_date_fields (4.0.1)
-      rails (>= 5.0)
+    gov_uk_date_fields (4.1.0)
+      rails (>= 5.0.7.2)
     govuk_elements_form_builder (1.3.0)
       govuk_elements_rails (>= 3.0.0)
       govuk_frontend_toolkit (>= 6.0.0)
@@ -349,7 +349,7 @@ DEPENDENCIES
   cucumber-rails
   dotenv-rails
   factory_bot_rails
-  gov_uk_date_fields (~> 4.0.1)
+  gov_uk_date_fields (~> 4.1.0)
   govuk_elements_form_builder (~> 1.3.0)
   i18n-debug
   i18n-tasks (~> 0.9.28)

--- a/app/assets/javascripts/modules/ga-events.js
+++ b/app/assets/javascripts/modules/ga-events.js
@@ -2,7 +2,7 @@
 
 moj.Modules.gaEvents = {
     radioFormClass: '.govuk-radios__item input[type="radio"]',
-    dateFormClass: '.govuk-date-input input[type="number"]',
+    dateFormClass: '.govuk-date-input input[type="text"]',
     linkClass: '.ga-pageLink',
     revealingLinkClass: '.govuk-details__summary span.govuk-details__summary-text',
 
@@ -188,7 +188,7 @@ moj.Modules.gaEvents = {
     },
 
     getDateYearData: function ($form) {
-        var $dateYears = $form.find('input[type="number"][id$="_yyyy"]'),
+        var $dateYears = $form.find('input[type="text"][id$="_yyyy"]'),
             eventDataArray = [];
 
         $dateYears.each(function (n, year) {

--- a/app/views/steps/conviction/conviction_length/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length/edit.html.erb
@@ -19,7 +19,7 @@
         <%= step_form @form_object do |f| %>
           <%= f.text_field :conviction_length,
                            i18n_attribute: @form_object.conviction_length_type,
-                           input_options: { class: 'govuk-input--width-3', type: :number, pattern: '[0-9]*' },
+                           input_options: { class: 'govuk-input--width-3', inputmode: :numeric, pattern: '[0-9]*' },
                            label_options: { page_heading: false, size: 's' } %>
 
           <%= f.continue_button %>


### PR DESCRIPTION
The recommended way to use the numeric inputs is to be of type `text` but with pattern and inputmode attributes.

The dates gem has been updated to produce this new markup [0] following the reports of issues with previous markup [1].

Also updated the `conviction_length` step to produce an input of type `text`, instead of number, and add the `inputmode` attribute.

[0] https://github.com/ministryofjustice/gov_uk_date_fields/releases/tag/v4.1.0
[1] https://github.com/alphagov/govuk-frontend/issues/1449