### PR TITLE
Show results page for multiple checks

### DIFF
--- a/app/controllers/steps/check/check_your_answers_controller.rb
+++ b/app/controllers/steps/check/check_your_answers_controller.rb
@@ -1,6 +1,8 @@
 module Steps
   module Check
     class CheckYourAnswersController < Steps::CheckStepController
+      before_action :check_disclosure_report_not_completed, only: [:show]
+
       def show
         @presenter = CheckAnswersPresenter.new(current_disclosure_report)
       end

--- a/app/controllers/steps/check/results_controller.rb
+++ b/app/controllers/steps/check/results_controller.rb
@@ -7,7 +7,12 @@ module Steps
       prepend_before_action :show_check_answers_if_enabled, only: [:show]
 
       def show
-        @presenter = ResultsPresenter.build(current_disclosure_check)
+        @presenter = if show_multiple_results?
+                       CheckAnswersPresenter.new(current_disclosure_report)
+                     else
+                       ResultsPresenter.build(current_disclosure_check)
+                     end
+
         render variants: @presenter.variant
       end
 
@@ -19,6 +24,10 @@ module Steps
 
       def show_check_answers?
         multiples_enabled? && continue_to_check_your_answers?
+      end
+
+      def show_multiple_results?
+        multiples_enabled? && !continue_to_check_your_answers?
       end
 
       def continue_to_check_your_answers?

--- a/app/presenters/check_answers_presenter.rb
+++ b/app/presenters/check_answers_presenter.rb
@@ -15,6 +15,10 @@ class CheckAnswersPresenter
     end
   end
 
+  def variant
+    :multiples
+  end
+
   def to_partial_path
     'check_your_answers/check'
   end

--- a/app/presenters/check_group_presenter.rb
+++ b/app/presenters/check_group_presenter.rb
@@ -18,7 +18,8 @@ class CheckGroupPresenter
   end
 
   def add_another_sentence_button?
-    first_check_kind.inquiry.conviction?
+    check_group.disclosure_report.in_progress? &&
+      first_check_kind.inquiry.conviction?
   end
 
   def check_group_name
@@ -28,7 +29,7 @@ class CheckGroupPresenter
   private
 
   def first_check_kind
-    completed_checks.first.kind
+    @_first_check_kind ||= completed_checks.first.kind
   end
 
   def completed_checks

--- a/app/views/steps/check/results/show.en.html+multiples.erb
+++ b/app/views/steps/check/results/show.en.html+multiples.erb
@@ -1,0 +1,24 @@
+<% title 'When your cautions or convictions are spent' %>
+<% track_transaction name: 'Multiple check completed', category: 'Completed checks' %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        <!-- TODO: Make this header dynamic depending if we really have or not unspent offenses -->
+        <h1 class="govuk-heading-xl">
+          You have unspent cautions or convictions
+        </h1>
+
+        <div class="govuk-inset-text">
+          The result you’ve been given is for guidance only. Find out
+          <a class="govuk-link" href="#">how to use this information</a> before deciding whether or not to tell people
+          about your caution or conviction.
+        </div>
+
+        <%= render @presenter.summary %>
+      </div>
+    </div>
+  </main>
+</div>

--- a/spec/controllers/steps/check/check_your_answers_controller_spec.rb
+++ b/spec/controllers/steps/check/check_your_answers_controller_spec.rb
@@ -1,38 +1,64 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Check::CheckYourAnswersController, type: :controller do
-    describe '#show' do
-      let(:disclosure_check) { build(:disclosure_check, kind: kind) }
+  describe '#show' do
+    let(:disclosure_check) { build(:disclosure_check) }
+
+    before do
+      allow(controller).to receive(:current_disclosure_check).and_return(disclosure_check)
+    end
+
+    context 'when there is no disclosure check in the session' do
+      before do
+        allow(controller).to receive(:current_disclosure_check).and_return(nil)
+      end
+
+      it 'redirects to the invalid session error page' do
+        get :show
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'when the disclosure report is completed (and feature flag enabled)' do
+      let(:disclosure_check) { DisclosureCheck.create(status: :in_progress) }
 
       before do
-        allow(controller).to receive(:current_disclosure_check).and_return(disclosure_check)
+        disclosure_check.disclosure_report.completed!
+
+        # feature flag
+        allow(controller).to receive(:multiples_enabled?).and_return(true)
       end
 
-      context 'for a caution' do
-        let(:kind) { 'caution' }
-
-        it 'render template' do
-          get :show
-
-          expect(response).to render_template(:show)
-        end
+      it 'redirects to the report completed error page' do
+        get :show, session: { disclosure_check_id: disclosure_check.id }
+        expect(response).to redirect_to(report_completed_errors_path)
       end
-
-      context 'for a conviction' do
-        let(:kind) { 'conviction' }
-
-        before do
-          allow_any_instance_of(
-            ConvictionResultPresenter
-          ).to receive(:expiry_date).and_return(Date.yesterday)
-        end
-
-        it 'render template' do
-          get :show
-
-          expect(response).to render_template(:show)
-        end
-      end
-
     end
