### PR TITLE
Show link to go back to check your answers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,6 +81,14 @@ module ApplicationHelper
     }.merge(attributes)
   end
 
+  # TODO: remove feature-flag condition once we finish the `multiples` work
+  # We allow to cancel the check in progress if there is at least one check completed
+  def allow_to_cancel_check?
+    return false unless multiples_enabled?
+
+    current_disclosure_report.disclosure_checks.completed.any?
+  end
+
   # Use this to feature-flag code that should only run/show on test environments
   def dev_tools_enabled?
     Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')

--- a/app/models/disclosure_report.rb
+++ b/app/models/disclosure_report.rb
@@ -1,5 +1,6 @@
 class DisclosureReport < ApplicationRecord
   has_many :check_groups, dependent: :destroy
+  has_many :disclosure_checks, through: :check_groups, source: :disclosure_checks
 
   enum status: {
     in_progress: 0,

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -90,6 +90,7 @@ en:
       start_again: New check
       resume_check: Resume check
       restart_check: Start a new check
+      cancel_check: Go back to check your answers
       visit_pilot: Visit the pilot service
       results_page: Go to results page
     fieldset:

--- a/lib/govuk_components/form_builder.rb
+++ b/lib/govuk_components/form_builder.rb
@@ -4,11 +4,28 @@ module GovukComponents
     delegate :t, :concat, to: :@template
 
     def continue_button(value: :continue, options: {})
-      button t("helpers.buttons.#{value}"), {
-        name: nil,
-        class: 'govuk-button',
-        data: { module: 'govuk-button', 'prevent-double-click': true },
-      }.merge(options)
+      capture do
+        concat button t("helpers.buttons.#{value}"), {
+          name: nil,
+          class: 'govuk-button',
+          data: { module: 'govuk-button', 'prevent-double-click': true },
+        }.merge(options)
+
+        concat(cancel_check_link) if @template.allow_to_cancel_check?
+      end
+    end
+
+    def cancel_check_link(value: :cancel_check)
+      content_tag(
+        :p,
+        content_tag(
+          :a, t("helpers.buttons.#{value}"),
+          href: @template.steps_check_check_your_answers_path,
+          class: 'govuk-link govuk-link--no-visited-state ga-pageLink',
+          data: { ga_category: 'steps', ga_label: 'cancel check' }
+        ),
+        class: 'govuk-body'
+      )
     end
 
     # Methods below overrides the one from the original gem, and reimplement them

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -178,6 +178,42 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#allow_to_cancel_check?' do
+    before do
+      allow(helper).to receive(:multiples_enabled?).and_return(multiples_enabled)
+    end
+
+    context 'multiples feature flag disabled' do
+      let(:multiples_enabled) { false }
+
+      it 'always returns false' do
+        expect(helper.allow_to_cancel_check?).to eq(false)
+      end
+    end
+
+    context 'multiples feature flag enabled' do
+      let(:multiples_enabled) { true }
+
+      let(:disclosure_report) { instance_double(DisclosureReport) }
+      let(:disclosure_checks) { double('result_set', completed: checks) }
+
+      before do
+        allow(disclosure_report).to receive(:disclosure_checks).and_return(disclosure_checks)
+        allow(helper).to receive(:current_disclosure_report).and_return(disclosure_report)
+      end
+
+      context 'for no checks completed' do
+        let(:checks) { [] }
+        it { expect(helper.allow_to_cancel_check?).to eq(false) }
+      end
+
+      context 'for at least one check completed' do
+        let(:checks) { [1] }
+        it { expect(helper.allow_to_cancel_check?).to eq(true) }
+      end
+    end
+  end
+
   describe 'dev_tools_enabled?' do
     before do
       allow(Rails).to receive_message_chain(:env, :development?).and_return(development_env)

--- a/spec/lib/govuk_components/form_builder_spec.rb
+++ b/spec/lib/govuk_components/form_builder_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 class TestHelper < ActionView::Base
+  def allow_to_cancel_check?; end
+
+  def steps_check_check_your_answers_path
+    '/steps/check/answers'
+  end
 end
 
 RSpec.describe GovukComponents::FormBuilder do
@@ -17,10 +22,31 @@ RSpec.describe GovukComponents::FormBuilder do
     let(:builder) { described_class.new :whatever, Object.new, helper, {} }
     let(:html_output) { builder.continue_button }
 
-    it 'outputs the continue button' do
-      expect(
-        html_output
-      ).to eq('<button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Continue</button>')
+    before do
+      allow(helper).to receive(:allow_to_cancel_check?).and_return(allow_to_cancel_check)
+    end
+
+    context 'it is not possible to cancel the current check' do
+      let(:allow_to_cancel_check) { false }
+
+      it 'outputs the continue button' do
+        expect(
+          html_output
+        ).to eq('<button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Continue</button>')
+      end
+    end
+
+    context 'it is possible to cancel the current check' do
+      let(:allow_to_cancel_check) { true }
+
+      it 'outputs the continue button' do
+        expect(
+          html_output
+        ).to eq(
+          '<button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true">Continue</button>' + \
+          '<p class="govuk-body"><a href="/steps/check/answers" class="govuk-link govuk-link--no-visited-state ga-pageLink" data-ga-category="steps" data-ga-label="cancel check">Go back to check your answers</a></p>'
+        )
+      end
     end
   end
 

--- a/spec/support/view_spec_helpers.rb
+++ b/spec/support/view_spec_helpers.rb
@@ -3,6 +3,10 @@ module ViewSpecHelpers
     def current_disclosure_check
       raise 'Stub `current_disclosure_check` if you want to test the behavior.'
     end
+
+    def current_disclosure_report
+      raise 'Stub `current_disclosure_report` if you want to test the behavior.'
+    end
   end
 
   def initialize_view_helpers(view)


### PR DESCRIPTION
After the first check has been completed, following ones will show a 'Go back to check your answers' link below the 'Continue' button.

This, in essence, will take the user to the CYA and leave the check in the session, but still marked as `in-progress`, so the CYA page must cope with this (the presenter must exclude not completed checks).

<img width="582" alt="Screen Shot 2019-10-21 at 11 04 28" src="https://user-images.githubusercontent.com/687910/67196362-92151080-f3f2-11e9-921d-ec80fd43b7b7.png">
