### PR TITLE
Refactor some conviction methods into decorator

### DIFF
--- a/app/decorators/conviction_decorator.rb
+++ b/app/decorators/conviction_decorator.rb
@@ -1,0 +1,15 @@
+module ConvictionDecorator
+  def compensation?
+    [
+      ConvictionType::COMPENSATION_TO_A_VICTIM,
+      ConvictionType::ADULT_COMPENSATION_TO_A_VICTIM,
+    ].include?(self)
+  end
+
+  def custodial_sentence?
+    [
+      ConvictionType::CUSTODIAL_SENTENCE,
+      ConvictionType::ADULT_CUSTODIAL_SENTENCE,
+    ].include?(self)
+  end
+end

--- a/app/presenters/conviction_result_presenter.rb
+++ b/app/presenters/conviction_result_presenter.rb
@@ -5,13 +5,6 @@ class ConvictionResultPresenter < ResultsPresenter
     'results/conviction'
   end
 
-  def custodial_sentence?
-    [
-      ConvictionType::CUSTODIAL_SENTENCE,
-      ConvictionType::ADULT_CUSTODIAL_SENTENCE,
-    ].include?(conviction_type)
-  end
-
   private
 
   def question_attributes

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -1,10 +1,11 @@
 class ConvictionType < ValueObject
-  attr_reader :parent, :skip_length, :compensation, :calculator_class
+  include ConvictionDecorator
+
+  attr_reader :parent, :skip_length, :calculator_class
 
   def initialize(raw_value, params = {})
     @parent = params.fetch(:parent, nil)
     @skip_length = params.fetch(:skip_length, false)
-    @compensation = params.fetch(:compensation, false)
     @calculator_class = params.fetch(:calculator_class, nil)
 
     super(raw_value)
@@ -15,7 +16,6 @@ class ConvictionType < ValueObject
   end
 
   alias skip_length? skip_length
