### PR TITLE
Display checks grouped by check group in CYA page

### DIFF
--- a/app/models/check_group.rb
+++ b/app/models/check_group.rb
@@ -1,7 +1,6 @@
 class CheckGroup < ApplicationRecord
   belongs_to :disclosure_report, default: -> { create_disclosure_report }
   has_many :disclosure_checks, dependent: :destroy
-  scope :with_completed_checks, -> { joins(:disclosure_checks).where(disclosure_checks: { status: :completed }) }
 
-  has_many :completed_disclosure_checks, -> { completed_check }, class_name: 'DisclosureCheck'
+  scope :with_completed_checks, -> { joins(:disclosure_checks).where(disclosure_checks: { status: :completed }).distinct }
 end

--- a/app/models/check_group.rb
+++ b/app/models/check_group.rb
@@ -1,6 +1,7 @@
 class CheckGroup < ApplicationRecord
   belongs_to :disclosure_report, default: -> { create_disclosure_report }
   has_many :disclosure_checks, dependent: :destroy
-
   scope :with_completed_checks, -> { joins(:disclosure_checks).where(disclosure_checks: { status: :completed }) }
+
+  has_many :completed_disclosure_checks, -> { completed_check }, class_name: 'DisclosureCheck'
 end

--- a/app/models/disclosure_check.rb
+++ b/app/models/disclosure_check.rb
@@ -7,6 +7,8 @@ class DisclosureCheck < ApplicationRecord
     completed: 10,
   }
 
+  scope :completed_check, -> { completed }
+
   # TODO: once the new data models are in place, we would do the purge
   # through the DisclosureReport model, instead of here, and we will be
   # able to remove this method and spec.

--- a/app/models/disclosure_check.rb
+++ b/app/models/disclosure_check.rb
@@ -7,8 +7,6 @@ class DisclosureCheck < ApplicationRecord
     completed: 10,
   }
 
-  scope :completed_check, -> { completed }
-
   # TODO: once the new data models are in place, we would do the purge
   # through the DisclosureReport model, instead of here, and we will be
   # able to remove this method and spec.

--- a/app/presenters/check_answers_presenter.rb
+++ b/app/presenters/check_answers_presenter.rb
@@ -6,11 +6,10 @@ class CheckAnswersPresenter
   end
 
   def summary
