### PR TITLE
Return a blank date error if the year is not greater than 0

### DIFF
--- a/app/validators/sensible_date_validator.rb
+++ b/app/validators/sensible_date_validator.rb
@@ -12,12 +12,17 @@ class SensibleDateValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     return unless value.is_a?(Date)
+    return record.errors.add(attribute, :blank) unless positive_year?(value)
 
     record.errors.add(attribute, :invalid) unless valid_year?(value)
     record.errors.add(attribute, :future)  unless valid_future?(value)
   end
 
   private
+
+  def positive_year?(date)
+    date.year.to_i.positive?
+  end
 
   def valid_year?(date)
     date.year.to_i >= @_year

--- a/spec/support/form_validation_shared_examples.rb
+++ b/spec/support/form_validation_shared_examples.rb
@@ -155,6 +155,19 @@ RSpec.shared_examples 'a date question form' do |options|
         end
       end
 
+      context 'when year part of the date is missing' do
+        let(:date_value) { Date.new(0000, 10, 31) }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(question_attribute, :blank)).to eq(true)
+        end
+      end
+
       context 'when date is invalid' do
         let(:date_value) { Date.new(18, 10, 31) } # 2-digits year (18)
 


### PR DESCRIPTION
When a user only enters day and month they currently get  the following error message:

`The date of the conviction is not valid`

They should get the following error message

`Enter the date of the conviction in the format dd/mm/yyyy`

This is because if you enter day: 1,  month : 2  and leave year blank.

you get the following date 
`(byebug) value`
`Sun, 01 Feb 0000`
`(byebug) value.is_a?(Date)`
`true`

I have added a small check to make sure the year is greater than 0