### PR TITLE
Enable GA userId for MVP pilot

### DIFF
--- a/app/controllers/concerns/security_handling.rb
+++ b/app/controllers/concerns/security_handling.rb
@@ -48,18 +48,23 @@ module SecurityHandling
     }
   end
 
+  # :nocov:
+  def authenticate_participant(username)
+    return unless Participant.valid_reference?(username)
+
+    @_current_participant = Participant.touch_or_create_by(reference: username)
+  end
+
   def check_http_credentials
-    # :nocov:
     return unless ENV.fetch('HTTP_AUTH_ENABLED', false)
 
     authenticate_or_request_with_http_basic do |username, password|
       if username.eql?(password)
-        # Access for MVP participants
-        Participant.valid_reference?(username) && Participant.touch_or_create_by(reference: username)
+        authenticate_participant(username)
       else
         username == ENV.fetch('HTTP_AUTH_USER') && password == ENV.fetch('HTTP_AUTH_PASSWORD')
       end
     end
-    # :nocov:
   end
+  # :nocov:
 end

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -36,6 +36,10 @@ module AnalyticsHelper
       current_disclosure_check.kind
   end
 
+  def current_participant
+    @_current_participant
+  end
+
   private
 
   # Custom dimensions on Google Analytics are named `dimensionX` where X

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -6,6 +6,10 @@
 
   ga('create', '<%= analytics_tracking_id %>', 'auto');
 
+  <% if current_participant %>
+  ga('set', 'userId', '<%= current_participant.reference %>');
+  <% end %>
+
   ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
 

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -77,4 +77,18 @@ RSpec.describe AnalyticsHelper, type: :helper do
       it { expect(helper.transaction_sku).to eq('unknown') }
     end
   end
+
+  describe '#current_participant' do
+    context 'we do not have a participant' do
+      it { expect(helper.current_participant).to eq(nil) }
+    end
+
+    context 'we have a participant' do
+      before do
+        helper.instance_variable_set(:@_current_participant, 'foobar')
+      end
+
+      it { expect(helper.current_participant).to eq('foobar') }
+    end
+  end
 end


### PR DESCRIPTION
At least during the pilot, we will need a way of measuring success and we will need to know how many checks have been completed per YOT.

This will link together the analytics belonging to each YOT so it is easier to evaluate the metrics we get.

There is no personal identification involved.