### PR TITLE
Add check your answer page

### DIFF
--- a/app/controllers/steps/check/check_your_answers_controller.rb
+++ b/app/controllers/steps/check/check_your_answers_controller.rb
@@ -1,0 +1,9 @@
+module Steps
+  module Check
+    class CheckYourAnswersController < Steps::CheckStepController
+      def show
+        @presenter = ResultsPresenter.build(current_disclosure_check)
+      end
+    end
+  end
+end

--- a/app/views/steps/check/check_your_answers/show.html.erb
+++ b/app/views/steps/check/check_your_answers/show.html.erb
@@ -1,0 +1,29 @@
+<% title t('.page_title') %>
+
+<div class="govuk-width-container">
+  <%= step_header %>
+
+  <main class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">What you've told us</h1>
+
+        <p class="govuk-body">Here’s what you’ve told us so far. You can check the information you’ve entered is correct before choosing to:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>add a sentence to an existing conviction – for example, if you were given a community order and a fine for a single offence)</li>
+          <li>enter a separate caution or conviction – for example, if you were convicted for an unrelated offence</li>
+          <li>continue to the results page, if you have no more cautions, convictions or sentences to check</li>
+        </ul>
+
+        <p class="govuk-heading-m">Your cautions or convictions</p>
+
+        <dl class="govuk-summary-list">
+           <%= render @presenter.summary %>
+        </dl>
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/config/locales/en/check.yml
+++ b/config/locales/en/check.yml
@@ -8,3 +8,6 @@ en:
       under_age:
         edit:
           page_title: Age when cautioned or convicted
+      check_your_answers:
+        show:
+          page_title: Check your answers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       edit_step :under_age
       show_step :exit_over18
       show_step :results
+      show_step :check_your_answers
     end
 
     namespace :caution do

--- a/spec/controllers/steps/check/check_your_answers_controller_spec.rb
+++ b/spec/controllers/steps/check/check_your_answers_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Check::CheckYourAnswersController, type: :controller do
+    describe '#show' do
+      let(:disclosure_check) { build(:disclosure_check, kind: kind) }
+
+      before do
+        allow(controller).to receive(:current_disclosure_check).and_return(disclosure_check)
+      end
+
+      context 'for a caution' do
+        let(:kind) { 'caution' }
+
+        it 'render template' do
+          get :show
+
+          expect(response).to render_template(:show)
+        end
+      end
+
+      context 'for a conviction' do
+        let(:kind) { 'conviction' }
+
+        before do
+          allow_any_instance_of(
+            ConvictionResultPresenter
+          ).to receive(:expiry_date).and_return(Date.yesterday)
+        end
+
+        it 'render template' do
+          get :show
+
+          expect(response).to render_template(:show)
+        end
+      end
+
+    end
+end


### PR DESCRIPTION
Add a basic check your answer page, reusing `ResultsPresenter` to display question and answer.

![Screen Shot 2019-10-17 at 09 48 20](https://user-images.githubusercontent.com/22822829/66993779-18181b00-f0c4-11e9-89f0-3c74a7a386f7.png)
