### PR TITLE
Update adult motoring calculators

### DIFF
--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -1,6 +1,6 @@
 module Calculators
   class MotoringCalculator < BaseCalculator
-    NEVER_SPENT_THRESHOLD = 60
+    ENDORSEMENT_THRESHOLD = 60
 
     # If a lifetime ban was given:
     #  - never spent
@@ -24,7 +24,7 @@ module Calculators
       private
 
       def spent_time
-        if distance_in_months(conviction_start_date, motoring_disqualification_end_date) <= 60
+        if distance_in_months(conviction_start_date, motoring_disqualification_end_date) <= ENDORSEMENT_THRESHOLD
           conviction_start_date.advance(FIVE_YEARS_ADDED_TIME)
         else
           motoring_disqualification_end_date

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -1,26 +1,82 @@
 module Calculators
   class MotoringCalculator < BaseCalculator
-    THREE_YEARS_ADDED_TIME = { months: 36 }.freeze
-    FIVE_YEARS_ADDED_TIME  = { months: 60 }.freeze
+    NEVER_SPENT_THRESHOLD = 60
 
-    # start date + 36 months
-    #
-    class StartPlusThreeYears < MotoringCalculator
+    # If a lifetime ban was given:
+    #  - never spent
+    # If an endorsement was received
+    #  - If (end_date - start_date) is less than or equal to 5 years: start_date + 5 years
+    #  - If (end_date - start_date) is greater than 5 years: end_date
+
+    # If an endorsement was not received
+    #  - end date
+    class Disqualification < MotoringCalculator
+      TWO_YEARS_ADDED_TIME = { months: 24 }.freeze
+      FIVE_YEARS_ADDED_TIME = { months: 60 }.freeze
+
       def expiry_date
-        conviction_start_date.advance(THREE_YEARS_ADDED_TIME)
+        return false if GenericYesNo.new(disclosure_check.motoring_lifetime_ban).yes?
+        return spent_time if motoring_endorsement?
+
+        motoring_disqualification_end_date
+      end
+
+      private
+
+      def spent_time
+        if distance_in_months(conviction_start_date, motoring_disqualification_end_date) <= 60
+          conviction_start_date.advance(FIVE_YEARS_ADDED_TIME)
+        else
+          motoring_disqualification_end_date
+        end
+      end
+
+      def motoring_disqualification_end_date
+        @motoring_disqualification_end_date ||= disclosure_check.motoring_disqualification_end_date
       end
     end
 
-    # start date + 60 months
-    #
-    class StartPlusFiveYears < MotoringCalculator
+    # If an endorsement was received
+    # start_date + 5 years
+
+    # If an endorsement was not received
+    # Go to different result page: https://moj-disclosure-checker.herokuapp.com/motoring/v3/fpn-no-conviction
+    class PenaltyNotice < MotoringCalculator
+      REHABILITATION_1 = { months: 60 }.freeze
+
       def expiry_date
-        conviction_start_date.advance(FIVE_YEARS_ADDED_TIME)
+        return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
+
+        false
       end
+    end
+
+    # If an endorsement was received
+    # start_date + 5 years
+    # If an endorsement was not received
+    # start_date + 1 year
+    class MotoringFine < MotoringCalculator
+      REHABILITATION_1 = { months: 60 }.freeze
+      REHABILITATION_2 = { months: 12 }.freeze
+    end
+
+    # If an endorsement was received:
+    # start_date + 5 years
+    # If an endorsement was not received:
+    # start_date + 3 years
+    class PenaltyPoints < MotoringCalculator
+      REHABILITATION_1 = { months: 60 }.freeze
+      REHABILITATION_2 = { months: 36 }.freeze
     end
 
     def expiry_date
-      raise NotImplementedError, 'implement in subclasses'
+      return conviction_start_date.advance(self.class::REHABILITATION_1) if motoring_endorsement?
+
+      conviction_start_date.advance(self.class::REHABILITATION_2)
+    end
+
+    def motoring_endorsement?
+      GenericYesNo.new(disclosure_check.motoring_endorsement).yes?
     end
   end
 end

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -11,7 +11,6 @@ module Calculators
     # If an endorsement was not received
     #  - end date
     class Disqualification < MotoringCalculator
