### PR TITLE
Preliminary PoC for multiples calculator

### DIFF
--- a/app/services/base_multiples_calculator.rb
+++ b/app/services/base_multiples_calculator.rb
@@ -1,0 +1,19 @@
+class BaseMultiplesCalculator
+  attr_reader :check_group
+
+  def initialize(check_group)
+    @check_group = check_group
+  end
+
+  # :nocov:
+  def spent_date
+    raise 'implement in subclasses'
+  end
+  # :nocov:
+
+  private
+
+  def expiry_date_for(check)
+    CheckResult.new(disclosure_check: check).expiry_date
+  end
+end

--- a/app/services/calculators/multiples/multiple_offenses_calculator.rb
+++ b/app/services/calculators/multiples/multiple_offenses_calculator.rb
@@ -1,0 +1,35 @@
+module Calculators
+  module Multiples
+    class MultipleOffensesCalculator
+      attr_reader :disclosure_report
+      attr_reader :results
+
+      def initialize(disclosure_report)
+        @disclosure_report = disclosure_report
+        @results = []
+      end
+
+      def process!
+        disclosure_report.check_groups.with_completed_checks.each(&method(:process_group))
+      end
+
+      def spent_date_for(check_group)
+        results.find { |p| p.check_group == check_group }.spent_date
+      end
+
+      private
+
+      # rubocop:disable Style/ConditionalAssignment
+      def process_group(check_group)
+        if check_group.disclosure_checks.count > 1
+          # multiple sentences inside the same proceedings
+          results << SameProceedings.new(check_group)
+        else
+          # sentences given in separate proceedings
+          results << SeparateProceedings.new(check_group)
+        end
+      end
+      # rubocop:enable Style/ConditionalAssignment
+    end
+  end
+end

--- a/app/services/calculators/multiples/multiple_offenses_calculator.rb
+++ b/app/services/calculators/multiples/multiple_offenses_calculator.rb
@@ -6,7 +6,7 @@ module Calculators
 
       def initialize(disclosure_report)
         @disclosure_report = disclosure_report
-        @results = []
+        @results = {}
       end
 
       def process!
@@ -14,22 +14,20 @@ module Calculators
       end
 
       def spent_date_for(check_group)
-        results.find { |p| p.check_group == check_group }.spent_date
+        results[check_group.id].spent_date
       end
 
       private
 
-      # rubocop:disable Style/ConditionalAssignment
       def process_group(check_group)
-        if check_group.disclosure_checks.count > 1
-          # multiple sentences inside the same proceedings
-          results << SameProceedings.new(check_group)
-        else
-          # sentences given in separate proceedings
-          results << SeparateProceedings.new(check_group)
-        end
+        results[check_group.id] = if check_group.disclosure_checks.count > 1
+                                    # multiple sentences inside the same proceedings
+                                    SameProceedings.new(check_group)
+                                  else
+                                    # sentences given in separate proceedings
+                                    SeparateProceedings.new(check_group)
+                                  end
       end
-      # rubocop:enable Style/ConditionalAssignment
     end
   end
 end

--- a/app/services/calculators/multiples/same_proceedings.rb
+++ b/app/services/calculators/multiples/same_proceedings.rb
@@ -1,0 +1,29 @@
+# TODO: pending things to code or clarify
+#
+#   - Calculation changes for prison sentences (consecutive or concurrent).
+#   - What to do with `no_record` (at the moment we ignore them).
+#
+module Calculators
+  module Multiples
+    class SameProceedings < BaseMultiplesCalculator
+      def spent_date
+        return :never_spent if expiry_dates.include?(:never_spent)
+
+        # Pick the latest date in the collection
+        expiry_dates.max
+      end
+
+      private
+
+      def expiry_dates
+        @_expiry_dates ||= check_group.disclosure_checks.map(
+          &method(:expiry_date_for)
+        ) - excluded_dates
+      end
+
+      def excluded_dates
+        [:no_record].freeze
+      end
+    end
+  end
+end

--- a/app/services/calculators/multiples/separate_proceedings.rb
+++ b/app/services/calculators/multiples/separate_proceedings.rb
@@ -1,0 +1,21 @@
+# TODO: pending things to code or clarify
+#
+#   - This calculator is not finished, it just returns the spent date for the
+#     caution/conviction, nothing else. We are awaiting some clarifications.
+#
+module Calculators
+  module Multiples
+    class SeparateProceedings < BaseMultiplesCalculator
+      def spent_date
+        expiry_date_for(disclosure_check)
+      end
+
+      private
+
+      # The only check inside this group
+      def disclosure_check
+        @_disclosure_check ||= check_group.disclosure_checks.first
+      end
+    end
+  end
+end

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
   let(:disclosure_report) { instance_double(DisclosureReport, check_groups: groups_result_set) }
   let(:groups_result_set) { double('groups_result_set', with_completed_checks: [check_group1, check_group2]) }
 
-  let(:check_group1) { instance_double(CheckGroup, disclosure_checks: %w(a b c)) }
-  let(:check_group2) { instance_double(CheckGroup, disclosure_checks: %w(a)) }
+  let(:check_group1) { instance_double(CheckGroup, id: '100', disclosure_checks: %w(a b c)) }
+  let(:check_group2) { instance_double(CheckGroup, id: '200', disclosure_checks: %w(a)) }
 
   before do
     subject.process!
@@ -15,11 +15,11 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
 
   context '#process!' do
     it 'adds to the results the check groups having more than one disclosure check' do
