### PR TITLE
Add link to CYA on compensation not paid

### DIFF
--- a/app/views/errors/check_completed.html.erb
+++ b/app/views/errors/check_completed.html.erb
@@ -10,9 +10,9 @@
         <p class="govuk-body"><%=t '.lead_text' %></p>
         <p class="govuk-body">
           <% if multiples_enabled? %>
-            <%= link_to t('.check_answers_page'), steps_check_check_your_answers_path, class: 'govuk-link' %>
+            <%= link_to t('.check_answers_page'), steps_check_check_your_answers_path, class: 'govuk-link govuk-link--no-visited-state' %>
           <% else %>
-            <%= link_to t('.results_page'), steps_check_results_path, class: 'govuk-link' %>
+            <%= link_to t('.results_page'), steps_check_results_path, class: 'govuk-link govuk-link--no-visited-state' %>
           <% end %>
         </p>
 

--- a/app/views/errors/report_completed.html.erb
+++ b/app/views/errors/report_completed.html.erb
@@ -8,7 +8,7 @@
         <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
         <p class="govuk-body"><%=t '.lead_text' %></p>
-        <p class="govuk-body"><%= link_to t('.results_page'), steps_check_results_path(show_results: true), class: 'govuk-link' %></p>
+        <p class="govuk-body"><%= link_to t('.results_page'), steps_check_results_path(show_results: true), class: 'govuk-link govuk-link--no-visited-state' %></p>
 
         <%= link_button :start_again, root_path %>
       </div>

--- a/app/views/steps/conviction/compensation_not_paid/show.en.html.erb
+++ b/app/views/steps/conviction/compensation_not_paid/show.en.html.erb
@@ -12,6 +12,14 @@
 
         <p class="govuk-body">You've said that you have not paid the full compensation you were ordered to pay.</p>
         <p class="govuk-body">Your conviction will not become spent until the compensation has been paid in full.</p>
+
+        <% if allow_to_cancel_check? %>
+          <p class="govuk-body">
+            <%= link_to 'Go to check your answers', steps_check_check_your_answers_path, class: 'govuk-link govuk-link--no-visited-state' %>
+          </p>
+        <% end %>
+
+        <%= link_button :start_again, root_path(new: 'y') %>
       </div>
     </div>
 


### PR DESCRIPTION
If multiples is enabled and we have at least one completed check, we will let the user jump to CYA page if they fall into this kickout page, otherwise they don't have a way out.

Also added a 'start again' button for consistency with other pages. This will reset the session.

Added the `govuk-link--no-visited-state` class to a few other links.

<img width="670" alt="Screen Shot 2019-10-22 at 12 56 15" src="https://user-images.githubusercontent.com/687910/67283314-5ac66280-f4cb-11e9-897b-0f830d3d5d4c.png">
