### PR TITLE
Allow no end date for motoring disqualification

### DIFF
--- a/app/forms/steps/conviction/motoring_disqualification_end_date_form.rb
+++ b/app/forms/steps/conviction/motoring_disqualification_end_date_form.rb
@@ -7,7 +7,6 @@ module Steps
 
       acts_as_gov_uk_date :motoring_disqualification_end_date
 
-      validates_presence_of :motoring_disqualification_end_date
       validates :motoring_disqualification_end_date, sensible_date: { allow_future: true }
 
       private

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -4,30 +4,40 @@ module Calculators
 
     # If a lifetime ban was given:
     #  - never spent
+    # If no end_date was given: Start date + 5 years
+    #  - Start date + 5 years
     # If an endorsement was received
     #  - If (end_date - start_date) is less than or equal to 5 years: start_date + 5 years
     #  - If (end_date - start_date) is greater than 5 years: end_date
 
     # If an endorsement was not received
-    #  - end date
+    # If no end_date was given:
+    #  - Start date + 2 years
+    # with an End date
+    #  - End date
     class Disqualification < MotoringCalculator
       FIVE_YEARS_ADDED_TIME = { months: 60 }.freeze
+      TWO_YEARS_ADDED_TIME  = { months: 24 }.freeze
 
       def expiry_date
         return false if GenericYesNo.new(disclosure_check.motoring_lifetime_ban).yes?
-        return spent_time if motoring_endorsement?
+        return conviction_start_date.advance(missing_end_date_spent_time) if motoring_disqualification_end_date.nil?
 
-        motoring_disqualification_end_date
+        spent_time
       end
 
       private
 
       def spent_time
-        if distance_in_months(conviction_start_date, motoring_disqualification_end_date) <= ENDORSEMENT_THRESHOLD
-          conviction_start_date.advance(FIVE_YEARS_ADDED_TIME)
-        else
-          motoring_disqualification_end_date
-        end
+        return conviction_start_date.advance(FIVE_YEARS_ADDED_TIME) if motoring_endorsement? && distance_in_months(conviction_start_date, motoring_disqualification_end_date) <= ENDORSEMENT_THRESHOLD
+
+        motoring_disqualification_end_date
+      end
+
+      def missing_end_date_spent_time
+        return FIVE_YEARS_ADDED_TIME if motoring_endorsement?
+
+        TWO_YEARS_ADDED_TIME
       end
 
       def motoring_disqualification_end_date

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -176,7 +176,7 @@ en:
       steps_conviction_motoring_endorsement_form:
         motoring_endorsement: An endorsement means that your conviction is recorded on your driving licence. Endorsements are usually given by courts.
       steps_conviction_motoring_disqualification_end_date_form:
-        motoring_disqualification_end_date: For example, 23 9 2018
+        motoring_disqualification_end_date_html: "Leave this blank if your ban had no end date. <p>For example, 23 9 2018</p>"
       radio_buttons:
         kind:
           caution: You were given an official warning by the police

--- a/spec/forms/steps/conviction/motoring_disqualification_end_date_form_spec.rb
+++ b/spec/forms/steps/conviction/motoring_disqualification_end_date_form_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Conviction::MotoringDisqualificationEndDateForm do
-  it_behaves_like 'a date question form', attribute_name: :motoring_disqualification_end_date, allow_future: true
+  it_behaves_like 'a date question form', attribute_name: :motoring_disqualification_end_date, allow_empty_date: true, allow_future: true
 end

--- a/spec/services/calculators/motoring_calculator_spec.rb
+++ b/spec/services/calculators/motoring_calculator_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Calculators::MotoringCalculator do
   let(:known_date) { Date.new(2018, 10, 31) }
   let(:motoring_endorsement) { GenericYesNo::NO }
   let(:motoring_disqualification_end_date) { Date.new(2020, 10, 31) }
-  let(:motoring_lifetime_ban) { GenericYesNo::NO }
+  let(:motoring_lifetime_ban) { nil }
 
   describe Calculators::MotoringCalculator::Disqualification do
     context '#expiry_date' do
@@ -21,20 +21,37 @@ RSpec.describe Calculators::MotoringCalculator do
         it { expect(subject.expiry_date).to eq(false) }
       end
 
-      context 'with a motoring endorsement ' do
-        let(:motoring_endorsement) { GenericYesNo::YES }
-        context 'less than or equal 5 years' do
-          it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+      context 'without a motoring lifetime ban' do
+        let(:motoring_lifetime_ban) { GenericYesNo::NO }
+        context 'with a motoring_disqualification_end_date' do
+          context 'with a motoring endorsement ' do
+            let(:motoring_endorsement) { GenericYesNo::YES }
+            context 'less than or equal 5 years' do
+              it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+            end
+
+            context 'greater than 5 years' do
+              let(:motoring_disqualification_end_date) { Date.new(2025, 10, 31) }
+              it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+            end
+          end
+
+          context 'without a motoring endorsement ' do
+            it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+          end
         end
 
-        context 'greater than 5 years' do
-          let(:motoring_disqualification_end_date) { Date.new(2025, 10, 31) }
-          it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
-        end
-      end
+        context 'with a motoring_disqualification_end_date' do
+          let(:motoring_disqualification_end_date) { nil }
+          context 'with a motoring endorsement ' do
+            let(:motoring_endorsement) { GenericYesNo::YES }
+            it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+          end
 
-      context 'without a motoring endorsement ' do
-        it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+          context 'without a motoring endorsement ' do
+            it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
+          end
+        end
       end
     end
   end

--- a/spec/support/form_validation_shared_examples.rb
+++ b/spec/support/form_validation_shared_examples.rb
@@ -127,7 +127,9 @@ RSpec.shared_examples 'a date question form' do |options|
   subject { described_class.new(arguments) }
 
   describe '#save' do
-    it { should validate_presence_of(question_attribute) }
+    if options[:allow_empty_date].nil?
+      it { should validate_presence_of(question_attribute) }
+    end
 
     context 'when no disclosure_check is associated with the form' do
       let(:disclosure_check) { nil }
@@ -141,13 +143,15 @@ RSpec.shared_examples 'a date question form' do |options|
       context 'when date is not given' do
         let(:date_value) { nil }
 
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
+        if options[:allow_empty_date].nil?
+          it 'returns false' do
+            expect(subject.save).to be(false)
+          end
 
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors.added?(question_attribute, :blank)).to eq(true)
+          it 'has a validation error on the field' do
+            expect(subject).to_not be_valid
+            expect(subject.errors.added?(question_attribute, :blank)).to eq(true)
+          end
         end
       end
 


### PR DESCRIPTION
Allow a user not to enter a date in the motoring disqualification end date step if they don't have an end date.
