### PR TITLE
Improve the generation of participant references

### DIFF
--- a/config/participants.yml
+++ b/config/participants.yml
@@ -5,6 +5,9 @@
 # A 'test' reference is included, for testing purposes, with hash:
 #   9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
 #
+# To generate new references, use the rake task `generate_references`
+# Refer to `lib/tasks/tools.rake`
+#
 development:
   - 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
 

--- a/lib/tasks/tools.rake
+++ b/lib/tasks/tools.rake
@@ -4,9 +4,10 @@ namespace :tools do
   # Removed letters and numbers that might cause confusion (like 1 and l).
   #
   # Run with: `bundle exec rake tools:generate_references[total]`
+  # Defaults to 1 generated reference if no total is provided.
   #
   task :generate_references, [:total] do |_task, args|
-    total = (args[:total] || 10).to_i
+    total = (args[:total] || 1).to_i
 
     alpha  = %w[a b c d e h k m n s u v w x z].freeze
     number = (2..9).to_a.freeze
@@ -28,6 +29,12 @@ namespace :tools do
       count = (total - result.size)
     end
 
-    puts result.join(',')
+    puts 'Reference | SHA'
+    puts '-' * 76
+    result.each { |r| puts [r.ljust(12, " "), Digest::SHA256.hexdigest(r)].join }
+
+    puts
+    puts 'Note: before adding the SHA to `participants.yml` ensure it is not already present.'
+    puts
   end
 end


### PR DESCRIPTION
* Defaults to 1 generated references, down from 10.

* Added more documentation and outputs the SHA directly.