### PR TITLE
Add new data models for multiple convictions

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,6 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
+  default_scope { order(created_at: :asc) }
 end

--- a/app/models/check_group.rb
+++ b/app/models/check_group.rb
@@ -1,0 +1,6 @@
+class CheckGroup < ApplicationRecord
+  belongs_to :disclosure_report
+
+  # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
+  default_scope { order(created_at: :asc) }
+end

--- a/app/models/check_group.rb
+++ b/app/models/check_group.rb
@@ -1,5 +1,6 @@
 class CheckGroup < ApplicationRecord
-  belongs_to :disclosure_report
+  belongs_to :disclosure_report, default: -> { create_disclosure_report }
+  has_many :disclosure_checks, dependent: :destroy
 
   # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
   default_scope { order(created_at: :asc) }

--- a/app/models/check_group.rb
+++ b/app/models/check_group.rb
@@ -1,7 +1,4 @@
 class CheckGroup < ApplicationRecord
   belongs_to :disclosure_report, default: -> { create_disclosure_report }
   has_many :disclosure_checks, dependent: :destroy
-
-  # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
-  default_scope { order(created_at: :asc) }
 end

--- a/app/models/disclosure_check.rb
+++ b/app/models/disclosure_check.rb
@@ -1,4 +1,6 @@
 class DisclosureCheck < ApplicationRecord
+  belongs_to :check_group, default: -> { create_check_group }
+
   enum status: {
     in_progress: 0,
     completed: 10,

--- a/app/models/disclosure_check.rb
+++ b/app/models/disclosure_check.rb
@@ -6,9 +6,6 @@ class DisclosureCheck < ApplicationRecord
     completed: 10,
   }
 
-  # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
-  default_scope { order(created_at: :asc) }
-
   # TODO: once the new data models are in place, we would do the purge
   # through the DisclosureReport model, instead of here, and we will be
   # able to remove this method and spec.

--- a/app/models/disclosure_report.rb
+++ b/app/models/disclosure_report.rb
@@ -1,4 +1,6 @@
 class DisclosureReport < ApplicationRecord
