### PR TITLE
Motor disqualification end date step

### DIFF
--- a/app/controllers/steps/conviction/motoring_disqualification_end_date_controller.rb
+++ b/app/controllers/steps/conviction/motoring_disqualification_end_date_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Conviction
+    class MotoringDisqualificationEndDateController < Steps::ConvictionStepController
+      def edit
+        @form_object = MotoringDisqualificationEndDateForm.new(
+          disclosure_check: current_disclosure_check,
+          motoring_disqualification_end_date: current_disclosure_check.motoring_disqualification_end_date
+        )
+      end
+
+      def update
+        update_and_advance(MotoringDisqualificationEndDateForm, as: :motoring_disqualification_end_date)
+      end
+    end
+  end
+end

--- a/app/forms/steps/conviction/motoring_disqualification_end_date_form.rb
+++ b/app/forms/steps/conviction/motoring_disqualification_end_date_form.rb
@@ -1,0 +1,24 @@
+module Steps
+  module Conviction
+    class MotoringDisqualificationEndDateForm < BaseForm
+      include GovUkDateFields::ActsAsGovUkDate
+
+      attribute :motoring_disqualification_end_date, Date
+
+      acts_as_gov_uk_date :motoring_disqualification_end_date
+
+      validates_presence_of :motoring_disqualification_end_date
+      validates :motoring_disqualification_end_date, sensible_date: true
+
+      private
+
+      def persist!
+        raise DisclosureCheckNotFound unless disclosure_check
+
+        disclosure_check.update(
+          motoring_disqualification_end_date: motoring_disqualification_end_date
+        )
+      end
+    end
+  end
+end

--- a/app/forms/steps/conviction/motoring_disqualification_end_date_form.rb
+++ b/app/forms/steps/conviction/motoring_disqualification_end_date_form.rb
@@ -8,7 +8,7 @@ module Steps
       acts_as_gov_uk_date :motoring_disqualification_end_date
 
       validates_presence_of :motoring_disqualification_end_date
-      validates :motoring_disqualification_end_date, sensible_date: true
+      validates :motoring_disqualification_end_date, sensible_date: { allow_future: true }
 
       private
 

--- a/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
+++ b/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
@@ -1,0 +1,27 @@
+<% title t('.page_title') %>
+
+<div class="govuk-width-container">
+  <%= step_header %>
+
+  <main id="main-content" class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= error_summary %>
+        <%= step_subsection %>
+
+        <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+        <%= step_form @form_object do |f| %>
+          <%= f.gov_uk_date_field :motoring_disqualification_end_date,
+                                  legend_options: { page_heading: false, visually_hidden: true } %>
+
+          <%= render partial: 'steps/shared/unknown_date_details', locals: { ga_label: 'compensation unknown date' } %>
+
+          <%= f.continue_button %>
+        <% end %>
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -67,3 +67,7 @@ en:
       motoring_endorsement:
         edit:
           page_title: Motoring Endorsement
+      motoring_disqualification_end_date:
+        edit:
+          page_title: Motoring disqualification end date
+          heading: When did your disqualification end?

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -50,6 +50,12 @@ en:
               blank: Enter the date of the compensation payment
               invalid: The date of the compensation payment date is not valid
               future: The date of the compensation payment date can’t be in the future
+        steps/conviction/motoring_disqualification_end_date_form:
+          attributes:
+            motoring_disqualification_end_date:
+              blank: Enter the end date of the motoring disqualification
+              invalid: The end date of the motoring disqualification is not valid
+              future: The end date of the motoring disqualification can’t be in the future
 
   errors:
     format: "%{message}"

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -55,7 +55,6 @@ en:
             motoring_disqualification_end_date:
               blank: Enter the end date of the motoring disqualification
               invalid: The end date of the motoring disqualification is not valid
-              future: The end date of the motoring disqualification can’t be in the future
 
   errors:
     format: "%{message}"

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -156,6 +156,8 @@ en:
         compensation_payment_date: When did you pay the compensation in full?
       steps_conviction_motoring_endorsement_form:
         motoring_endorsement: Did you get an endorsement?
+      steps_conviction_motoring_disqualification_end_date_form:
+        motoring_disqualification_end_date: When did your disqualification end?
 
     hint:
       steps_caution_known_date_form:
@@ -171,6 +173,8 @@ en:
         compensation_payment_date: For example, 23 9 2018
       steps_conviction_motoring_endorsement_form:
         motoring_endorsement: An endorsement means that your conviction is recorded on your driving licence. Endorsements are usually given by courts.
