### PR TITLE
Refactor completion mechanism

### DIFF
--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -6,16 +6,16 @@ module CompletionStep
   extend ActiveSupport::Concern
 
   included do
-    before_action :mark_completed, unless: :completed?
+    before_action :mark_report_completed, unless: :report_completed?
   end
 
   private
 
-  def completed?
-    current_disclosure_check.completed?
+  def report_completed?
+    current_disclosure_report.completed?
   end
 
-  def mark_completed
-    current_disclosure_check.completed!
+  def mark_report_completed
+    current_disclosure_report.completed!
   end
 end

--- a/app/controllers/steps/check/check_your_answers_controller.rb
+++ b/app/controllers/steps/check/check_your_answers_controller.rb
@@ -1,8 +1,6 @@
 module Steps
   module Check
     class CheckYourAnswersController < Steps::CheckStepController
-      include CompletionStep
-
       def show
         @presenter = ResultsPresenter.build(current_disclosure_check)
       end

--- a/app/controllers/steps/check/results_controller.rb
+++ b/app/controllers/steps/check/results_controller.rb
@@ -3,18 +3,20 @@ module Steps
     class ResultsController < Steps::CheckStepController
       include CompletionStep
 
+      # TODO: temporary feature-flag, to be removed when not needed
+      prepend_before_action :show_check_answers_if_enabled, only: [:show]
+
       def show
-        if show_check_answers?
-          redirect_to steps_check_check_your_answers_path
-        else
-          @presenter = ResultsPresenter.build(current_disclosure_check)
-          render variants: @presenter.variant
-        end
+        @presenter = ResultsPresenter.build(current_disclosure_check)
+        render variants: @presenter.variant
       end
 
       private
 
-      # TODO: temporary feature-flag, to be removed when not needed
+      def show_check_answers_if_enabled
+        redirect_to steps_check_check_your_answers_path if show_check_answers?
+      end
+
       def show_check_answers?
         multiples_enabled? && continue_to_check_your_answers?
       end

--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -34,6 +34,8 @@ class BaseDecisionTree
   end
 
   def results
+    disclosure_check.completed!
+
     show('/steps/check/results')
   end
 end

--- a/spec/controllers/steps/check/check_your_answers_controller_spec.rb
+++ b/spec/controllers/steps/check/check_your_answers_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Check::CheckYourAnswersController, type: :controller do
-  it_behaves_like 'a completion step controller'
-
     describe '#show' do
       let(:disclosure_check) { build(:disclosure_check, kind: kind) }
 

--- a/spec/services/caution_decision_tree_spec.rb
+++ b/spec/services/caution_decision_tree_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CautionDecisionTree do
 
     context 'and type is `simple caution`' do
       let(:caution_type) { CautionType::ADULT_SIMPLE_CAUTION }
-      it { is_expected.to have_destination('/steps/check/results', :show) }
+      it { is_expected.to complete_the_check_and_show_results }
     end
 
     context 'and type is `conditional caution`' do
@@ -40,6 +40,6 @@ RSpec.describe CautionDecisionTree do
 
   context 'when the step is `conditional_end_date`' do
     let(:step_params) { { conditional_end_date: 'conditional' } }
-    it { is_expected.to have_destination('/steps/check/results', :show) }
+    it { is_expected.to complete_the_check_and_show_results }
   end
 end

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ConvictionDecisionTree do
 
     context 'when subtype equal fine' do
       let(:conviction_subtype) { :fine }
-      it { is_expected.to have_destination('/steps/check/results', :show) }
+      it { is_expected.to complete_the_check_and_show_results }
     end
 
     context 'when subtype equal adult_disqualification' do
@@ -92,7 +92,7 @@ RSpec.describe ConvictionDecisionTree do
 
     context 'and the answer is `no_length`' do
       let(:conviction_length_type) { ConvictionLengthType::NO_LENGTH.to_s }
-      it { is_expected.to have_destination('/steps/check/results', :show) }
+      it { is_expected.to complete_the_check_and_show_results }
     end
 
     context 'and the answer is other than `no_length`' do
@@ -103,7 +103,7 @@ RSpec.describe ConvictionDecisionTree do
 
   context 'when the step is `conviction_length`' do
     let(:step_params) { { conviction_length: 'anything' } }
-    it { is_expected.to have_destination('/steps/check/results', :show) }
+    it { is_expected.to complete_the_check_and_show_results }
   end
 
   context 'when the step is `compensation_paid`' do
@@ -122,12 +122,12 @@ RSpec.describe ConvictionDecisionTree do
 
   context 'when the step is `compensation_payment_date`' do
     let(:step_params) { { compensation_payment_date: 'anything' } }