+
+    context 'for a caution' do
+      let(:kind) { 'caution' }
+
+      it 'render template' do
+        get :show
+
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'for a conviction' do
+      let(:kind) { 'conviction' }
+
+      before do
+        allow_any_instance_of(
+          ConvictionResultPresenter
+        ).to receive(:expiry_date).and_return(Date.yesterday)
+      end
+
+      it 'render template' do
+        get :show
+
+        expect(response).to render_template(:show)
+      end
+    end
+  end
 end

--- a/spec/controllers/steps/check/results_controller_spec.rb
+++ b/spec/controllers/steps/check/results_controller_spec.rb
@@ -6,22 +6,15 @@ RSpec.describe Steps::Check::ResultsController, type: :controller do
   describe '#show' do
     let(:disclosure_check) { build(:disclosure_check, kind: kind) }
     let(:enable_multiples) { false }
+    let(:kind) { 'caution' }
 
     before do
       allow(controller).to receive(:current_disclosure_check).and_return(disclosure_check)
       allow(controller).to receive(:multiples_enabled?).and_return(enable_multiples)
     end
 
-
     context 'show check your answers' do
       let(:enable_multiples) { true }
-      let(:kind) { 'caution' }
-
-      it 'show result page' do
-        get :show, params: { show_results: true }
-
-        expect(response).to render_template(:show)
-      end
 
       it 'redirect to check your answer' do
         get :show
@@ -30,6 +23,29 @@ RSpec.describe Steps::Check::ResultsController, type: :controller do
       end
     end
 
+    context 'show results page' do
+      context 'when multiples is enabled' do
+        let(:enable_multiples) { true }
+
+        it 'show multiple result page' do
+          get :show, params: { show_results: true }
+
+          expect(response).to render_template(:show)
+          expect(assigns[:presenter]).to be_a_kind_of(CheckAnswersPresenter)
+        end
+      end
+
+      context 'when multiples is disabled' do
+        let(:enable_multiples) { false }
+
+        it 'show single result page' do
+          get :show, params: { show_results: true }
+
+          expect(response).to render_template(:show)
+          expect(assigns[:presenter]).to be_a_kind_of(ResultsPresenter)
+        end
+      end
+    end
 
     context 'for a caution' do
       let(:kind) { 'caution' }

--- a/spec/presenters/check_answers_presenter_spec.rb
+++ b/spec/presenters/check_answers_presenter_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe CheckAnswersPresenter do
     it { expect(subject.to_partial_path).to eq('check_your_answers/check') }
   end
 
+  describe '#variant' do
+    it { expect(subject.variant).to eq(:multiples) }
+  end
+
   describe '#summary' do
     let(:summary) { subject.summary }
     context 'for a single youth caution' do

--- a/spec/presenters/check_group_presenter_spec.rb
+++ b/spec/presenters/check_group_presenter_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe CheckGroupPresenter do
   let!(:disclosure_check) { create(:disclosure_check, :completed) }
-  let!(:disclosure_report) { disclosure_check.disclosure_report }
   let(:number) { 1 }
 
   subject { described_class.new(number, disclosure_check.check_group, scope: 'some/path') }
@@ -31,16 +30,27 @@ RSpec.describe CheckGroupPresenter do
     end
   end
 
-
   describe '#add_another_sentence_button?' do
-    context 'caution' do
-      let!(:disclosure_check) { create(:disclosure_check, :caution, :completed) }
-      it { expect(subject.add_another_sentence_button?).to eq(false) }
+    context 'when the disclosure report is already completed' do
+      before do
+        disclosure_check.disclosure_report.completed!
+      end
+
+      it 'always returns false' do
+        expect(subject.add_another_sentence_button?).to eq(false)
+      end
     end
-    context 'conviction' do
-      let!(:disclosure_check) { create(:disclosure_check, :conviction,  :completed) }
-      it { expect(subject.add_another_sentence_button?).to eq(true) }
+
+    context 'when the disclosure report is still in progress' do
+      context 'caution' do
+        let!(:disclosure_check) { create(:disclosure_check, :caution, :completed) }
+        it { expect(subject.add_another_sentence_button?).to eq(false) }
+      end
+
+      context 'conviction' do
+        let!(:disclosure_check) { create(:disclosure_check, :conviction,  :completed) }
+        it { expect(subject.add_another_sentence_button?).to eq(true) }
+      end
     end
   end
-
 end


### PR DESCRIPTION
At the moment just a basic show page, re-using the `CheckAnswersPresenter` to list again all the cautions and convictions.

Next steps, as follow-up PRs, will be to introduce the spent date panels in each of the groups, making use of the `MultipleOffensesCalculator` from PR #281.

Also, adding the remaining copy in the results page as per design.

<img width="550" alt="Screen Shot 2019-10-25 at 13 06 23" src="https://user-images.githubusercontent.com/687910/67570020-492dc680-f728-11e9-9635-df1b93bde2e9.png">