-  alias compensation? compensation
 
   VALUES = [
     YOUTH_PARENT_TYPES = [
@@ -64,7 +64,7 @@ class ConvictionType < ValueObject
     CONDITIONAL_DISCHARGE              = new(:conditional_discharge,            parent: DISCHARGE, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 
     FINE                               = new(:fine,                             parent: FINANCIAL, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
-    COMPENSATION_TO_A_VICTIM           = new(:compensation_to_a_victim,         parent: FINANCIAL, compensation: true, calculator_class: Calculators::CompensationCalculator),
+    COMPENSATION_TO_A_VICTIM           = new(:compensation_to_a_victim,         parent: FINANCIAL, calculator_class: Calculators::CompensationCalculator),
 
     REPARATION_ORDER                   = new(:reparation_order,                 parent: PREVENTION_REPARATION, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
     RESTRAINING_ORDER                  = new(:restraining_order,                parent: PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
@@ -88,7 +88,7 @@ class ConvictionType < ValueObject
     ADULT_CONDITIONAL_DISCHARGE         = new(:adult_conditional_discharge,        parent: ADULT_DISCHARGE, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 
     ADULT_FINE                          = new(:adult_fine,                         parent: ADULT_FINANCIAL, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusTwelveMonths),
-    ADULT_COMPENSATION_TO_A_VICTIM      = new(:adult_compensation_to_a_victim,     parent: ADULT_FINANCIAL, compensation: true, calculator_class: Calculators::CompensationCalculator),
+    ADULT_COMPENSATION_TO_A_VICTIM      = new(:adult_compensation_to_a_victim,     parent: ADULT_FINANCIAL, calculator_class: Calculators::CompensationCalculator),
 
     ADULT_DISMISSAL                     = new(:adult_dismissal,                    parent: ADULT_MILITARY, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusTwelveMonths),
     ADULT_OVERSEAS_COMMUNITY_ORDER      = new(:adult_overseas_community_order,     parent: ADULT_MILITARY, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),

--- a/app/value_objects/value_object.rb
+++ b/app/value_objects/value_object.rb
@@ -22,6 +22,10 @@ class ValueObject
     [ValueObject, self.class, value].hash
   end
 
+  def inquiry
+    to_s.inquiry
+  end
+
   def to_s
     value.to_s
   end

--- a/app/views/steps/check/results/show.en.html+conviction_spent.erb
+++ b/app/views/steps/check/results/show.en.html+conviction_spent.erb
@@ -25,7 +25,7 @@
             period</a> is now spent.
         </p>
 
-        <% if @presenter.custodial_sentence? %>
+        <% if @presenter.conviction_type.custodial_sentence? %>
           <p class="govuk-body">
             This result is correct if you served your sentence in full as the court ordered you to. The conviction might not be
             spent if you did not stick to the terms of your sentence.

--- a/spec/decorators/conviction_decorator_spec.rb
+++ b/spec/decorators/conviction_decorator_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe ConvictionDecorator do
+  context 'compensation?' do
+    context 'for a conviction without compensation' do
+      subject { ConvictionType::HOSPITAL_ORDER }
+      it { expect(subject.compensation?).to eq(false) }
+    end
+
+    context 'for a conviction with compensation' do
+      subject { ConvictionType::COMPENSATION_TO_A_VICTIM }
+      it { expect(subject.compensation?).to eq(true) }
+    end
+  end
+
+  describe '#custodial_sentence?' do
+    context 'for a youth `CUSTODIAL_SENTENCE` conviction type' do
+      subject { ConvictionType::CUSTODIAL_SENTENCE }
+      it { expect(subject.custodial_sentence?).to eq(true) }
+    end
+
+    context 'for an adult `ADULT_CUSTODIAL_SENTENCE` conviction type' do
+      subject { ConvictionType::ADULT_CUSTODIAL_SENTENCE }
+      it { expect(subject.custodial_sentence?).to eq(true) }
+    end
+
+    context 'for a `DISCHARGE` conviction type' do
+      subject { ConvictionType::DISCHARGE }
+      it { expect(subject.custodial_sentence?).to eq(false) }
+    end
+  end
+end

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -28,25 +28,6 @@ RSpec.describe ConvictionResultPresenter do
     end
   end
 
-  describe '#custodial_sentence?' do
-    let(:disclosure_check) { instance_double(DisclosureCheck, conviction_type: conviction_type) }
-
-    context 'for a youth `CUSTODIAL_SENTENCE` conviction type' do
-      let(:conviction_type) { ConvictionType::CUSTODIAL_SENTENCE.to_s }
-      it { expect(subject.custodial_sentence?).to eq(true) }
-    end
-
-    context 'for an adult `ADULT_CUSTODIAL_SENTENCE` conviction type' do
-      let(:conviction_type) { ConvictionType::ADULT_CUSTODIAL_SENTENCE.to_s }
-      it { expect(subject.custodial_sentence?).to eq(true) }
-    end
-
-    context 'for a `DISCHARGE` conviction type' do
-      let(:conviction_type) { ConvictionType::DISCHARGE.to_s }
-      it { expect(subject.custodial_sentence?).to eq(false) }
-    end
-  end
-
   describe '#summary' do
     let(:summary) { subject.summary }
 

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -195,17 +195,6 @@ RSpec.describe ConvictionType do
           it { expect(conviction_type.skip_length?).to eq(true) }
         end
       end
-
-      context 'compensation?' do
-        context 'compensation is false' do
-          it { expect(conviction_type.compensation?).to eq(false) }
-        end
-
-        context 'compensation is true' do
-          let(:subtype) { 'compensation_to_a_victim' }
-          it { expect(conviction_type.compensation?).to eq(true) }
-        end
-      end
     end
   end
 
@@ -216,7 +205,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'dismissal' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::StartPlusSixMonths) }
     end
 
@@ -224,7 +212,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'service_detention' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::StartPlusSixMonths) }
     end
 
@@ -232,7 +219,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'service_community_order' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::StartPlusSixMonths) }
     end
 
@@ -240,7 +226,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'overseas_community_order' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::StartPlusSixMonths) }
     end
 
@@ -248,7 +233,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'referral_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -256,7 +240,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'supervision_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -264,7 +247,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'youth_rehabilitation_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusSixMonths) }
     end
 
@@ -272,7 +254,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'detention_training_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::SentenceCalculator::DetentionTraining) }
     end
 
@@ -280,7 +261,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'detention' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::SentenceCalculator::Detention) }
     end
 
@@ -288,7 +268,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'hospital_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -296,7 +275,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'bind_over' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -304,7 +282,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'absolute_discharge' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::ImmediatelyCalculator) }
     end
 
@@ -312,7 +289,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'conditional_discharge' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -320,7 +296,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'fine' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::StartPlusSixMonths) }
     end
 
@@ -328,7 +303,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'compensation_to_a_victim' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(true) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::CompensationCalculator) }
     end
 
@@ -336,7 +310,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'reparation_order' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::ImmediatelyCalculator) }
     end
 
@@ -344,7 +317,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'restraining_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -352,7 +324,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'sexual_harm_prevention_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -362,7 +333,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_attendance_centre_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -370,7 +340,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_community_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusTwelveMonths) }
     end
 
@@ -378,7 +347,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_criminal_behaviour' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusTwelveMonths) }
     end
 
@@ -386,7 +354,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_reparation_order' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::ImmediatelyCalculator) }
     end
 
