### PR TITLE
Default age of new convictions inside a group

### DIFF
--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -7,10 +7,11 @@ class ChecksController < ApplicationController
       initialize_disclosure_check(
         navigation_stack: navigation_stack,
         kind: CheckKind::CONVICTION.value,
+        under_age: first_check_in_group.under_age,
         check_group: check_group
       )
 
-      redirect_to edit_steps_check_under_age_path
+      redirect_to edit_steps_conviction_conviction_type_path
     else
       # add another caution or conviction in new proceedings
       initialize_disclosure_check(
@@ -29,7 +30,11 @@ class ChecksController < ApplicationController
   end
 
   def check_group
-    current_disclosure_report.check_groups.find(check_group_id)
+    @_check_group ||= current_disclosure_report.check_groups.find(check_group_id)
+  end
+
+  def first_check_in_group
+    @_first_check_in_group ||= check_group.disclosure_checks.first
   end
 
   # New checks created through this controller will start

--- a/spec/controllers/checks_controller_spec.rb
+++ b/spec/controllers/checks_controller_spec.rb
@@ -58,17 +58,22 @@ RSpec.describe ChecksController, type: :controller do
         it 'defaults some attributes' do
           post :create, params: { check_group_id: disclosure_check.check_group_id }
 
-          # we default to `conviction` kind as only conviction can be added to existing proceedings
           last_check = DisclosureCheck.last
+
+          # we default to `conviction` kind as only convictions can be added to existing proceedings
           expect(last_check.kind).to eq(CheckKind::CONVICTION.to_s)
+
+          # we default to the age of the first conviction in the group, as all convictions must
+          # have happened at the same age
+          expect(last_check.under_age).to eq(GenericYesNo::YES.to_s)
 
           # the back link should point to CYA page
           expect(last_check.navigation_stack).to eq([steps_check_check_your_answers_path])
         end
 
-        it 'redirects to the under age question' do
+        it 'redirects to the conviction type question' do
           post :create, params: { check_group_id: disclosure_check.check_group_id }
-          expect(response).to redirect_to(edit_steps_check_under_age_path)
+          expect(response).to redirect_to(edit_steps_conviction_conviction_type_path)
         end
       end
     end


### PR DESCRIPTION
When adding a conviction to an existing proceeding (group), we can skip the 'under_age' question, as all checks inside the same group will have the same age.

We pick the first check in the group and take this age to use it in the new check being initialized.

Also, as a consequence, we redirect to the question after (conviction type).