-      expect(subject.results).to include(kind_of(Calculators::Multiples::SameProceedings))
+      expect(subject.results['100']).to be_kind_of(Calculators::Multiples::SameProceedings)
     end
 
     it 'adds to the results the check groups having only one disclosure check' do
-      expect(subject.results).to include(kind_of(Calculators::Multiples::SeparateProceedings))
+      expect(subject.results['200']).to be_kind_of(Calculators::Multiples::SeparateProceedings)
     end
   end
 

--- a/spec/services/calculators/multiples/multiple_proceedings_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_proceedings_calculator_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
+  subject { described_class.new(disclosure_report) }
+
+  let(:disclosure_report) { instance_double(DisclosureReport, check_groups: groups_result_set) }
+  let(:groups_result_set) { double('groups_result_set', with_completed_checks: [check_group1, check_group2]) }
+
+  let(:check_group1) { instance_double(CheckGroup, disclosure_checks: %w(a b c)) }
+  let(:check_group2) { instance_double(CheckGroup, disclosure_checks: %w(a)) }
+
+  before do
+    subject.process!
+  end
+
+  context '#process!' do
+    it 'adds to the results the check groups having more than one disclosure check' do
+      expect(subject.results).to include(kind_of(Calculators::Multiples::SameProceedings))
+    end
+
+    it 'adds to the results the check groups having only one disclosure check' do
+      expect(subject.results).to include(kind_of(Calculators::Multiples::SeparateProceedings))
+    end
+  end
+
+  context '#spent_date_for' do
+    before do
+      BaseMultiplesCalculator.subclasses.each do |klass|
+        allow_any_instance_of(klass).to receive(:spent_date).and_return("date_#{klass}")
+      end
+    end
+
+    it 'returns the spent date for the matching check group' do
+      expect(subject.spent_date_for(check_group1)).to eq('date_Calculators::Multiples::SameProceedings')
+      expect(subject.spent_date_for(check_group2)).to eq('date_Calculators::Multiples::SeparateProceedings')
+    end
+  end
+end

--- a/spec/services/calculators/multiples/same_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/same_proceedings_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Multiples::SameProceedings do
+  subject { described_class.new(check_group) }
+
+  let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check1, disclosure_check2, disclosure_check3]) }
+
+  let(:disclosure_check1) { instance_double(DisclosureCheck) }
+  let(:disclosure_check2) { instance_double(DisclosureCheck) }
+  let(:disclosure_check3) { instance_double(DisclosureCheck) }
+
+  let(:check_result1) { instance_double(CheckResult, expiry_date: Date.new(2015, 10, 31)) }
+  let(:check_result2) { instance_double(CheckResult, expiry_date: Date.new(2018, 10, 31)) }
+  let(:check_result3) { instance_double(CheckResult, expiry_date: Date.new(2016, 10, 31)) }
+
+  let(:check_never_spent) { instance_double(CheckResult, expiry_date: :never_spent) }
+  let(:check_no_record) { instance_double(CheckResult, expiry_date: :no_record) }
+
+  context '#spent_date' do
+    context 'when there is at least one `never_spent` date' do
+      before do
+        allow(CheckResult).to receive(:new).and_return(check_result1, check_result2, check_never_spent)
+      end
+
+      it 'returns `never_spent`' do
+        expect(subject.spent_date).to eq(:never_spent)
+      end
+    end
+
+    context 'when all individual spent dates are dates' do
+      before do
+        allow(CheckResult).to receive(:new).and_return(check_result1, check_result2, check_result3)
+      end
+
+      it 'picks the latest date' do
+        expect(subject.spent_date).to eq(Date.new(2018, 10, 31))
+      end
+    end
+
+    context 'when there is at least one `no_record` date' do
+      before do
+        allow(CheckResult).to receive(:new).and_return(check_result1, check_result2, check_no_record)
+      end
+
+      it 'ignores the conviction with `no_record` and picks the latest date' do
+        expect(subject.spent_date).to eq(Date.new(2018, 10, 31))
+      end
+    end
+  end
+end

--- a/spec/services/calculators/multiples/separate_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/separate_proceedings_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Multiples::SeparateProceedings do
+  subject { described_class.new(check_group) }
+
+  let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check]) }
+  let(:disclosure_check) { instance_double(DisclosureCheck) }
+
+  let(:check_result) { instance_double(CheckResult, expiry_date: expiry_date) }
+  let(:expiry_date) { Date.new(2018, 10, 31) }
+
+  context '#spent_date' do
+    before do
+      allow(CheckResult).to receive(:new).with(
+        disclosure_check: disclosure_check
+      ).and_return(check_result)
+    end
+
+    it 'calculates and returns the spent date of the caution or conviction' do
+      expect(subject.spent_date).to eq(expiry_date)
+    end
+  end
+end


### PR DESCRIPTION
This is a proof of concept, and a preliminary work for what could be the multiples calculator.

It is still WIP and not properly working under all scenarios, but it currently will work for:

- A group of convictions in the same proceedings (any type of conviction, but with the limitation at the moment of at most 1 prison sentence in the group).

- Any number of individual (separate proceedings) cautions (simple or conditional) and, at most, 1 conviction of any type (if there is more than 1 conviction, the calculation will be wrong).

The way to use it (at least initially, as I expect some refactors) is, somewhere in the Results presenter to call:

```ruby
calculator = Calculators::Multiples::MultipleOffensesCalculator.new(disclosure_report)
calculator.process!
```

And then, in each group where the spent date need to be shown, call the following to retrieve the date (or `:never_spent` or `:no_record`):

```ruby
calculator.spent_date_for(check_group)
```

Where `check_group` is the CheckGroup instance.