+  has_many :check_groups, dependent: :destroy
+
   enum status: {
     in_progress: 0,
     completed: 10,

--- a/app/models/disclosure_report.rb
+++ b/app/models/disclosure_report.rb
@@ -1,4 +1,4 @@
-class DisclosureCheck < ApplicationRecord
+class DisclosureReport < ApplicationRecord
   enum status: {
     in_progress: 0,
     completed: 10,
@@ -7,10 +7,6 @@ class DisclosureCheck < ApplicationRecord
   # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
   default_scope { order(created_at: :asc) }
 
-  # TODO: once the new data models are in place, we would do the purge
-  # through the DisclosureReport model, instead of here, and we will be
-  # able to remove this method and spec.
-  #
   def self.purge!(date)
     where('created_at <= :date', date: date).destroy_all
   end

--- a/app/models/disclosure_report.rb
+++ b/app/models/disclosure_report.rb
@@ -6,9 +6,6 @@ class DisclosureReport < ApplicationRecord
     completed: 10,
   }
 
-  # Using UUIDs as the record IDs. We can't trust sequential ordering by ID
-  default_scope { order(created_at: :asc) }
-
   def self.purge!(date)
     where('created_at <= :date', date: date).destroy_all
   end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -2,8 +2,6 @@ class Participant < ApplicationRecord
   scope :opted_in, -> { where(opted_out: ['no', nil]) }
   scope :opted_out, -> { where(opted_out: 'yes') }
 
-  default_scope { order(created_at: :asc) }
-
   class << self
     def valid_reference?(reference)
       Rails.configuration.participants.include?(

--- a/db/migrate/20191016114935_create_disclosure_report.rb
+++ b/db/migrate/20191016114935_create_disclosure_report.rb
@@ -1,0 +1,10 @@
+class CreateDisclosureReport < ActiveRecord::Migration[5.2]
+  def change
+    create_table :disclosure_reports, id: :uuid do |t|
+      t.integer :status, default: 0
+      t.timestamps
+    end
+
+    add_index :disclosure_reports, :status
+  end
+end

--- a/db/migrate/20191016120112_create_check_group.rb
+++ b/db/migrate/20191016120112_create_check_group.rb
@@ -1,0 +1,9 @@
+class CreateCheckGroup < ActiveRecord::Migration[5.2]
+  def change
+    create_table :check_groups, id: :uuid do |t|
+      t.timestamps
+    end
+
+    add_reference :check_groups, :disclosure_report, type: :uuid, foreign_key: true, index: { unique: true }
+  end
+end

--- a/db/migrate/20191016121824_add_check_group_to_disclosure_checks.rb
+++ b/db/migrate/20191016121824_add_check_group_to_disclosure_checks.rb
@@ -1,0 +1,5 @@
+class AddCheckGroupToDisclosureChecks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :disclosure_checks, :check_group, type: :uuid, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_16_114935) do
+ActiveRecord::Schema.define(version: 2019_10_16_120112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "check_groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.uuid "disclosure_report_id"
+    t.index ["disclosure_report_id"], name: "index_check_groups_on_disclosure_report_id", unique: true
+  end
 
   create_table "disclosure_checks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -55,4 +62,5 @@ ActiveRecord::Schema.define(version: 2019_10_16_114935) do
     t.index ["reference"], name: "index_participants_on_reference", unique: true
   end
 
+  add_foreign_key "check_groups", "disclosure_reports"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_30_094336) do
+ActiveRecord::Schema.define(version: 2019_10_16_114935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -36,6 +36,13 @@ ActiveRecord::Schema.define(version: 2019_09_30_094336) do
     t.date "motoring_disqualification_end_date"
     t.string "motoring_lifetime_ban"
     t.index ["status"], name: "index_disclosure_checks_on_status"
+  end
+
+  create_table "disclosure_reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "status", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_disclosure_reports_on_status"
   end
 
   create_table "participants", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_16_120112) do
+ActiveRecord::Schema.define(version: 2019_10_16_121824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -42,6 +42,8 @@ ActiveRecord::Schema.define(version: 2019_10_16_120112) do
     t.string "motoring_endorsement"
     t.date "motoring_disqualification_end_date"
     t.string "motoring_lifetime_ban"
+    t.uuid "check_group_id"
+    t.index ["check_group_id"], name: "index_disclosure_checks_on_check_group_id"
     t.index ["status"], name: "index_disclosure_checks_on_status"
   end
 
@@ -63,4 +65,5 @@ ActiveRecord::Schema.define(version: 2019_10_16_120112) do
   end
 
   add_foreign_key "check_groups", "disclosure_reports"
+  add_foreign_key "disclosure_checks", "check_groups"
 end

--- a/spec/models/disclosure_report_spec.rb
+++ b/spec/models/disclosure_report_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe DisclosureReport, type: :model do
+  subject { described_class.new(attributes) }
+
+  let(:attributes) { {} }
+
+  describe '.purge!' do
+    let(:finder_double) { double.as_null_object }
+
+    before do
+      travel_to Time.now
+    end
+
+    it 'picks records equal to or older than the passed-in date' do
+      expect(described_class).to receive(:where).with(
+        'created_at <= :date', date: 28.days.ago
+      ).and_return(finder_double)
+
+      described_class.purge!(28.days.ago)
+    end
+
+    it 'calls #destroy_all on the records it finds' do
+      allow(described_class).to receive(:where).and_return(finder_double)
+      expect(finder_double).to receive(:destroy_all)
+
+      described_class.purge!(28.days.ago)
+    end
+  end
+end


### PR DESCRIPTION
In preparation for multiple convictions, we need new data models to hold the structured data.

Individual commits for clarity.

Basically, added 2 new models: `CheckGroup` and `DisclosureReport` and updated existing `DisclosureCheck`.