### PR TITLE
Add callout to sentence length page

### DIFF
--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -1,5 +1,30 @@
 ---
 en:
+  dictionary:
+    sentence_info: &sentence_info |
+      <p class="govuk-body">
+        Enter the whole length of the sentence you were given in court, even if you were released:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>early</li>
+        <li>on temporary license</li>
+        <li>on parole</li>
+        <li>under supervision</li>
+      </ul>
+    sentence_info_with_callout: &sentence_info_with_callout |
+      <p class="govuk-body">
+        Enter the whole length of the sentence you were given in court, even if you were released:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>early</li>
+        <li>on temporary license</li>
+        <li>on parole</li>
+        <li>under supervision</li>
+      </ul>
+      <div class="govuk-inset-text">
+        If your sentence was extended, the number you enter must include both the original sentence length and the length it was extended by.
+      </div>
+
   steps:
     conviction:
       known_date:
@@ -30,26 +55,10 @@ en:
             adult_suspended_prison_sentence: What was the length of the sentence?
             adult_disqualification: What was the length of the disqualification?
           explanation:
-            detention_html: |
-              <p class="govuk-body-m">
-                Enter the whole length of the sentence you were given in court, even if you were released:
-              </p>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>early</li>
-                <li>on temporary license</li>
-                <li>on parole</li>
-                <li>under supervision</li>
-              </ul>
-            detention_training_order_html: |
-              <p class="govuk-body-m">
-                Enter the whole length of the sentence you were given in court, even if you were released:
-              </p>
-              <ul class="govuk-list govuk-list--bullet">
-                <li>early</li>
-                <li>on temporary license</li>
-                <li>on parole</li>
-                <li>under supervision</li>
-              </ul>
+            detention_html: *sentence_info_with_callout
+            detention_training_order_html: *sentence_info
+            adult_prison_sentence_html: *sentence_info_with_callout
+            adult_suspended_prison_sentence_html: *sentence_info_with_callout
       compensation_paid:
         edit:
           page_title: Compensation paid


### PR DESCRIPTION
Add a callout to:

- over-18s prison
- over-18s suspended prison
- under-18s detention

The under-18s DTO doesn’t need the callout (as the sentence can’t be extended) but needs everything else.

<img width="668" alt="Screen Shot 2019-09-09 at 11 46 44" src="https://user-images.githubusercontent.com/687910/64524908-887a9200-d2f7-11e9-9db3-87649589c65e.png">
