### PR TITLE
Fix back links after adding new checks

### DIFF
--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -5,6 +5,7 @@ class ChecksController < ApplicationController
     if check_group_id
       # add another conviction in existing proceedings
       initialize_disclosure_check(
+        navigation_stack: navigation_stack,
         kind: CheckKind::CONVICTION.value,
         check_group: check_group
       )
@@ -13,6 +14,7 @@ class ChecksController < ApplicationController
     else
       # add another caution or conviction in new proceedings
       initialize_disclosure_check(
+        navigation_stack: navigation_stack,
         disclosure_report: current_disclosure_report
       )
 
@@ -28,5 +30,11 @@ class ChecksController < ApplicationController
 
   def check_group
     current_disclosure_report.check_groups.find(check_group_id)
+  end
+
+  # New checks created through this controller will start
+  # with the following paths in the stack.
+  def navigation_stack
+    [steps_check_check_your_answers_path]
   end
 end

--- a/app/controllers/concerns/starting_point_step.rb
+++ b/app/controllers/concerns/starting_point_step.rb
@@ -8,11 +8,4 @@ module StartingPointStep
     # if there isn't one in the session - because it's the first
     super || initialize_disclosure_check
   end
-
-  def update_navigation_stack
-    # The step including this concern will reset the navigation stack
-    # before re-initialising it in StepController#update_navigation_stack
-    current_disclosure_check.navigation_stack = []
-    super
-  end
 end

--- a/spec/controllers/checks_controller_spec.rb
+++ b/spec/controllers/checks_controller_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe ChecksController, type: :controller do
           }.to change { disclosure_report.check_groups.count }.by(1)
         end
 
+        it 'defaults some attributes' do
+          post :create, params: { check_group_id: disclosure_check.check_group_id }
+
+          last_check = DisclosureCheck.last
+
+          # the back link should point to CYA page
+          expect(last_check.navigation_stack).to eq([steps_check_check_your_answers_path])
+        end
+
         it 'redirects to the caution or conviction question (kind)' do
           post :create
           expect(response).to redirect_to(edit_steps_check_kind_path)
@@ -44,9 +53,17 @@ RSpec.describe ChecksController, type: :controller do
             post :create, params: { check_group_id: disclosure_check.check_group_id }
           }.not_to change { disclosure_report.check_groups.count }
 
+        end
+
+        it 'defaults some attributes' do
+          post :create, params: { check_group_id: disclosure_check.check_group_id }
+
           # we default to `conviction` kind as only conviction can be added to existing proceedings
           last_check = DisclosureCheck.last
           expect(last_check.kind).to eq(CheckKind::CONVICTION.to_s)
+
+          # the back link should point to CYA page
+          expect(last_check.navigation_stack).to eq([steps_check_check_your_answers_path])
         end
 
         it 'redirects to the under age question' do

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -117,11 +117,11 @@ RSpec.shared_examples 'a starting point step controller' do
         expect(session[:disclosure_check_id]).to eq(existing_case.id)
       end
 
-      it 'clears the navigation stack in the session' do
+      it 'does not change any existing navigation' do
         get :edit, session: { disclosure_check_id: existing_case.id }
         existing_case.reload
 
-        expect(existing_case.navigation_stack).to eq([controller.request.fullpath])
+        expect(existing_case.navigation_stack).to eq(['/not', '/empty', controller.request.fullpath])
       end
     end
   end


### PR DESCRIPTION
With the introduction of the CYA page, when adding a new caution or conviction, the back link in the first step will point to the home page, instead of the CYA as it would be expected.

Also, more importantly, if the user clicks this `back` link and loads the home page, the session will be reset.

This is fixed so the `back` link after adding a new caution or conviction takes the user back to the CYA instead of the home page, without overriding any existing navigation stack.