### PR TITLE
Update result page content - change call about guidance only

### DIFF
--- a/app/views/steps/check/results/shared/_guidance.en.html.erb
+++ b/app/views/steps/check/results/shared/_guidance.en.html.erb
@@ -1,0 +1,3 @@
+<div class="govuk-inset-text">
+  The result you’ve been given is for guidance only. Find out <a class="govuk-link" href="#disclaimer">how to use this information</a> before deciding whether or not to tell people about your caution or conviction.
+</div>

--- a/app/views/steps/check/results/show.en.html+caution_not_spent.erb
+++ b/app/views/steps/check/results/show.en.html+caution_not_spent.erb
@@ -23,9 +23,7 @@
           Based on what you’ve told us, this caution will be spent on the given date.
         </p>
 
-        <div class="govuk-inset-text">
-          If you entered any approximate dates, the result you’ve been given will be incorrect.
-        </div>
+        <%= render partial: 'steps/check/results/shared/guidance' %>
 
         <%= render partial: 'steps/check/results/shared/meaning' %>
 

--- a/app/views/steps/check/results/show.en.html+caution_spent.erb
+++ b/app/views/steps/check/results/show.en.html+caution_spent.erb
@@ -23,9 +23,7 @@
           Based on what you’ve told us, this caution is now spent.
         </p>
 
-        <div class="govuk-inset-text">
-          If you entered any approximate dates, the result you’ve been given will be incorrect.
-        </div>
+        <%= render partial: 'steps/check/results/shared/guidance' %>
 
         <%= render partial: 'steps/check/results/shared/meaning' %>
 

--- a/app/views/steps/check/results/show.en.html+conviction_never_spent.erb
+++ b/app/views/steps/check/results/show.en.html+conviction_never_spent.erb
@@ -31,9 +31,7 @@
             record check</a>.
         </p>
 
-        <div class="govuk-inset-text">
-          If you entered any approximate dates, the result you’ve been given might not be correct.
-        </div>
+        <%= render partial: 'steps/check/results/shared/guidance' %>
 
         <%= render partial: 'steps/check/results/shared/summary', locals: { result: @presenter } %>
 

--- a/app/views/steps/check/results/show.en.html+conviction_not_spent.erb
+++ b/app/views/steps/check/results/show.en.html+conviction_not_spent.erb
@@ -25,9 +25,7 @@
             period</a> will be spent on the given date.
         </p>
 
-        <div class="govuk-inset-text">
-          The result you’ve been given is for guidance only. Find out <a class="govuk-link" href="#disclaimer">how to use this information</a> before deciding whether or not to tell people about your caution or conviction.
-        </div>
+        <%= render partial: 'steps/check/results/shared/guidance' %>
 
         <%= render partial: 'steps/check/results/shared/meaning' %>
 

--- a/app/views/steps/check/results/show.en.html+conviction_spent.erb
+++ b/app/views/steps/check/results/show.en.html+conviction_spent.erb
@@ -32,9 +32,7 @@
           </p>
         <% end %>
 
-        <div class="govuk-inset-text">
-          The result you’ve been given is for guidance only. Find out <a class="govuk-link" href="#disclaimer">how to use this information</a> before deciding whether or not to tell people about your caution or conviction.
-        </div>
+        <%= render partial: 'steps/check/results/shared/guidance' %>
 
         <%= render partial: 'steps/check/results/shared/meaning' %>
 


### PR DESCRIPTION
Move disclaimer callout  to partial.

Update the following templates:

- show.en.html+conviction_never_spent.erb
- show.en.html+caution_spent.erb
- show.en.html+caution_not_spent.erb
- show.en.html+conviction_spent.erb
- show.en.html+conviction_not_spent.erb

For more details  see PR #[258](https://github.com/ministryofjustice/disclosure-checker/pull/258) 