@@ -394,7 +361,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_restraining_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -402,7 +368,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_serious_crime_prevention' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -410,7 +375,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_sexual_harm_prevention_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -418,7 +382,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_supervision_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -428,7 +391,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_fine' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::StartPlusTwelveMonths) }
     end
 
@@ -436,7 +398,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_compensation_to_a_victim' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(true) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::CompensationCalculator) }
     end
 
@@ -446,7 +407,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_dismissal' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::StartPlusTwelveMonths) }
     end
 
@@ -454,7 +414,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_overseas_community_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusTwelveMonths) }
     end
 
@@ -462,7 +421,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_service_community_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusTwelveMonths) }
     end
 
@@ -470,7 +428,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_service_detention' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::StartPlusTwelveMonths) }
     end
 
@@ -480,7 +437,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_disqualification' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -488,7 +444,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_motoring_fine' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::StartPlusFiveYears) }
     end
 
@@ -496,7 +451,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_penalty_notice' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::StartPlusThreeYears) }
     end
 
@@ -504,7 +458,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_penalty_points' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::StartPlusThreeYears) }
     end
 
@@ -512,7 +465,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_bind_over' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -520,7 +472,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_absolute_discharge' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::ImmediatelyCalculator) }
     end
 
@@ -528,7 +479,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_conditional_discharge' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -536,7 +486,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_hospital_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
     end
 
@@ -544,7 +493,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_suspended_prison_sentence' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::SentenceCalculator::SuspendedPrison) }
     end
 
@@ -552,7 +500,6 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_prison_sentence' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.compensation?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::SentenceCalculator::Prison) }
     end
   end

--- a/spec/value_objects/value_object_spec.rb
+++ b/spec/value_objects/value_object_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe ValueObject do
+  class FooValue < ValueObject; end
+  class BarValue < ValueObject; end
+
+  let(:value) { 'Hello!' }
+  subject     { described_class.new(value) }
+
+  let(:foo_one)      { FooValue.new('one') }
+  let(:also_foo_one) { FooValue.new('one') }
+  let(:foo_two)      { FooValue.new('two') }
+  let(:bar_one)      { BarValue.new('one') }
+
+  it 'is immutable' do
+    expect(subject).to be_frozen
+  end
+
+  describe '#==' do
+    it 'considers same class/same value equal' do
+      expect(foo_one).to eq(also_foo_one)
+    end
+
+    it 'considers same class/different value not equal' do
+      expect(foo_one).to_not eq(foo_two)
+    end
+
+    it 'considers different class/same value not equal' do
+      expect(foo_one).to_not eq(bar_one)
+    end
+
+    it 'considers different class/different value not equal' do
+      expect(foo_two).to_not eq(bar_one)
+    end
+  end
+
+  describe '#hash' do
+    it 'considers same class/same value equal' do
+      expect(foo_one.hash).to eq(also_foo_one.hash)
+    end
+
+    it 'considers same class/different value not equal' do
+      expect(foo_one.hash).to_not eq(foo_two.hash)
+    end
+
+    it 'considers different class/same value not equal' do
+      expect(foo_one.hash).to_not eq(bar_one.hash)
+    end
+
+    it 'considers different class/different value not equal' do
+      expect(foo_two.hash).to_not eq(bar_one.hash)
+    end
+  end
+
+  describe '#inquiry' do
+    it 'returns a StringInquirer for the value' do
+      expect(foo_one.inquiry).to be_a(ActiveSupport::StringInquirer)
+    end
+
+    it 'the value can be inquired' do
+      expect(foo_one.inquiry.one?).to eq(true)
+      expect(foo_one.inquiry.two?).to eq(false)
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the value as a string' do
+      expect(foo_one.to_s).to eq('one')
+    end
+  end
+
+  describe '#to_sym' do
+    it 'returns the value (which is already a symbol)' do
+      expect(foo_one.to_sym).to eq(:one)
+    end
+  end
+end


### PR DESCRIPTION
The `ConvictionType` value-object was getting too big and it might grow further with motoring convictions.

A new module, that is included in the value object, named `ConvictionDecorator` will group together some of these utility and query methods to reduce complexity when testing and also avoid having more attributes than neccessary (we still maintain `skip_length` because this one is used by a lot of different convictions, not just 2 like compensation).

Also, added to the superclass `ValueObject` an `inquiry` method to simplify doing things like checking if a conviction is of a specific type or not.

So for example, it is now possible to do this (might be useful for decision trees):

```ruby
c = ConvictionType::ADULT_MOTORING_FINE

c.inquiry.foobar?
=> false
c.inquiry.adult_motoring_fine?
=> true
c.parent.inquiry.adult_motoring?
=> true
```