### PR TITLE
Update adult motoring journey - Add disqualification end date step

### DIFF
--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -18,7 +18,7 @@ class ConvictionDecisionTree < BaseDecisionTree
       after_conviction_length_type
     when :compensation_paid
       after_compensation_paid
-    when :conviction_length, :compensation_payment_date
+    when :conviction_length, :compensation_payment_date, :motoring_disqualification_end_date
       results
     else
       raise InvalidStep, "Invalid step '#{as || step_params}'"
@@ -37,6 +37,7 @@ class ConvictionDecisionTree < BaseDecisionTree
 
   def after_known_date
     return results if conviction_subtype.skip_length?
+    return edit(:motoring_disqualification_end_date) if conviction_subtype.inquiry.adult_disqualification?
 
     edit(:conviction_length_type)
   end

--- a/features/adults/conviction_motoring.feature
+++ b/features/adults/conviction_motoring.feature
@@ -12,18 +12,14 @@ Feature: Conviction
     Then I should see "<known_date_header>"
 
     And I enter a valid date
-    Then I should see "<length_type_header>"
+    Then I should see "<motoring_disqualification_end_date_header>"
 
-    And  I choose "Years"
-    Then I should see "<length_header>"
-    And I fill in "Number of years" with "5"
-
-    Then I click the "Continue" button
-    And I should be on "<result>"
+    And I enter a valid date
+    Then I should be on "<result>"
 
     Examples:
-      | subtype           | known_date_header                         | length_type_header                                                      | length_header                                | result               |
-      | Disqualification  | When were you given the disqualification? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | /steps/check/results |
+      | subtype           | known_date_header                         | motoring_disqualification_end_date_header | result               |
+      | Disqualification  | When were you given the disqualification? | When did your disqualification end?       | /steps/check/results |
 
   @happy_path
   Scenario Outline: Motoring convictions without length

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -26,13 +26,18 @@ RSpec.describe ConvictionDecisionTree do
     let(:step_params) { { known_date: 'anything' } }
     let(:conviction_subtype) { :detention_training_order }
 
-    context 'when subtype not equal fine' do
+    context 'when subtype not equal fine or adult_disqualification' do
       it { is_expected.to have_destination(:conviction_length_type, :edit) }
     end
 
     context 'when subtype equal fine' do
       let(:conviction_subtype) { :fine }
       it { is_expected.to have_destination('/steps/check/results', :show) }
+    end
+
+    context 'when subtype equal adult_disqualification' do
+      let(:conviction_subtype) { :adult_disqualification }
+      it { is_expected.to have_destination(:motoring_disqualification_end_date, :edit) }
     end
   end
 
@@ -113,6 +118,11 @@ RSpec.describe ConvictionDecisionTree do
 
   context 'when the step is `compensation_payment_date`' do
     let(:step_params) { { compensation_payment_date: 'anything' } }
+    it { is_expected.to have_destination('/steps/check/results', :show) }
+  end
+
+  context 'when the step is `motoring_disqualification_end_date`' do
+    let(:step_params) { { motoring_disqualification_end_date: 'anything' } }
     it { is_expected.to have_destination('/steps/check/results', :show) }
   end
 


### PR DESCRIPTION
Update adult motoring journey to do the following

- display motoring disqualification end date step after `known_date` step when `conviction_type `is `adult_disqualification`
- display result page on submitting `motoring_disqualification_end_date`