### PR TITLE
Add feature-flag to enable/disable multiple journeys

### DIFF
--- a/app/controllers/experiments_controller.rb
+++ b/app/controllers/experiments_controller.rb
@@ -21,6 +21,16 @@ class ExperimentsController < ApplicationController
     cookies.delete :motoring_enabled
     redirect_to root_path
   end
+
+  def enable_multiples
+    cookies.permanent[:multiples_enabled] = 1
+    redirect_to root_path
+  end
+
+  def disable_multiples
+    cookies.delete :multiples_enabled
+    redirect_to root_path
+  end
   # :nocov:
 
   private

--- a/app/controllers/steps/check/results_controller.rb
+++ b/app/controllers/steps/check/results_controller.rb
@@ -4,8 +4,27 @@ module Steps
       include CompletionStep
 
       def show
-        @presenter = ResultsPresenter.build(current_disclosure_check)
-        render variants: @presenter.variant
+        if show_check_answers?
+          redirect_to steps_check_check_your_answers_path
+        else
+          @presenter = ResultsPresenter.build(current_disclosure_check)
+          render variants: @presenter.variant
+        end
+      end
+
+      private
+
+      # TODO: temporary feature-flag, to be removed when not needed
+      def show_check_answers?
+        enable_multiples? && continue_to_check_your_answers?
+      end
+
+      def enable_multiples?
+        cookies[:multiples_enabled].present?
+      end
+
+      def continue_to_check_your_answers?
+        params[:show_results].blank?
       end
     end
   end

--- a/app/views/steps/check/check_your_answers/show.html.erb
+++ b/app/views/steps/check/check_your_answers/show.html.erb
@@ -22,6 +22,8 @@
         <dl class="govuk-summary-list">
            <%= render @presenter.summary %>
         </dl>
+
+        <%= link_button :results_page, steps_check_results_path(show_results: true), class: 'govuk-button govuk-!-margin-top-2' %>
       </div>
     </div>
 

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -91,6 +91,7 @@ en:
       resume_check: Resume check
       restart_check: Start a new check
       visit_pilot: Visit the pilot service
+      results_page: Go to results page
     fieldset:
       steps_check_kind_form:
         kind: Were you cautioned or convicted?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,9 @@ Rails.application.routes.draw do
   get 'enable_motoring',  controller: :experiments
   get 'disable_motoring', controller: :experiments
 
+  get 'enable_multiples',  controller: :experiments
+  get 'disable_multiples', controller: :experiments
+
   # Back office
   namespace :backoffice do
     resources :participants, only: [:index]

--- a/spec/controllers/steps/check/results_controller_spec.rb
+++ b/spec/controllers/steps/check/results_controller_spec.rb
@@ -5,10 +5,31 @@ RSpec.describe Steps::Check::ResultsController, type: :controller do
 
   describe '#show' do
     let(:disclosure_check) { build(:disclosure_check, kind: kind) }
+    let(:enable_multiples) { false }
 
     before do
       allow(controller).to receive(:current_disclosure_check).and_return(disclosure_check)
+      allow(controller).to receive(:enable_multiples?).and_return(enable_multiples)
     end
+
+
+    context 'show check your answers' do
+      let(:enable_multiples) { true }
+      let(:kind) { 'caution' }
+
+      it 'show result page' do
+        get :show, params: { show_results: true }
+
+        expect(response).to render_template(:show)
+      end
+
+      it 'redirect to check your answer' do
+        get :show
+
+        expect(response).to redirect_to(steps_check_check_your_answers_path)
+      end
+    end
+
 
     context 'for a caution' do
       let(:kind) { 'caution' }


### PR DESCRIPTION
Add feature-flag to enable/disable multiple journeys

Display check your answers page if the multiples feature flag is enable and show_results parameter isn't set.

Add a button on check your answer page to go to result page.