### PR TITLE
Changed 'convicted' to 'sentenced' in hint text

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -177,7 +177,7 @@ en:
       steps_caution_conditional_end_date_form:
         conditional_end_date_html: "Enter the date you agreed the conditions would end. This might have included paying a fine or compensation. <span class='nowrap'>For example, 23 9 2018</span>"
       steps_conviction_known_date_form:
-        known_date_html: "Enter the date your sentence or order started. This might be the day you were convicted in court or the first day you were held on remand. <span class='nowrap'>For example, 23 9 2018</span>"
+        known_date_html: "Enter the date your sentence or order started. This might be the day you were sentenced in court or the first day you were held on remand. <span class='nowrap'>For example, 23 9 2018</span>"
       steps_conviction_compensation_payment_date_form:
         compensation_payment_date: For example, 23 9 2018
       radio_buttons:


### PR DESCRIPTION
Sentence calculation policy team requested that this word be changed.