### PR TITLE
Extend error handling to deal with reports

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -8,6 +8,8 @@ module ErrorHandling
         redirect_to invalid_session_errors_path
       when Errors::CheckCompleted
         redirect_to check_completed_errors_path
+      when Errors::ReportCompleted
+        redirect_to report_completed_errors_path
       else
         raise if Rails.application.config.consider_all_requests_local
 
@@ -25,5 +27,10 @@ module ErrorHandling
 
   def check_disclosure_check_not_completed
     raise Errors::CheckCompleted if current_disclosure_check.completed?
+  end
+
+  # TODO: remove feature-flag condition once we finish the `multiples` work
+  def check_disclosure_report_not_completed
+    raise Errors::ReportCompleted if current_disclosure_report.completed? && multiples_enabled?
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -13,6 +13,10 @@ class ErrorsController < ApplicationController
     respond_with_status(:unprocessable_entity)
   end
 
+  def report_completed
+    respond_with_status(:unprocessable_entity)
+  end
+
   def unhandled
     respond_with_status(:internal_server_error)
   end

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -1,6 +1,9 @@
 class StepController < ApplicationController
   before_action :check_disclosure_check_presence
-  before_action :check_disclosure_check_not_completed, except: [:show]
+
+  before_action :check_disclosure_report_not_completed,
+                :check_disclosure_check_not_completed, except: [:show]
+
   before_action :update_navigation_stack, only: [:show, :edit]
 
   private

--- a/app/errors/errors.rb
+++ b/app/errors/errors.rb
@@ -1,4 +1,5 @@
 module Errors
   class InvalidSession < StandardError; end
   class CheckCompleted < StandardError; end
+  class ReportCompleted < StandardError; end
 end

--- a/app/views/errors/report_completed.html.erb
+++ b/app/views/errors/report_completed.html.erb
@@ -8,13 +8,7 @@
         <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
         <p class="govuk-body"><%=t '.lead_text' %></p>
-        <p class="govuk-body">
-          <% if multiples_enabled? %>
-            <%= link_to t('.check_answers_page'), steps_check_check_your_answers_path, class: 'govuk-link' %>
-          <% else %>
-            <%= link_to t('.results_page'), steps_check_results_path, class: 'govuk-link' %>
-          <% end %>
-        </p>
+        <p class="govuk-body"><%= link_to t('.results_page'), steps_check_results_path(show_results: true), class: 'govuk-link' %></p>
 
         <%= link_button :start_again, root_path %>
       </div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -80,6 +80,12 @@ en:
       heading: You have already completed this check
       lead_text: If you want to make changes you will need to start a new check.
       results_page: Go to results page
+      check_answers_page: Go to check your answers
+    report_completed:
+      page_title: Report completed
+      heading: You have already completed this report
+      lead_text: If you want to make changes you will need to start again.
+      results_page: Go to results page
     invalid_session:
       page_title: Sorry, you'll have to start again
       heading: Sorry, you'll have to start again

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
     get :unhandled
     get :not_found
     get :check_completed
+    get :report_completed
   end
 
   # Health and ping endpoints (`status` and `health` are alias)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ApplicationController do
     def my_url; true; end
     def invalid_session; raise Errors::InvalidSession; end
     def check_completed; raise Errors::CheckCompleted; end
+    def report_completed; raise Errors::ReportCompleted; end
     def another_exception; raise Exception; end
   end
 
@@ -33,6 +34,17 @@ RSpec.describe ApplicationController do
 
         get :check_completed
         expect(response).to redirect_to(check_completed_errors_path)
+      end
+    end
+
+    context 'Errors::ReportCompleted' do
+      it 'should not report the exception, and redirect to the error page' do
+        routes.draw { get 'report_completed' => 'anonymous#report_completed' }
+
+        expect(Raven).not_to receive(:capture_exception)
+
+        get :report_completed
+        expect(response).to redirect_to(report_completed_errors_path)
       end
     end
 

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -19,7 +19,32 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
       end
     end
 
-    context 'when a case in progress is in the session' do
+    context 'when the disclosure check is completed' do
+      let(:existing_case) { DisclosureCheck.create(status: :completed) }
+
+      it 'redirects to the check completed error page' do
+        put :update, params: expected_params, session: { disclosure_check_id: existing_case.id }
+        expect(response).to redirect_to(check_completed_errors_path)
+      end
+    end
+
+    context 'when the disclosure report is completed (and feature flag enabled)' do
+      let(:existing_case) { DisclosureCheck.create(status: :in_progress) }
+
+      before do
+        existing_case.disclosure_report.completed!
+
+        # feature flag
+        allow(controller).to receive(:multiples_enabled?).and_return(true)
+      end
+
+      it 'redirects to the report completed error page' do
+        put :update, params: expected_params, session: { disclosure_check_id: existing_case.id }
+        expect(response).to redirect_to(report_completed_errors_path)
+      end
+    end
+
+    context 'when the disclosure check is in progress' do
       let(:existing_case) { DisclosureCheck.create(status: :in_progress) }
 
       before do


### PR DESCRIPTION
Same as we had with check completed, we now have a new scenario where a "report" (definition of report being a bunch of cautions and conviction checks) have been completed.

This happens at the very end of the service once the loop over the multiple caution or convictions have been done and the user wants to see the final results.

This should be transparent to a user without the 'multiples' feature flag enabled.

Some copy is still TBD.