-    disclosure_report.check_groups.map.with_index(1) do |check_group, i|
-      CheckRow.new(
+    completed_checks.map.with_index(1) do |check_group, i|
+      CheckGroupPresenter.new(
         i,
-        check_group_name(check_group),
-        display_checks(check_group),
+        check_group,
         scope: to_partial_path
       )
     end
@@ -22,13 +21,7 @@ class CheckAnswersPresenter
 
   private
 
-  def display_checks(check_group)
-    check_group.disclosure_checks.map do |disclosure_check|
-      ResultsPresenter.build(disclosure_check).summary
-    end.flatten
-  end
-
-  def check_group_name(check_group)
-    check_group.disclosure_checks.first.kind
+  def completed_checks
+    disclosure_report.check_groups.with_completed_checks.group('check_groups.id')
   end
 end

--- a/app/presenters/check_answers_presenter.rb
+++ b/app/presenters/check_answers_presenter.rb
@@ -6,7 +6,7 @@ class CheckAnswersPresenter
   end
 
   def summary
-    completed_checks.map.with_index(1) do |check_group, i|
+    disclosure_report.check_groups.with_completed_checks.map.with_index(1) do |check_group, i|
       CheckGroupPresenter.new(
         i,
         check_group,
@@ -17,11 +17,5 @@ class CheckAnswersPresenter
 
   def to_partial_path
     'check_your_answers/check'
-  end
-
-  private
-
-  def completed_checks
-    disclosure_report.check_groups.with_completed_checks.group('check_groups.id')
   end
 end

--- a/app/presenters/check_group_presenter.rb
+++ b/app/presenters/check_group_presenter.rb
@@ -1,11 +1,9 @@
 class CheckGroupPresenter
-  attr_reader :number, :name, :check_group, :scope, :add_another_sentence_button, :checks
+  attr_reader :number, :check_group, :scope
 
   def initialize(number, check_group, scope:)
     @number = number
     @check_group = check_group
-    @name = first_check_kind
-    @add_another_sentence_button = add_another_sentence_button?
     @scope = scope
   end
 
@@ -19,11 +17,15 @@ class CheckGroupPresenter
     'check_your_answers/shared/check'
   end
 
-  private
-
   def add_another_sentence_button?
     first_check_kind.inquiry.conviction?
   end
+
+  def check_group_name
+    first_check_kind
+  end
+
+  private
 
   def first_check_kind
     completed_checks.first.kind

--- a/app/presenters/check_group_presenter.rb
+++ b/app/presenters/check_group_presenter.rb
@@ -4,13 +4,13 @@ class CheckGroupPresenter
   def initialize(number, check_group, scope:)
     @number = number
     @check_group = check_group
-    @name = check_group_name
+    @name = first_check_kind
     @add_another_sentence_button = add_another_sentence_button?
     @scope = scope
   end
 
   def summary
-    check_group.completed_disclosure_checks.map do |disclosure_check|
+    completed_checks.map do |disclosure_check|
       CheckPresenter.new(disclosure_check)
     end
   end
@@ -21,13 +21,15 @@ class CheckGroupPresenter
 
   private
 
-  def check_group_name
-    check_group.completed_disclosure_checks.first.kind
+  def add_another_sentence_button?
+    first_check_kind.inquiry.conviction?
   end
 
-  def add_another_sentence_button?
-    return false unless check_group.completed_disclosure_checks.present?
+  def first_check_kind
+    completed_checks.first.kind
+  end
 
-    check_group.completed_disclosure_checks.first.kind == 'conviction'
+  def completed_checks
+    @_completed_checks ||= check_group.disclosure_checks.completed
   end
 end

--- a/app/presenters/check_group_presenter.rb
+++ b/app/presenters/check_group_presenter.rb
@@ -1,0 +1,33 @@
+class CheckGroupPresenter
+  attr_reader :number, :name, :check_group, :scope, :add_another_sentence_button, :checks
+
+  def initialize(number, check_group, scope:)
+    @number = number
+    @check_group = check_group
+    @name = check_group_name
+    @add_another_sentence_button = add_another_sentence_button?
+    @scope = scope
+  end
+
+  def summary
+    check_group.completed_disclosure_checks.map do |disclosure_check|
+      CheckPresenter.new(disclosure_check)
+    end
+  end
+
+  def to_partial_path
+    'check_your_answers/shared/check'
+  end
+
+  private
+
+  def check_group_name
+    check_group.completed_disclosure_checks.first.kind
+  end
+
+  def add_another_sentence_button?
+    return false unless check_group.completed_disclosure_checks.present?
+
+    check_group.completed_disclosure_checks.first.kind == 'conviction'
+  end
+end

--- a/app/presenters/check_presenter.rb
+++ b/app/presenters/check_presenter.rb
@@ -1,0 +1,18 @@
+class CheckPresenter
+  attr_reader :disclosure_check
+
+  def initialize(disclosure_check)
+    @disclosure_check = disclosure_check
+  end
+
+  def summary
+    CheckRow.new(
+      ResultsPresenter.build(disclosure_check).summary,
+      scope: to_partial_path
+    )
+  end
+
+  def to_partial_path
+    'check_your_answers/shared/check_row'
+  end
+end

--- a/app/presenters/check_row.rb
+++ b/app/presenters/check_row.rb
@@ -1,14 +1,12 @@
-class CheckRow < CheckAnswersPresenter
-  attr_reader :number, :name, :question_answers, :scope
+class CheckRow
+  attr_reader :question_answers, :scope
 
-  def initialize(number, name, question_answers, scope:)
-    @number = number
-    @name = name
+  def initialize(question_answers, scope:)
     @question_answers = question_answers
     @scope = scope
   end
 
   def to_partial_path
-    'check_your_answers/shared/check'
+    'check_your_answers/shared/check_row'
   end
 end

--- a/app/views/steps/check/check_your_answers/shared/_check.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check.html.erb
@@ -2,6 +2,15 @@
   <%= "#{check.number}. #{t("kind.#{check.name}", scope: check.scope)}"%>
 </h3>
 
-<dl class="govuk-summary-list">
-  <%= render check.question_answers %>
-</dl>
+<div class="govuk-inset-text govuk-!-margin-top-2">
+
+  <%= render check.summary %>
+
+  <% if check.add_another_sentence_button %>
+    <div class="govuk-!-margin-top-1">
+      <%= button_to 'Add another sentence to this conviction', checks_path(check_group_id: check.check_group.id),
+                          class: 'govuk-button govuk-button--secondary',
+                          data: { module: 'govuk-button', 'prevent-double-click': true } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/steps/check/check_your_answers/shared/_check.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check.html.erb
@@ -8,7 +8,7 @@
 
   <% if check.add_another_sentence_button %>
     <div class="govuk-!-margin-top-1">
-      <%= button_to 'Add another sentence to this conviction', checks_path(check_group_id: check.check_group.id),
+      <%= button_to 'Add another sentence to this conviction', checks_path(check_group_id: check.check_group),
                           class: 'govuk-button govuk-button--secondary',
                           data: { module: 'govuk-button', 'prevent-double-click': true } %>
     </div>

--- a/app/views/steps/check/check_your_answers/shared/_check.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check.html.erb
@@ -1,14 +1,14 @@
 <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
-  <%= "#{check.number}. #{t("kind.#{check.name}", scope: check.scope)}"%>
+  <%= "#{check.number}. #{t("kind.#{check.check_group_name}", scope: check.scope)}"%>
 </h3>
 
 <div class="govuk-inset-text govuk-!-margin-top-2">
 
   <%= render check.summary %>
 
-  <% if check.add_another_sentence_button %>
+  <% if check.add_another_sentence_button? %>
     <div class="govuk-!-margin-top-1">
-      <%= button_to 'Add another sentence to this conviction', checks_path(check_group_id: check.check_group),
+      <%= button_to 'Add another sentence to this conviction', check_group_path(check.check_group),
                           class: 'govuk-button govuk-button--secondary',
                           data: { module: 'govuk-button', 'prevent-double-click': true } %>
     </div>

--- a/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
@@ -1,0 +1,3 @@
+<dl class="govuk-summary-list govuk-!-margin-bottom-7">
+  <%= render check_row.summary.question_answers%>
+</dl>

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -46,5 +46,9 @@ FactoryBot.define do
       conviction_length_type { ConvictionLengthType::MONTHS }
       conviction_length { 15 }
     end
+
+    trait :completed do
+      status { :completed }
+    end
   end
 end

--- a/spec/presenters/check_answers_presenter_spec.rb
+++ b/spec/presenters/check_answers_presenter_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe CheckAnswersPresenter do
         expect(summary.size).to eq(1)
         expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
         expect(summary[0].number).to eql(1)
-        expect(summary[0].name).to eql('caution')
         expect(summary[0].check_group).to eql(disclosure_check.check_group)
       end
     end

--- a/spec/presenters/check_answers_presenter_spec.rb
+++ b/spec/presenters/check_answers_presenter_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe CheckAnswersPresenter do
-  let!(:disclosure_check) { create(:disclosure_check) }
+  let!(:disclosure_check) { create(:disclosure_check, :completed) }
   let!(:disclosure_report) { disclosure_check.disclosure_report }
 
   subject { described_class.new(disclosure_report) }
@@ -11,26 +11,12 @@ RSpec.describe CheckAnswersPresenter do
   describe '#summary' do
     let(:summary) { subject.summary }
     context 'for a single youth caution' do
-      it 'returns the correct question-answer pairs' do
+      it 'returns CheckGroupPresenter' do
         expect(summary.size).to eq(1)
-
+        expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
         expect(summary[0].number).to eql(1)
         expect(summary[0].name).to eql('caution')
-
-        question_answers = summary[0].question_answers
-        expect(question_answers.size).to eq(4)
-
-        expect(question_answers[0].question).to eql(:kind)
-        expect(question_answers[0].answer).to eql('caution')
-
-        expect(question_answers[1].question).to eql(:caution_type)
-        expect(question_answers[1].answer).to eql('youth_simple_caution')
-
-        expect(question_answers[2].question).to eql(:under_age)
-        expect(question_answers[2].answer).to eql('yes')
-
-        expect(question_answers[3].question).to eql(:known_date)
-        expect(question_answers[3].answer).to eq('31 October 2018')
+        expect(summary[0].check_group).to eql(disclosure_check.check_group)
       end
     end
   end

--- a/spec/presenters/check_group_presenter_spec.rb
+++ b/spec/presenters/check_group_presenter_spec.rb
@@ -19,4 +19,28 @@ RSpec.describe CheckGroupPresenter do
       end
     end
   end
+
+  describe '#check_group_name' do
+    context 'caution' do
+      let!(:disclosure_check) { create(:disclosure_check, :caution, :completed) }
+      it { expect(subject.check_group_name).to eq('caution') }
+    end
+    context 'conviction' do
+      let!(:disclosure_check) { create(:disclosure_check, :conviction,  :completed) }
+      it { expect(subject.check_group_name).to eq('conviction') }
+    end
+  end
+
+
+  describe '#add_another_sentence_button?' do
+    context 'caution' do
+      let!(:disclosure_check) { create(:disclosure_check, :caution, :completed) }
+      it { expect(subject.add_another_sentence_button?).to eq(false) }
+    end
+    context 'conviction' do
+      let!(:disclosure_check) { create(:disclosure_check, :conviction,  :completed) }
+      it { expect(subject.add_another_sentence_button?).to eq(true) }
+    end
+  end
+
 end

--- a/spec/presenters/check_group_presenter_spec.rb
+++ b/spec/presenters/check_group_presenter_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe CheckGroupPresenter do
+  let!(:disclosure_check) { create(:disclosure_check, :completed) }
+  let!(:disclosure_report) { disclosure_check.disclosure_report }
+  let(:number) { 1 }
+
+  subject { described_class.new(number, disclosure_check.check_group, scope: 'some/path') }
+
+  describe '#to_partial_path' do
+    it { expect(subject.to_partial_path).to eq('check_your_answers/shared/check') }
+  end
+
+  describe '#summary' do
+    let(:summary) { subject.summary }
+    context 'for a single youth caution' do
+      it 'returns CheckPresenter' do
+        expect(summary.size).to eq(1)
+        expect(summary[0]).to be_an_instance_of(CheckPresenter)
+        expect(summary[0].disclosure_check).to eql(disclosure_check)
+      end
+    end
+  end
+end

--- a/spec/presenters/check_presenter_spec.rb
+++ b/spec/presenters/check_presenter_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe CheckPresenter do
+  let(:disclosure_check) { create(:disclosure_check, :completed) }
+
+  subject { described_class.new(disclosure_check) }
+
+  describe '#to_partial_path' do
+    it { expect(subject.to_partial_path).to eq('check_your_answers/shared/check_row') }
+  end
+
+
+  describe '#summary' do
+    let(:summary) { subject.summary }
+    context 'for a single youth caution' do
+      it 'returns CheckRow' do
+        expect(summary).to be_an_instance_of(CheckRow)
+        expect(summary.question_answers.size).to eq(4)
+      end
+    end
+  end
+end

--- a/spec/presenters/check_row_spec.rb
+++ b/spec/presenters/check_row_spec.rb
@@ -4,18 +4,10 @@ RSpec.describe CheckRow do
   let(:number) { 1 }
   let(:name) { 'name' }
   let(:question_answers) { 'question_rows' }
-  subject { described_class.new(number, name, question_answers, scope: 'path/to/locales') }
+  subject { described_class.new(question_answers, scope: 'path/to/locales') }
 
   describe '#to_partial_path' do
-    it { expect(subject.to_partial_path).to eq('check_your_answers/shared/check') }
-  end
-
-  describe '#number' do
-    it { expect(subject.number).to eq(number) }
-  end
-
-  describe '#name' do
-    it { expect(subject.name).to eq(name) }
+    it { expect(subject.to_partial_path).to eq('check_your_answers/shared/check_row') }
   end
 
   describe '#question_answers' do


### PR DESCRIPTION
Iterate over the different CheckGroups with completed checks  in the current DisclosureReport, rendering the caution or convictions inside each.

![Screen Shot 2019-10-24 at 15 43 49](https://user-images.githubusercontent.com/22822829/67496953-21315b00-f675-11e9-8d6e-6b849ae624c6.png)