-    it { is_expected.to have_destination('/steps/check/results', :show) }
+    it { is_expected.to complete_the_check_and_show_results }
   end
 
   context 'when the step is `motoring_disqualification_end_date`' do
     let(:step_params) { { motoring_disqualification_end_date: 'anything' } }
-    it { is_expected.to have_destination('/steps/check/results', :show) }
+    it { is_expected.to complete_the_check_and_show_results }
   end
 
   context 'when the step is `motoring_endorsement`' do
@@ -142,7 +142,7 @@ RSpec.describe ConvictionDecisionTree do
 
       context ' without a endorsement' do
         let(:motoring_endorsement) {GenericYesNo::NO }
-        it { is_expected.to have_destination('/steps/check/results', :show) }
+        it { is_expected.to complete_the_check_and_show_results }
       end
     end
 
@@ -164,7 +164,7 @@ RSpec.describe ConvictionDecisionTree do
     context 'when the step is `motoring_lifetime_ban` equal yes' do
       let(:motoring_lifetime_ban)  { GenericYesNo::YES }
       let(:step_params) { { motoring_lifetime_ban: motoring_lifetime_ban } }
-      it { is_expected.to have_destination('/steps/check/results', :show) }
+      it { is_expected.to complete_the_check_and_show_results }
     end
 
     context 'when the step is `motoring_lifetime_ban` equal no' do

--- a/spec/support/matchers/decision_tree_matcher.rb
+++ b/spec/support/matchers/decision_tree_matcher.rb
@@ -11,3 +11,16 @@ RSpec::Matchers.define :have_destination do |controller, action, params = {}|
     "expected decision tree destination to be an appropriately formatted hash, got '#{decision_tree.destination}'"
   end
 end
+
+RSpec::Matchers.define :complete_the_check_and_show_results do
+  match do |decision_tree|
+    expect(decision_tree.disclosure_check).to receive(:completed!)
+
+    destination = decision_tree.destination
+    destination[:controller] == '/steps/check/results' && destination[:action] == :show
+  end
+
+  failure_message do |decision_tree|
+    "expected decision tree destination to be the results page, got '#{decision_tree.destination}'"
+  end
+end

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -183,12 +183,13 @@ end
 
 RSpec.shared_examples 'a completion step controller' do
   describe '#show' do
-    let(:disclosure_disclosure_check) {
+    let(:current_disclosure_check) {
       build(:disclosure_check, status: status, navigation_stack: %w(/not /empty))
     }
+    let(:current_disclosure_report) { DisclosureReport.new(status: status) }
     let(:status) { :in_progress }
 
-    context 'when no case exists in the session' do
+    context 'when no disclosure check exists in the session' do
       before do
         # Needed because some specs that include these examples stub current_disclosure_check,
         # which is undesirable for this particular test
@@ -203,22 +204,22 @@ RSpec.shared_examples 'a completion step controller' do
 
     describe 'marking as completed' do
       before do
-        allow(controller).to receive(:current_disclosure_check).and_return(disclosure_disclosure_check)
+        allow(controller).to receive(:current_disclosure_check).and_return(current_disclosure_check)
+        allow(controller).to receive(:current_disclosure_report).and_return(current_disclosure_report)
       end
 
-      context 'when the check is not already marked as `completed`' do
-        it 'changes the status to `completed`' do
-          expect {
-            get :show, session: { disclosure_check_id: '123' }
-          }.to change { disclosure_disclosure_check.status }.from('in_progress').to('completed')
+      context 'when the report is not already marked as `completed`' do
+        it 'calls the `mark_report_completed` method' do
+          expect(controller).to receive(:mark_report_completed)
+          get :show, session: { disclosure_check_id: '123' }
         end
       end
 
-      context 'when the check is already marked as `completed`' do
+      context 'when the report is already marked as `completed`' do
         let(:status) { :completed }
 
-        it 'does not call the `mark_completed` method' do
-          expect(controller).not_to receive(:mark_completed)
+        it 'does not call the `mark_report_completed` method' do
+          expect(controller).not_to receive(:mark_report_completed)
           get :show, session: { disclosure_check_id: '123' }
         end
       end


### PR DESCRIPTION
Now we have 2 different completions: one for the individual check (a caution or a conviction) and another for the whole set of checks (one or more) past the CYA page.

In order to be more precise when a check is completed, the action of completing an individual check has been moved to the decision tree who is responsable for knowing when to redirect the user to the results page.

In following PRs we will introduce a proper error handling when an individual check is completed or when the whole report is completed, along with the functionality to cancel an "in-progress" check.