### PR TITLE
Add 'spent' definition to start page

### DIFF
--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -9,7 +9,8 @@
         </h1>
 
         <p class="govuk-body-l">
-          Use this service to check when a caution or conviction becomes spent in England and Wales.
+          Use this service to check when a caution or conviction becomes spent in England and Wales. When a caution or
+          conviction is ‘spent’ it means you do not need to tell people about it if they ask for a basic criminal record check.
         </p>
 
         <p class="govuk-body">


### PR DESCRIPTION
Feedback shows users are stumbling with what 'spent' means.

Added a succinct definition to the start page.