### PR TITLE
Add details to date steps

### DIFF
--- a/app/views/steps/caution/conditional_end_date/edit.html.erb
+++ b/app/views/steps/caution/conditional_end_date/edit.html.erb
@@ -12,16 +12,10 @@
         <%= step_form @form_object do |f| %>
           <%= f.gov_uk_date_field :conditional_end_date %>
 
-          <details class="govuk-details" data-module="govuk-details">
-            <summary class="govuk-details__summary">
-              <span class="govuk-details__summary-text" data-ga-category="explanations" data-ga-label="conditions not ended">
-                <%= t ".conditions_not_ended_title" %>
-              </span>
-            </summary>
-            <div class="govuk-details__text">
-              <%= t ".conditions_not_ended_html" %>
-            </div>
-          </details>
+          <%= render partial: 'steps/shared/unknown_date_details', locals: {
+              i18n_scope: :conditional_caution,
+              ga_label: 'conditions not ended'
+          } %>
 
           <%= f.continue_button %>
         <% end %>

--- a/app/views/steps/caution/known_date/edit.html.erb
+++ b/app/views/steps/caution/known_date/edit.html.erb
@@ -11,6 +11,9 @@
 
         <%= step_form @form_object do |f| %>
           <%= f.gov_uk_date_field :known_date %>
+
+          <%= render partial: 'steps/shared/unknown_date_details', locals: { ga_label: 'caution unknown date' } %>
+
           <%= f.continue_button %>
         <% end %>
       </div>

--- a/app/views/steps/conviction/compensation_payment_date/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_date/edit.html.erb
@@ -18,6 +18,8 @@
           <%= f.gov_uk_date_field :compensation_payment_date,
                                   legend_options: { page_heading: false, visually_hidden: true } %>
 
+          <%= render partial: 'steps/shared/unknown_date_details', locals: { ga_label: 'compensation unknown date' } %>
+
           <%= f.continue_button %>
         <% end %>
       </div>

--- a/app/views/steps/conviction/known_date/edit.html.erb
+++ b/app/views/steps/conviction/known_date/edit.html.erb
@@ -13,6 +13,8 @@
         <%= step_form @form_object do |f| %>
           <%= f.gov_uk_date_field :known_date, i18n_attribute: @form_object.conviction_subtype %>
 
+          <%= render partial: 'steps/shared/unknown_date_details', locals: { ga_label: 'conviction unknown date' } %>
+
           <%= f.continue_button %>
         <% end %>
       </div>

--- a/app/views/steps/shared/_unknown_date_details.html.erb
+++ b/app/views/steps/shared/_unknown_date_details.html.erb
@@ -1,0 +1,10 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text" data-ga-category="explanations" data-ga-label="<%= ga_label %>">
+      <%=t ['.', local_assigns[:i18n_scope], :title].compact.join('.') %>
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <%=t ['.', local_assigns[:i18n_scope], :body_html].compact.join('.') %>
+  </div>
+</details>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,3 +11,20 @@ en:
     reset_session:
       page_title: Check in progress
       heading: It looks like you already have a check in progress
+
+  steps:
+    shared:
+      unknown_date_details:
+        title: I do not know this date
+        body_html: |
+          <p>If you do not know the exact date you can enter an approximate one.</p>
+          <p>If you enter an approximate date, the result you’re given at the end of the service will not be correct.</p>
+        conditional_caution:
+          title: My conditions have not ended or I do not know when they end
+          body_html: |
+            <h2 class="govuk-heading-s">If your conditions have not yet ended</h2>
+            <p>You can enter a future date if you know when your conditions will end.</p>
+            <p>The result you’re given at the end of the service will be correct as long as you stick to the conditions of your caution.</p>
+            <h2 class="govuk-heading-s">If you do not know when your conditions end</h2>
+            <p>If you do not know the exact date you can enter an approximate one.</p>
+            <p>If you enter an approximate date, the result you’re given at the end of the service will not be correct.</p>

--- a/config/locales/en/caution.yml
+++ b/config/locales/en/caution.yml
@@ -12,11 +12,3 @@ en:
       conditional_end_date:
         edit:
           page_title: End date of conditions
-          conditions_not_ended_title: My conditions have not ended
-          conditions_not_ended_html: |
-            <p>You can enter a future date if you know when your conditions will end. The date your caution becomes spent will be correct as long as you stick to the conditions of your caution.</p>
-            <h2 class="govuk-heading-s">If the conditions last less than 3 months</h2>
-            <p>Your caution will be spent on the day the conditions end.</p>
-            <p>If one of the conditions is to pay a fine or compensation, your caution will be spent on the day that all the conditions end - including paying the financial penalty in full.</p>
-            <h2 class="govuk-heading-s">If the conditions last 3 months or more</h2>
-            <p>Your caution will be spent 3 months after the day the caution was given to you.</p>


### PR DESCRIPTION
Add a `<details>` block to all date steps we have in the application, to explain more about it.

All are the same, except for conditional caution, where the copy is slighly different.

As we are reusing the same markup, it has been extracted to a partial that can be passed a few variables.

<img width="691" alt="Screen Shot 2019-08-29 at 12 56 16" src="https://user-images.githubusercontent.com/687910/63938396-91987300-ca5c-11e9-9031-e2d300b458a3.png">

<img width="668" alt="Screen Shot 2019-08-29 at 12 57 59" src="https://user-images.githubusercontent.com/687910/63938436-aa088d80-ca5c-11e9-87c5-38a53cf431c5.png">
