### PR TITLE
Make more explicit the expiry date

### DIFF
--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -34,9 +34,10 @@ class ResultsPresenter
     tense = if expiry_date.instance_of?(Date)
               expiry_date.past? ? :spent : :not_spent
             else
-              expiry_date ? :no_record : :never_spent
+              expiry_date
             end
 
+    # The tense can be one of these values: spent, not_spent, never_spent or no_record
     [disclosure_check.kind, tense].join('_')
   end
 

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -20,7 +20,7 @@ module Calculators
       TWO_YEARS_ADDED_TIME  = { months: 24 }.freeze
 
       def expiry_date
-        return false if GenericYesNo.new(disclosure_check.motoring_lifetime_ban).yes?
+        return :never_spent if GenericYesNo.new(disclosure_check.motoring_lifetime_ban).yes?
         return conviction_start_date.advance(missing_end_date_spent_time) if motoring_disqualification_end_date.nil?
 
         spent_time
@@ -56,7 +56,7 @@ module Calculators
       def expiry_date
         return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
 
-        true
+        :no_record
       end
     end
 

--- a/app/services/calculators/sentence_calculator.rb
+++ b/app/services/calculators/sentence_calculator.rb
@@ -54,7 +54,7 @@ module Calculators
       raise InvalidCalculation unless valid?
 
       if conviction_length_in_months > NEVER_SPENT_THRESHOLD
-        false
+        :never_spent
       else
         conviction_end_date.advance(spent_time)
       end

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -23,8 +23,13 @@ RSpec.describe ConvictionResultPresenter do
     end
 
     context 'never spent conviction' do
-      let(:expiry_date) { false }
+      let(:expiry_date) { :never_spent }
       it { expect(subject.variant).to eq('conviction_never_spent') }
+    end
+
+    context 'no record (motoring-specific)' do
+      let(:expiry_date) { :no_record }
+      it { expect(subject.variant).to eq('conviction_no_record') }
     end
   end
 

--- a/spec/services/calculators/motoring_calculator_spec.rb
+++ b/spec/services/calculators/motoring_calculator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Calculators::MotoringCalculator do
     context '#expiry_date' do
       context 'with a motoring lifetime ban' do
         let(:motoring_lifetime_ban) { GenericYesNo::YES }
-        it { expect(subject.expiry_date).to eq(false) }
+        it { expect(subject.expiry_date).to eq(:never_spent) }
       end
 
       context 'without a motoring lifetime ban' do
@@ -93,7 +93,7 @@ RSpec.describe Calculators::MotoringCalculator do
       end
 
       context 'without a motoring endorsement ' do
-        it { expect(subject.expiry_date).to eq(true) }
+        it { expect(subject.expiry_date).to eq(:no_record) }
       end
     end
   end

--- a/spec/services/calculators/sentence_calculator_spec.rb
+++ b/spec/services/calculators/sentence_calculator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Calculators::SentenceCalculator do
 
       context 'never spent for conviction length over 4 years' do
         let(:conviction_months) { 49 }
-        it { expect(subject.expiry_date).to eq(false) }
+        it { expect(subject.expiry_date).to eq(:never_spent) }
       end
 
       context 'there is no upper limit' do
@@ -60,7 +60,7 @@ RSpec.describe Calculators::SentenceCalculator do
 
       context 'never spent for conviction length over 4 years' do
         let(:conviction_months) { 49 }
-        it { expect(subject.expiry_date).to eq(false) }
+        it { expect(subject.expiry_date).to eq(:never_spent) }
       end
 
       context 'there is no upper limit' do


### PR DESCRIPTION
The variant method was a bit confusing.

Made it more explicit by declaring the `:no_record` or `:never_spent` values instead of using booleans.
Also this allow us to have more values in the future, if needed.