-      TWO_YEARS_ADDED_TIME = { months: 24 }.freeze
       FIVE_YEARS_ADDED_TIME = { months: 60 }.freeze
 
       def expiry_date

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -95,10 +95,10 @@ class ConvictionType < ValueObject
     ADULT_SERVICE_COMMUNITY_ORDER       = new(:adult_service_community_order,      parent: ADULT_MILITARY, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
     ADULT_SERVICE_DETENTION             = new(:adult_service_detention,            parent: ADULT_MILITARY, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusTwelveMonths),
 
-    ADULT_DISQUALIFICATION              = new(:adult_disqualification,             parent: ADULT_MOTORING, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
-    ADULT_MOTORING_FINE                 = new(:adult_motoring_fine,                parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::StartPlusFiveYears),
-    ADULT_PENALTY_NOTICE                = new(:adult_penalty_notice,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::StartPlusThreeYears),
-    ADULT_PENALTY_POINTS                = new(:adult_penalty_points,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::StartPlusThreeYears),
+    ADULT_DISQUALIFICATION              = new(:adult_disqualification,             parent: ADULT_MOTORING, calculator_class: Calculators::MotoringCalculator::Disqualification),
+    ADULT_MOTORING_FINE                 = new(:adult_motoring_fine,                parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::MotoringFine),
+    ADULT_PENALTY_NOTICE                = new(:adult_penalty_notice,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyNotice),
+    ADULT_PENALTY_POINTS                = new(:adult_penalty_points,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyPoints),
 
     ADULT_HOSPITAL_ORDER                = new(:adult_hospital_order,               parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_PRISON_SENTENCE               = new(:adult_prison_sentence,              parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::Prison),

--- a/spec/services/calculators/motoring_calculator_spec.rb
+++ b/spec/services/calculators/motoring_calculator_spec.rb
@@ -4,22 +4,80 @@ RSpec.describe Calculators::MotoringCalculator do
   subject { described_class.new(disclosure_check) }
 
   let(:disclosure_check) { build(:disclosure_check,
-                                 known_date: known_date) }
+                                 known_date: known_date,
+                                 motoring_endorsement: motoring_endorsement,
+                                 motoring_disqualification_end_date: motoring_disqualification_end_date,
+                                 motoring_lifetime_ban: motoring_lifetime_ban) }
+
   let(:known_date) { Date.new(2018, 10, 31) }
+  let(:motoring_endorsement) { GenericYesNo::NO }
+  let(:motoring_disqualification_end_date) { Date.new(2020, 10, 31) }
+  let(:motoring_lifetime_ban) { GenericYesNo::NO }
 
-  it "expiry_date method is implemented in subclass" do
-    expect {subject.expiry_date }.to raise_error(NotImplementedError)
-  end
-
-  describe Calculators::MotoringCalculator::StartPlusThreeYears do
+  describe Calculators::MotoringCalculator::Disqualification do
     context '#expiry_date' do
-      it { expect(subject.expiry_date.to_s).to eq('2021-10-31') }
+      context 'with a motoring lifetime ban' do
+        let(:motoring_lifetime_ban) { GenericYesNo::YES }
+        it { expect(subject.expiry_date).to eq(false) }
+      end
+
+      context 'with a motoring endorsement ' do
+        let(:motoring_endorsement) { GenericYesNo::YES }
+        context 'less than or equal 5 years' do
+          it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+        end
+
+        context 'greater than 5 years' do
+          let(:motoring_disqualification_end_date) { Date.new(2025, 10, 31) }
+          it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+        end
+      end
+
+      context 'without a motoring endorsement ' do
+        it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+      end
     end
   end
 
-  describe Calculators::MotoringCalculator::StartPlusFiveYears do
+
+  describe Calculators::MotoringCalculator::MotoringFine do
     context '#expiry_date' do
-      it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+      context 'with a motoring endorsement ' do
+        let(:motoring_endorsement) { GenericYesNo::YES }
+        it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+      end
+
+      context 'without a motoring endorsement ' do
+        it { expect(subject.expiry_date.to_s).to eq('2019-10-31') }
+      end
+    end
+  end
+
+
+  describe Calculators::MotoringCalculator::PenaltyPoints do
+    context '#expiry_date' do
+      context 'with a motoring endorsement ' do
+        let(:motoring_endorsement) { GenericYesNo::YES }
+        it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+      end
+
+      context 'without a motoring endorsement ' do
+        it { expect(subject.expiry_date.to_s).to eq('2021-10-31') }
+      end
+    end
+  end
+
+
+  describe Calculators::MotoringCalculator::PenaltyNotice do
+    context '#expiry_date' do
+      context 'with a motoring endorsement ' do
+        let(:motoring_endorsement) { GenericYesNo::YES }
+        it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+      end
+
+      context 'without a motoring endorsement ' do
+        it { expect(subject.expiry_date).to eq(false) }
+      end
     end
   end
 end

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -437,28 +437,28 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_disqualification' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::Disqualification) }
     end
 
     context 'ADULT_MOTORING_FINE' do
       let(:subtype) { 'adult_motoring_fine' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::StartPlusFiveYears) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::MotoringFine) }
     end
 
     context 'ADULT_PENALTY_NOTICE' do
       let(:subtype) { 'adult_penalty_notice' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::StartPlusThreeYears) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::PenaltyNotice) }
     end
 
     context 'ADULT_PENALTY_POINTS' do
       let(:subtype) { 'adult_penalty_points' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::StartPlusThreeYears) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::PenaltyPoints) }
     end
 
     context 'ADULT_BIND_OVER' do


### PR DESCRIPTION
Update motoring calculator with the new rules from policy:
- disqualification conviction has got the following rules:
    -  If a lifetime ban was given   = `never spent`
    - disqualification with endorsement 
      - If (end_date - start_date) is less than or equal to 5 years =  `start_date + 5 years`
      - If (end_date - start_date) is greater than 5 years =  `end_date`

    - disqualification without  endorsement = `end date`

- Motoring penalty notice conviction has got the following rules:
  - Penalty notice with endorsement  =  `start_date + 5 years`
  - Penalty notice without endorsement = `no conviction`

- Motoring fine conviction has got the following rules:
  - Motoring fine with endorsement  =  `start_date + 5 years`
  - Motoring fine without endorsement = `start_date + 1 year`

- Motoring penalty points conviction has got the following rules:
  - Penalty points with endorsement  =  `start_date + 5 years`
  - Penalty points without endorsement = `start_date + 3 years`


