### PR TITLE
update sentence calculator base on legal advice

### DIFF
--- a/app/services/calculators/sentence_calculator.rb
+++ b/app/services/calculators/sentence_calculator.rb
@@ -85,7 +85,7 @@ module Calculators
     end
 
     def conviction_end_date
-      super.advance(days: 1)
+      super.advance(days: -1)
     end
   end
 end

--- a/spec/services/calculators/sentence_calculator_spec.rb
+++ b/spec/services/calculators/sentence_calculator_spec.rb
@@ -15,17 +15,17 @@ RSpec.describe Calculators::SentenceCalculator do
     context '#expiry_date' do
       context 'conviction length of 6 months or less' do
         let(:conviction_months) { 5 }
-        it { expect(subject.expiry_date.to_s).to eq('2018-09-21') }
+        it { expect(subject.expiry_date.to_s).to eq('2018-09-19') }
       end
 
       context 'conviction length of 7 to 30 months' do
         let(:conviction_months) { 29 }
-        it { expect(subject.expiry_date.to_s).to eq('2021-03-21') }
+        it { expect(subject.expiry_date.to_s).to eq('2021-03-19') }
       end
 
       context 'conviction length of over 30 months and up to 4 years' do
         let(:conviction_months) { 48 }
-        it { expect(subject.expiry_date.to_s).to eq('2024-04-21') }
+        it { expect(subject.expiry_date.to_s).to eq('2024-04-19') }
       end
 
       context 'never spent for conviction length over 4 years' do
@@ -45,17 +45,17 @@ RSpec.describe Calculators::SentenceCalculator do
     context '#expiry_date' do
       context 'conviction length of 6 months or less' do
         let(:conviction_months) { 5 }
-        it { expect(subject.expiry_date.to_s).to eq('2019-03-21') }
+        it { expect(subject.expiry_date.to_s).to eq('2019-03-19') }
       end
 
       context 'conviction length of 7 to 30 months' do
         let(:conviction_months) { 29 }
-        it { expect(subject.expiry_date.to_s).to eq('2023-03-21') }
+        it { expect(subject.expiry_date.to_s).to eq('2023-03-19') }
       end
 
       context 'conviction length of over 30 months and up to 4 years' do
         let(:conviction_months) { 48 }
-        it { expect(subject.expiry_date.to_s).to eq('2027-10-21') }
+        it { expect(subject.expiry_date.to_s).to eq('2027-10-19') }
       end
 
       context 'never spent for conviction length over 4 years' do
@@ -75,12 +75,12 @@ RSpec.describe Calculators::SentenceCalculator do
     context '#expiry_date' do
       context 'conviction length of 6 months or less' do
         let(:conviction_months) { 5 }
-        it { expect(subject.expiry_date.to_s).to eq('2019-03-21') }
+        it { expect(subject.expiry_date.to_s).to eq('2019-03-19') }
       end
 
       context 'conviction length of 7 to 24 months' do
         let(:conviction_months) { 24 }
-        it { expect(subject.expiry_date.to_s).to eq('2022-10-21') }
+        it { expect(subject.expiry_date.to_s).to eq('2022-10-19') }
       end
 
       context 'there is an upper limit' do


### PR DESCRIPTION
For empale:   If you get convicted  of `Detention`  as under 18  for 1 month on 5 Feb 2017.  

The spent date of your conviction should be 4 September 2018

Perviously it was 6 September 2018.  

How a spent date is worked out for any custody sentence:
 
A = Conviction date 
B = Length of conviction
C = Rehabilitation period 

**Conviction end date**  = (A + B) - 1 day    
i.e  `5/2/2017 + 1 calendar month = 5/3/2017 - 1 day  = 4/3/2017 `

**Spent date** = Conviction end date + C
i.e `4/3/2017 + 18 calendar months = 4/9/2019