### PR TITLE
Use the http auth to track MVP visits

### DIFF
--- a/app/controllers/concerns/security_handling.rb
+++ b/app/controllers/concerns/security_handling.rb
@@ -54,7 +54,8 @@ module SecurityHandling
 
     authenticate_or_request_with_http_basic do |username, password|
       if username.eql?(password)
-        Participant.valid_reference?(username) # Access for MVP participants
+        # Access for MVP participants
+        Participant.valid_reference?(username) && Participant.touch_or_create_by(reference: username)
       else
         username == ENV.fetch('HTTP_AUTH_USER') && password == ENV.fetch('HTTP_AUTH_PASSWORD')
       end

--- a/app/controllers/steps/mvp/info_controller.rb
+++ b/app/controllers/steps/mvp/info_controller.rb
@@ -2,7 +2,6 @@ module Steps
   module Mvp
     class InfoController < Steps::MvpStepController
       before_action :validate_reference
-      before_action :increment_access_count, only: [:edit]
 
       def edit
         @form_object = InfoForm.build(participant_record)
@@ -26,15 +25,8 @@ module Steps
           (raise "Participant reference not found: '#{reference}'")
       end
 
-      # Using `+= 1` instead of `#increment` so the `updated_at` column
-      # gets also updated as part of the record save.
-      def increment_access_count
-        participant_record.access_count += 1
-        participant_record.save
-      end
-
       def participant_record
-        @_participant_record ||= Participant.find_or_create_by(
+        @_participant_record ||= Participant.touch_or_create_by(
           reference: reference
         )
       end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,7 +1,24 @@
 class Participant < ApplicationRecord
-  def self.valid_reference?(reference)
-    Rails.configuration.participants.include?(
-      Digest::SHA256.hexdigest(reference)
-    )
+  class << self
+    def valid_reference?(reference)
+      Rails.configuration.participants.include?(
+        Digest::SHA256.hexdigest(reference)
+      )
+    end
+
+    def touch_or_create_by(reference:)
+      Participant.find_or_create_by(
+        reference: reference
+      ).increment_access_count
+    end
+  end
+
+  # Using `+= 1` instead of `#increment` so the `updated_at` column
+  # gets also updated as part of the record save.
+  # Returns the instance.
+  #
+  def increment_access_count
+    self.access_count += 1
+    save && self
   end
 end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Participant, type: :model do
+  subject { described_class.new(attributes) }
+
+  let(:attributes) { {} }
+
+  # Avoid saving to the database
+  before do
+    allow(subject).to receive(:save).and_return(true)
+  end
+
   describe '.valid_reference?' do
     context 'for a valid reference' do
       let(:reference) { 'test' }
@@ -15,6 +24,35 @@ RSpec.describe Participant, type: :model do
     context 'for a blank reference' do
       let(:reference) { '' }
       it { expect(described_class.valid_reference?(reference)).to eq(false) }
+    end
+  end
+
+  describe '.touch_or_create_by' do
+    # Avoid saving to the database
+    before do
+      allow(Participant).to receive(:find_or_create_by).with(reference: 'test').and_return(subject)
+    end
+
+    it 'delegates to `find_or_create_by`' do
+      expect(described_class.touch_or_create_by(reference: 'test')).to eq(subject)
+    end
+
+    it 'increments the `access_count` attribute' do
+      expect {
+        described_class.touch_or_create_by(reference: 'test')
+      }.to change { subject.access_count }.by(1)
+    end
+  end
+
+  describe '#increment_access_count' do
+    it 'increments the `access_count` attribute' do
+      expect {
+        subject.increment_access_count
+      }.to change { subject.access_count }.by(1)
+    end
+
+    it 'returns the instance' do
+      expect(subject.increment_access_count).to eq(subject)
     end
   end
 end


### PR DESCRIPTION
As we are removing the opt-in/opt-out mechanism from the landing page (and we might even end up removing the landing page completely) we need another way to track which participants are using the MVP.

We can do this with the unique set of http auth credentials as these reference individual YOTs.