### PR TITLE
Add basic actions to add new checks

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_disclosure_check
 
+  def current_disclosure_report
+    @_current_disclosure_report ||= current_disclosure_check&.disclosure_report
+  end
+  helper_method :current_disclosure_report
+
   def previous_step_path
     # Second to last element in the array, will be nil for arrays of size 0 or 1
     current_disclosure_check&.navigation_stack&.slice(-2) || root_path

--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -1,0 +1,32 @@
+class ChecksController < ApplicationController
+  before_action :check_disclosure_check_presence
+
+  def create
+    if check_group_id
+      # add another conviction in existing proceedings
+      initialize_disclosure_check(
+        kind: CheckKind::CONVICTION.value,
+        check_group: check_group
+      )
+
+      redirect_to edit_steps_check_under_age_path
+    else
+      # add another caution or conviction in new proceedings
+      initialize_disclosure_check(
+        disclosure_report: current_disclosure_report
+      )
+
+      redirect_to edit_steps_check_kind_path
+    end
+  end
+
+  private
+
+  def check_group_id
+    params[:check_group_id]
+  end
+
+  def check_group
+    current_disclosure_report.check_groups.find(check_group_id)
+  end
+end

--- a/app/models/disclosure_check.rb
+++ b/app/models/disclosure_check.rb
@@ -1,5 +1,6 @@
 class DisclosureCheck < ApplicationRecord
   belongs_to :check_group, default: -> { create_check_group }
+  has_one :disclosure_report, through: :check_group
 
   enum status: {
     in_progress: 0,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,10 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :checks, only: [:create], param: :group_id do
+    post '', action: :create, as: :group
+  end
+
   resources :pilot, only: [:show]
 
   resource :errors, only: [] do

--- a/db/migrate/20191017102652_remove_check_group_unique_constraint.rb
+++ b/db/migrate/20191017102652_remove_check_group_unique_constraint.rb
@@ -1,0 +1,11 @@
+class RemoveCheckGroupUniqueConstraint < ActiveRecord::Migration[5.2]
+  def up
+    remove_reference :check_groups, :disclosure_report
+    add_reference :check_groups, :disclosure_report, type: :uuid, foreign_key: true, index: true
+  end
+
+  def down
+    remove_reference :check_groups, :disclosure_report
+    add_reference :check_groups, :disclosure_report, type: :uuid, foreign_key: true, index: { unique: true }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_16_121824) do
+ActiveRecord::Schema.define(version: 2019_10_17_102652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2019_10_16_121824) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "disclosure_report_id"
-    t.index ["disclosure_report_id"], name: "index_check_groups_on_disclosure_report_id", unique: true
+    t.index ["disclosure_report_id"], name: "index_check_groups_on_disclosure_report_id"
   end
 
   create_table "disclosure_checks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/controllers/checks_controller_spec.rb
+++ b/spec/controllers/checks_controller_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe ChecksController, type: :controller do
+  describe '#create' do
+    context 'when there is no disclosure check in the session' do
+      it 'redirects to the invalid session error page' do
+        post :create
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'when there is a disclosure check in the session' do
+      let(:disclosure_check) { create(:disclosure_check) }
+      let(:disclosure_report) { disclosure_check.disclosure_report }
+
+      before do
+        allow(controller).to receive(:current_disclosure_check).and_return(disclosure_check)
+      end
+
+      context 'for a new check in a separate proceeding' do
+        it 'creates a new disclosure check in a new group inside current disclosure report' do
+          expect {
+            post :create
+          }.to change { disclosure_report.check_groups.count }.by(1)
+        end
+
+        it 'redirects to the caution or conviction question (kind)' do
+          post :create
+          expect(response).to redirect_to(edit_steps_check_kind_path)
+        end
+      end
+
+      context 'for a new check in an existing proceeding' do
+        context 'when the group does not exist' do
+          it 'raises an exception' do
+            expect {
+              post :create, params: { check_group_id: '123' }
+            }.to raise_error
+          end
+        end
+
+        it 'creates a new disclosure check in an existing group' do
+          expect {
+            post :create, params: { check_group_id: disclosure_check.check_group_id }
+          }.not_to change { disclosure_report.check_groups.count }
+
+          # we default to `conviction` kind as only conviction can be added to existing proceedings
+          last_check = DisclosureCheck.last
+          expect(last_check.kind).to eq(CheckKind::CONVICTION.to_s)
+        end
+
+        it 'redirects to the under age question' do
+          post :create, params: { check_group_id: disclosure_check.check_group_id }
+          expect(response).to redirect_to(edit_steps_check_under_age_path)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The controller will handle creating new checks belonging to an existing group (existing proceedings) or a new group (new proceedings). Will be hooked to the CYA page in following PRs.

If the check belongs to an existing group, we default to kind `conviction` (as only convictions can be added to proceedings) and redirect to the under age path.

If the check is for a new group, it can be a conviction or a caution so we redirect to the `kind` path instead as we can't assume the kind.

Exposed a new helper method to get the current `DisclosureReport` which can be used in the CYA too when iterating through the different groups (proceedings).