### PR TITLE
Add motoring lifetime ban step

### DIFF
--- a/app/controllers/steps/conviction/motoring_lifetime_ban_controller.rb
+++ b/app/controllers/steps/conviction/motoring_lifetime_ban_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Conviction
+    class MotoringLifetimeBanController < Steps::ConvictionStepController
+      def edit
+        @form_object = MotoringLifetimeBanForm.new(
+          disclosure_check: current_disclosure_check,
+          motoring_lifetime_ban: current_disclosure_check.motoring_lifetime_ban
+        )
+      end
+
+      def update
+        update_and_advance(MotoringLifetimeBanForm)
+      end
+    end
+  end
+end

--- a/app/forms/steps/conviction/motoring_lifetime_ban_form.rb
+++ b/app/forms/steps/conviction/motoring_lifetime_ban_form.rb
@@ -1,0 +1,9 @@
+module Steps
+  module Conviction
+    class MotoringLifetimeBanForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :motoring_lifetime_ban
+    end
+  end
+end

--- a/app/views/steps/conviction/motoring_lifetime_ban/edit.html.erb
+++ b/app/views/steps/conviction/motoring_lifetime_ban/edit.html.erb
@@ -1,0 +1,23 @@
+<% title t('.page_title') %>
+
+<div class="govuk-width-container">
+  <%= step_header %>
+
+  <main id="main-content" class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= error_summary %>
+        <%= step_subsection %>
+
+        <!-- The header is part of the radios legend by default, but can be configured -->
+
+        <%= step_form @form_object do |f| %>
+          <%= f.radio_button_fieldset :motoring_lifetime_ban, choices: GenericYesNo.values %>
+          <%= f.continue_button %>
+        <% end %>
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -71,3 +71,6 @@ en:
         edit:
           page_title: Motoring disqualification end date
           heading: When did your disqualification end?
+      motoring_lifetime_ban:
+        edit:
+          page_title: Motoring lifetime ban

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -158,6 +158,8 @@ en:
         motoring_endorsement: Did you get an endorsement?
       steps_conviction_motoring_disqualification_end_date_form:
         motoring_disqualification_end_date: When did your disqualification end?
+      steps_conviction_motoring_lifetime_ban_form:
+        conviction_motoring_lifetime_ban: Were you given a lifetime ban?
 
     hint:
       steps_caution_known_date_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
       show_step :compensation_not_paid
       edit_step :motoring_endorsement
       edit_step :motoring_disqualification_end_date
+      edit_step :motoring_lifetime_ban
     end
   end
 

--- a/db/migrate/20190926082054_add_motoring_endorsement_to_disclosure_check.rb
+++ b/db/migrate/20190926082054_add_motoring_endorsement_to_disclosure_check.rb
@@ -1,5 +1,5 @@
 class AddMotoringEndorsementToDisclosureCheck < ActiveRecord::Migration[5.2]
   def change
-    add_column :disclosure_checks, :motoring_endorsement, :string
+    add_column :disclosure_checks, :motoring_lifetime_ban_to_disclosure_check, :string
   end
 end

--- a/db/migrate/20190930094336_add_motoring_lifetime_ban_to_disclosure_check.rb
+++ b/db/migrate/20190930094336_add_motoring_lifetime_ban_to_disclosure_check.rb
@@ -1,0 +1,5 @@
+class AddMotoringLifetimeBanToDisclosureCheck < ActiveRecord::Migration[5.2]
+  def change
+    add_column :disclosure_checks, :motoring_lifetime_ban, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_26_135912) do
+ActiveRecord::Schema.define(version: 2019_09_30_094336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2019_09_26_135912) do
     t.date "compensation_payment_date"
     t.string "motoring_endorsement"
     t.date "motoring_disqualification_end_date"
+    t.string "motoring_lifetime_ban"
     t.index ["status"], name: "index_disclosure_checks_on_status"
   end
 

--- a/spec/controllers/steps/conviction/motoring_lifetime_ban_controller_spec.rb
+++ b/spec/controllers/steps/conviction/motoring_lifetime_ban_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Conviction::MotoringLifetimeBanController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Conviction::MotoringLifetimeBanForm, ConvictionDecisionTree
+end

--- a/spec/forms/steps/conviction/motoring_lifetime_ban_form_spec.rb
+++ b/spec/forms/steps/conviction/motoring_lifetime_ban_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Conviction::MotoringLifetimeBanForm do
+  it_behaves_like 'a yes-no question form', attribute_name: :motoring_lifetime_ban
+end


### PR DESCRIPTION
- Add basic yes/no question step
- Add motoring_lifetime_ban column.
- Please note i haven't plumbed this step into the overall motoring journey, this will be done in the next PR.