### PR TITLE
Add basic http auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,6 @@ class ApplicationController < ActionController::Base
   include SecurityHandling
   include ErrorHandling
 
-  before_action :check_http_authenticate?
-
   # This is required to get request attributes in to the production logs.
   # See the various lograge configurations in `production.rb`.
   def append_info_to_payload(payload)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   include SecurityHandling
   include ErrorHandling
 
+  before_action :check_http_authenticate?
+
   # This is required to get request attributes in to the production logs.
   # See the various lograge configurations in `production.rb`.
   def append_info_to_payload(payload)

--- a/app/controllers/concerns/security_handling.rb
+++ b/app/controllers/concerns/security_handling.rb
@@ -5,7 +5,8 @@ module SecurityHandling
     protect_from_forgery with: :exception, prepend: true
 
     before_action :drop_dangerous_headers!,
-                  :ensure_session_validity
+                  :ensure_session_validity,
+                  :check_http_authenticate?
 
     after_action :set_security_headers
 

--- a/app/controllers/concerns/security_handling.rb
+++ b/app/controllers/concerns/security_handling.rb
@@ -46,4 +46,14 @@ module SecurityHandling
       'Strict-Transport-Security' => 'max-age=15768000; includeSubDomains',
     }
   end
+
+  def check_http_authenticate?
+    # :nocov:
+    return unless ENV.fetch('HTTP_AUTH_ENABLED', false)
+
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV.fetch('HTTP_AUTH_USER') && password == ENV.fetch('HTTP_AUTH_PASSWORD')
+    end
+    # :nocov:
+  end
 end

--- a/app/controllers/concerns/security_handling.rb
+++ b/app/controllers/concerns/security_handling.rb
@@ -4,9 +4,9 @@ module SecurityHandling
   included do
     protect_from_forgery with: :exception, prepend: true
 
-    before_action :drop_dangerous_headers!,
-                  :ensure_session_validity,
-                  :check_http_authenticate?
+    before_action :check_http_authenticate?,
+                  :drop_dangerous_headers!,
+                  :ensure_session_validity
 
     after_action :set_security_headers
 


### PR DESCRIPTION
Enable basic access authentication on the present of environment variable  `HTTP_AUTH_ENABLED`

Only can be enable for controllers which inherit from `application_controller.rb` i.e it won't be enable for StatusController action like ping etc.