### PR TITLE
Update adult motoring conviction subtypes

### DIFF
--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -96,7 +96,8 @@ class ConvictionType < ValueObject
     ADULT_SERVICE_DETENTION             = new(:adult_service_detention,            parent: ADULT_MILITARY, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusTwelveMonths),
 
     ADULT_DISQUALIFICATION              = new(:adult_disqualification,             parent: ADULT_MOTORING, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
-    ADULT_ENDORSEMENT                   = new(:adult_endorsement,                  parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::StartPlusFiveYears),
+    ADULT_MOTORING_FINE                 = new(:adult_motoring_fine,                parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::StartPlusFiveYears),
+    ADULT_PENALTY_NOTICE                = new(:adult_penalty_notice,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::StartPlusThreeYears),
     ADULT_PENALTY_POINTS                = new(:adult_penalty_points,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::StartPlusThreeYears),
 
     ADULT_HOSPITAL_ORDER                = new(:adult_hospital_order,               parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -66,8 +66,9 @@ en:
       adult_service_community_order: Service community order
       adult_service_detention: Service detention
       # adult_motoring
-      adult_disqualification: Disqualification (driving ban)
-      adult_endorsement: Endorsement
+      adult_disqualification: Disqualification
+      adult_motoring_fine: Fine
+      adult_penalty_notice: Fixed Penalty notice (FPN)
       adult_penalty_points: Penalty points
       # adult_discharge
       adult_bind_over: Bind over
@@ -120,7 +121,8 @@ en:
         adult_dismissal: When were you given the dismissal?
         adult_service_detention: When were you given the detention?
         adult_disqualification: When were you given the disqualification?
-        adult_endorsement: When were you given the endorsement?
+        adult_motoring_fine: When were you given the fine?
+        adult_penalty_notice: When were you given the fixed notice points?
         adult_penalty_points: When were you given the penalty points?
       steps_conviction_conviction_type_form:
         conviction_type: What type of conviction did you get?
@@ -232,9 +234,10 @@ en:
           adult_service_community_order: ""
           adult_service_detention: ""
           # adult_motoring
-          adult_disqualification: You were banned from driving for a certain period of time
-          adult_endorsement: (placeholder hint text)
-          adult_penalty_points: (placeholder hint text)
+          adult_disqualification: You were banned from driving
+          adult_motoring_fine: A court gave you a fine that was not a fixed penalty notice (FPN)
+          adult_penalty_notice: You were given a fine ‘on the spot’ or by post
+          adult_penalty_points: You were given a number of penalty points for a driving offence
           # adult_discharge
           adult_bind_over: Your sentence was postponed as long as you kept to certain conditions
           adult_absolute_discharge: You were found guilty of a crime but did not get sentenced

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -66,8 +66,9 @@ en:
       adult_service_community_order: Service community order
       adult_service_detention: Service detention
       # adult_motoring
-      adult_disqualification: Disqualification (driving ban)
-      adult_endorsement: Endorsement
+      adult_disqualification: Disqualification
+      adult_motoring_fine: Fine
+      adult_penalty_notice: Fixed Penalty notice (FPN)
       adult_penalty_points: Penalty points
       # adult_discharge
       adult_bind_over: Bind over

--- a/features/adults/conviction_motoring.feature
+++ b/features/adults/conviction_motoring.feature
@@ -19,8 +19,8 @@ Feature: Conviction
     And I should be on "<result>"
 
     Examples:
-      | subtype                        | known_date_header                         | length_type_header                                                      | length_header                                | result               |
-      | Disqualification (driving ban) | When were you given the disqualification? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | /steps/check/results |
+      | subtype           | known_date_header                         | length_type_header                                                      | length_header                                | result               |
+      | Disqualification  | When were you given the disqualification? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | /steps/check/results |
 
   @happy_path
   Scenario Outline: Motoring convictions without length
@@ -34,6 +34,7 @@ Feature: Conviction
     Then I should be on "<result>"
 
     Examples:
-      | subtype        | known_date_header                       | result               |
-      | Endorsement    | When were you given the endorsement?    | /steps/check/results |
-      | Penalty points | When were you given the penalty points? | /steps/check/results |
+      | subtype                    | known_date_header                            | result               |
+      | Fine                       | When were you given the fine?                | /steps/check/results |
+      | Fixed Penalty notice (FPN) | When were you given the fixed notice points? | /steps/check/results |
+      | Penalty points             | When were you given the penalty points?      | /steps/check/results |

--- a/spec/services/conviction_length_choices_spec.rb
+++ b/spec/services/conviction_length_choices_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ConvictionLengthChoices do
       ConvictionType.values.size - described_class::SUBTYPES_HIDE_NO_LENGTH_CHOICE.size
     }
 
-    it { expect(total).to eq(45) }
+    it { expect(total).to eq(46) }
   end
 
   describe '.choices' do

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -162,7 +162,8 @@ RSpec.describe ConvictionType do
       it 'returns subtypes of this conviction type' do
         expect(values).to eq(%w(
           adult_disqualification
-          adult_endorsement
+          adult_motoring_fine
+          adult_penalty_notice
           adult_penalty_points
         ))
       end
@@ -483,12 +484,20 @@ RSpec.describe ConvictionType do
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
-    context 'ADULT_ENDORSEMENT' do
-      let(:subtype) { 'adult_endorsement' }
+    context 'ADULT_MOTORING_FINE' do
+      let(:subtype) { 'adult_motoring_fine' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
       it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::StartPlusFiveYears) }
+    end
+
+    context 'ADULT_PENALTY_NOTICE' do
+      let(:subtype) { 'adult_penalty_notice' }
+
+      it { expect(conviction_type.skip_length?).to eq(true) }
+      it { expect(conviction_type.compensation?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::StartPlusThreeYears) }
     end
 
     context 'ADULT_PENALTY_POINTS' do


### PR DESCRIPTION
Update adult motoring conviction subtypes to the following:

- Disqualification
- Fine
- Fixed penalty notice (FPN)
- Penalty points
