### PR TITLE
Add motoring endorsement step

### DIFF
--- a/app/controllers/steps/conviction/motoring_endorsement_controller.rb
+++ b/app/controllers/steps/conviction/motoring_endorsement_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Conviction
+    class MotoringEndorsementController < Steps::ConvictionStepController
+      def edit
+        @form_object = MotoringEndorsementForm.new(
+          disclosure_check: current_disclosure_check,
+          motoring_endorsement: current_disclosure_check.motoring_endorsement
+        )
+      end
+
+      def update
+        update_and_advance(MotoringEndorsementForm)
+      end
+    end
+  end
+end

--- a/app/forms/steps/conviction/motoring_endorsement_form.rb
+++ b/app/forms/steps/conviction/motoring_endorsement_form.rb
@@ -1,0 +1,9 @@
+module Steps
+  module Conviction
+    class MotoringEndorsementForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :motoring_endorsement
+    end
+  end
+end

--- a/app/views/steps/conviction/motoring_endorsement/edit.html.erb
+++ b/app/views/steps/conviction/motoring_endorsement/edit.html.erb
@@ -1,0 +1,23 @@
+<% title t('.page_title') %>
+
+<div class="govuk-width-container">
+  <%= step_header %>
+
+  <main id="main-content" class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= error_summary %>
+        <%= step_subsection %>
+
+        <!-- The header is part of the radios legend by default, but can be configured -->
+
+        <%= step_form @form_object do |f| %>
+          <%= f.radio_button_fieldset :motoring_endorsement, choices: GenericYesNo.values %>
+          <%= f.continue_button %>
+        <% end %>
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -64,3 +64,6 @@ en:
           page_title: Compensation payment date
           heading: When did you pay the compensation in full?
           lead_text: If you paid the compensation in stages, enter the date you made the final payment.
+      motoring_endorsement:
+        edit:
+          page_title: Motoring Endorsement

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -154,6 +154,8 @@ en:
         compensation_paid: Have you paid the compensation in full?
       steps_conviction_compensation_payment_date_form:
         compensation_payment_date: When did you pay the compensation in full?
+      steps_conviction_motoring_endorsement_form:
+        motoring_endorsement: Did you get an endorsement?
 
     hint:
       steps_caution_known_date_form:
@@ -167,6 +169,8 @@ en:
         known_date_html: "Enter the date your sentence or order started. This might be the day you were sentenced in court or the first day you were held on remand. <span class='nowrap'>For example, 23 9 2018</span>"
       steps_conviction_compensation_payment_date_form:
         compensation_payment_date: For example, 23 9 2018
+      steps_conviction_motoring_endorsement_form:
+        motoring_endorsement: An endorsement means that your conviction is recorded on your driving licence. Endorsements are usually given by courts.
       radio_buttons:
         kind:
           caution: You were given an official warning by the police

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       edit_step :compensation_paid
       edit_step :compensation_payment_date
       show_step :compensation_not_paid
+      edit_step :motoring_endorsement
     end
   end
 

--- a/db/migrate/20190926082054_add_motoring_endorsement_to_disclosure_check.rb
+++ b/db/migrate/20190926082054_add_motoring_endorsement_to_disclosure_check.rb
@@ -1,0 +1,5 @@
+class AddMotoringEndorsementToDisclosureCheck < ActiveRecord::Migration[5.2]
+  def change
+    add_column :disclosure_checks, :motoring_endorsement, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_16_102822) do
+ActiveRecord::Schema.define(version: 2019_09_26_082054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2019_09_16_102822) do
     t.integer "conviction_length"
     t.string "compensation_paid"
     t.date "compensation_payment_date"
+    t.string "motoring_endorsement"
     t.index ["status"], name: "index_disclosure_checks_on_status"
   end
 

--- a/spec/controllers/steps/conviction/motoring_endorsement_controller_spec.rb
+++ b/spec/controllers/steps/conviction/motoring_endorsement_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Conviction::MotoringEndorsementController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Conviction::MotoringEndorsementForm, ConvictionDecisionTree
+end

--- a/spec/forms/steps/conviction/motoring_endorsement_form_spec.rb
+++ b/spec/forms/steps/conviction/motoring_endorsement_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Conviction::MotoringEndorsementForm do
+  it_behaves_like 'a yes-no question form', attribute_name: :motoring_endorsement
+end


### PR DESCRIPTION
- Add basic yes/no question step
- Add motoring_endorsement column.
- Please note i haven't plumbed this step into the overall motoring journey, this will be done in the next PR.