+      steps_conviction_motoring_disqualification_end_date_form:
+        motoring_disqualification_end_date: For example, 23 9 2018
       radio_buttons:
         kind:
           caution: You were given an official warning by the police

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
       edit_step :compensation_payment_date
       show_step :compensation_not_paid
       edit_step :motoring_endorsement
+      edit_step :motoring_disqualification_end_date
     end
   end
 

--- a/db/migrate/20190926135912_add_motoring_disqualification_end_date_to_disclosure_check.rb
+++ b/db/migrate/20190926135912_add_motoring_disqualification_end_date_to_disclosure_check.rb
@@ -1,0 +1,5 @@
+class AddMotoringDisqualificationEndDateToDisclosureCheck < ActiveRecord::Migration[5.2]
+  def change
+    add_column :disclosure_checks, :motoring_disqualification_end_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_26_082054) do
+ActiveRecord::Schema.define(version: 2019_09_26_135912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2019_09_26_082054) do
     t.string "compensation_paid"
     t.date "compensation_payment_date"
     t.string "motoring_endorsement"
+    t.date "motoring_disqualification_end_date"
     t.index ["status"], name: "index_disclosure_checks_on_status"
   end
 

--- a/spec/controllers/steps/conviction/motoring_disqualification_end_date_controller_spec.rb
+++ b/spec/controllers/steps/conviction/motoring_disqualification_end_date_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Conviction::MotoringDisqualificationEndDateController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Conviction::MotoringDisqualificationEndDateForm, ConvictionDecisionTree
+end

--- a/spec/forms/steps/conviction/motoring_disqualification_end_date_form_spec.rb
+++ b/spec/forms/steps/conviction/motoring_disqualification_end_date_form_spec.rb
@@ -1,57 +1,5 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Conviction::MotoringDisqualificationEndDateForm do
-  let(:arguments) { {
-    disclosure_check: disclosure_check,
-    motoring_disqualification_end_date: motoring_disqualification_end_date
-  } }
-  let(:disclosure_check) { instance_double(DisclosureCheck) }
-  let(:motoring_disqualification_end_date) { 3.months.ago.to_date } # Change accordingly!
-
-  subject { described_class.new(arguments) }
-
-  describe '#save' do
-    it { should validate_presence_of(:motoring_disqualification_end_date) }
-
-    context 'when no disclosure_check is associated with the form' do
-      let(:disclosure_check) { nil }
-
-      it 'raises an error' do
-        expect { subject.save }.to raise_error(BaseForm::DisclosureCheckNotFound)
-      end
-    end
-
-    context 'date validation' do
-      context 'when date is not given' do
-        let(:motoring_disqualification_end_date) { nil }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors.added?(:motoring_disqualification_end_date, :blank)).to eq(true)
-        end
-      end
-
-      xcontext 'when date is invalid' do
-        # Implement as needed
-      end
-
-      xcontext 'when date is in the future' do
-        # Implement as needed
-      end
-    end
-
-    context 'when form is valid' do
-      it 'saves the record' do
-        expect(disclosure_check).to receive(:update).with(
-          motoring_disqualification_end_date: 3.months.ago.to_date
-        ).and_return(true)
-
-        expect(subject.save).to be(true)
-      end
-    end
-  end
+  it_behaves_like 'a date question form', attribute_name: :motoring_disqualification_end_date, allow_future: true
 end

--- a/spec/forms/steps/conviction/motoring_disqualification_end_date_form_spec.rb
+++ b/spec/forms/steps/conviction/motoring_disqualification_end_date_form_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Conviction::MotoringDisqualificationEndDateForm do
+  let(:arguments) { {
+    disclosure_check: disclosure_check,
+    motoring_disqualification_end_date: motoring_disqualification_end_date
+  } }
+  let(:disclosure_check) { instance_double(DisclosureCheck) }
+  let(:motoring_disqualification_end_date) { 3.months.ago.to_date } # Change accordingly!
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    it { should validate_presence_of(:motoring_disqualification_end_date) }
+
+    context 'when no disclosure_check is associated with the form' do
+      let(:disclosure_check) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(BaseForm::DisclosureCheckNotFound)
+      end
+    end
+
+    context 'date validation' do
+      context 'when date is not given' do
+        let(:motoring_disqualification_end_date) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:motoring_disqualification_end_date, :blank)).to eq(true)
+        end
+      end
+
+      xcontext 'when date is invalid' do
+        # Implement as needed
+      end
+
+      xcontext 'when date is in the future' do
+        # Implement as needed
+      end
+    end
+
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(disclosure_check).to receive(:update).with(
+          motoring_disqualification_end_date: 3.months.ago.to_date
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add basic date question step
- Add motoring_endorsement_end_date column.
- Please note i haven't plumbed this step into the overall motoring journey, this will be done in the next PR.