### PR TITLE
Update adult motoring journey - Add motoring lifetime ban step

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -159,7 +159,7 @@ en:
       steps_conviction_motoring_disqualification_end_date_form:
         motoring_disqualification_end_date: When did your disqualification end?
       steps_conviction_motoring_lifetime_ban_form:
-        conviction_motoring_lifetime_ban: Were you given a lifetime ban?
+        motoring_lifetime_ban: Were you given a lifetime ban?
 
     hint:
       steps_caution_known_date_form:

--- a/features/adults/conviction_motoring.feature
+++ b/features/adults/conviction_motoring.feature
@@ -1,11 +1,25 @@
 Feature: Conviction
 
   @happy_path
-  Scenario Outline: Motoring convictions with length
+  Scenario Outline: Lifetime Motoring convictions
+    Given I am completing a basic 18 or over "Motoring" conviction
+    Then I should see "What was your motoring conviction?"
+
+    When I choose "Disqualification"
+    Then I should see "Were you given a lifetime ban?"
+
+    And I choose "Yes"
+    Then I should be on "<result>"
+
+  @happy_path
+  Scenario Outline: Motoring convictions
     Given I am completing a basic 18 or over "Motoring" conviction
     Then I should see "What was your motoring conviction?"
 
     When I choose "<subtype>"
+    Then I should see "Were you given a lifetime ban?"
+
+    And I choose "No"
     Then I should see "Did you get an endorsement?"
 
     And I choose "Yes"

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ConvictionDecisionTree do
       conviction_type: conviction_type,
       conviction_subtype: conviction_subtype,
       compensation_paid: compensation_paid,
+      motoring_lifetime_ban: motoring_lifetime_ban
     )
   end
 
@@ -16,6 +17,7 @@ RSpec.describe ConvictionDecisionTree do
   let(:conviction_type)    { nil }
   let(:conviction_subtype) { nil }
   let(:compensation_paid)  { nil }
+  let(:motoring_lifetime_ban) { nil }
 
 
   subject { described_class.new(disclosure_check: disclosure_check, step_params: step_params, as: as, next_step: next_step) }
@@ -59,7 +61,7 @@ RSpec.describe ConvictionDecisionTree do
     context 'Motoring sub types' do
       context 'when subtype equal adult_disqualification' do
         let(:conviction_subtype) { :adult_disqualification }
-        it { is_expected.to have_destination(:motoring_endorsement, :edit) }
+        it { is_expected.to have_destination(:motoring_lifetime_ban, :edit) }
       end
 
       context 'when subtype equal adult_motoring_fine' do
@@ -129,5 +131,19 @@ RSpec.describe ConvictionDecisionTree do
   context 'when the step is `motoring_endorsement`' do
     let(:step_params) { { motoring_endorsement: 'anything' } }
     it { is_expected.to have_destination(:known_date, :edit) }
+  end
+
+  context 'when the step is `motoring_lifetime_ban`' do
+    context 'when the step is `motoring_lifetime_ban` equal yes' do
+      let(:motoring_lifetime_ban)  { GenericYesNo::YES }
+      let(:step_params) { { motoring_lifetime_ban: motoring_lifetime_ban } }
+      it { is_expected.to have_destination('/steps/check/results', :show) }
+    end
+
+    context 'when the step is `motoring_lifetime_ban` equal no' do
+      let(:motoring_lifetime_ban)  { GenericYesNo::NO }
+      let(:step_params) { { motoring_lifetime_ban: motoring_lifetime_ban } }
+      it { is_expected.to have_destination(:motoring_endorsement, :edit) }
+    end
   end
 end


### PR DESCRIPTION
Update adult motoring journey to do the following

- display lifetime ban step after conviction_sub type step when conviction_subtype is adult_disqualification
- display result page on submitting  `yes` to lifetime ban 
- display motoring_endorsement step  on submitting  `no` to lifetime ban 
- update feature tests