### PR TITLE
Retrieve the spent date from the calculator

### DIFF
--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -6,7 +6,8 @@ module CompletionStep
   extend ActiveSupport::Concern
 
   included do
-    before_action :mark_report_completed, unless: :report_completed?
+    before_action :mark_report_completed,
+                  :purge_incomplete_checks, unless: :report_completed?
   end
 
   private
@@ -17,5 +18,10 @@ module CompletionStep
 
   def mark_report_completed
     current_disclosure_report.completed!
+  end
+
+  # remove any incomplete checks as they don't serve any purpose now
+  def purge_incomplete_checks
+    current_disclosure_report.disclosure_checks.in_progress.destroy_all
   end
 end

--- a/app/presenters/check_answers_presenter.rb
+++ b/app/presenters/check_answers_presenter.rb
@@ -6,13 +6,20 @@ class CheckAnswersPresenter
   end
 
   def summary
+    calculator.process! if disclosure_report.completed?
+
     disclosure_report.check_groups.with_completed_checks.map.with_index(1) do |check_group, i|
       CheckGroupPresenter.new(
         i,
         check_group,
+        spent_date: calculator.spent_date_for(check_group), # will be `nil` if no date found
         scope: to_partial_path
       )
     end
+  end
+
+  def calculator
+    @_calculator ||= Calculators::Multiples::MultipleOffensesCalculator.new(disclosure_report)
   end
 
   def variant

--- a/app/presenters/check_group_presenter.rb
+++ b/app/presenters/check_group_presenter.rb
@@ -1,9 +1,10 @@
 class CheckGroupPresenter
-  attr_reader :number, :check_group, :scope
+  attr_reader :number, :check_group, :spent_date, :scope
 
-  def initialize(number, check_group, scope:)
+  def initialize(number, check_group, spent_date:, scope:)
     @number = number
     @check_group = check_group
+    @spent_date = spent_date
     @scope = scope
   end
 
@@ -11,6 +12,13 @@ class CheckGroupPresenter
     completed_checks.map do |disclosure_check|
       CheckPresenter.new(disclosure_check)
     end
+  end
+
+  def spent_date_panel
+    SpentDatePanel.new(
+      spent_date: spent_date,
+      kind: first_check_kind
+    )
   end
 
   def to_partial_path

--- a/app/presenters/spent_date_panel.rb
+++ b/app/presenters/spent_date_panel.rb
@@ -1,0 +1,31 @@
+class SpentDatePanel
+  attr_reader :spent_date, :kind
+
+  def initialize(spent_date:, kind:)
+    @spent_date = spent_date
+    @kind = kind
+  end
+
+  def to_partial_path
+    'results/shared/spent_date_panel'
+  end
+
+  def scope
+    [to_partial_path, tense]
+  end
+
+  def date
+    I18n.l(spent_date) if spent_date.instance_of?(Date)
+  end
+
+  private
+
+  # TODO: we use this or similar method in other places. Unify them.
+  def tense
+    if spent_date.instance_of?(Date)
+      spent_date.past? ? :spent : :not_spent
+    else
+      spent_date
+    end
+  end
+end

--- a/app/services/calculators/multiples/multiple_offenses_calculator.rb
+++ b/app/services/calculators/multiples/multiple_offenses_calculator.rb
@@ -14,7 +14,7 @@ module Calculators
       end
 
       def spent_date_for(check_group)
-        results[check_group.id].spent_date
+        results[check_group.id]&.spent_date
       end
 
       private

--- a/app/views/steps/check/check_your_answers/shared/_check.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check.html.erb
@@ -3,6 +3,7 @@
 </h3>
 
 <div class="govuk-inset-text govuk-!-margin-top-2">
+  <%= render check.spent_date_panel if check.spent_date %>
 
   <%= render check.summary %>
 

--- a/app/views/steps/check/results/shared/_spent_date_panel.html.erb
+++ b/app/views/steps/check/results/shared/_spent_date_panel.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-panel govuk-panel--confirmation">
+  <h3 class="govuk-panel__title govuk-!-font-size-27">
+    <%=t('title_html', scope: spent_date_panel.scope,
+         kind: spent_date_panel.kind, date: spent_date_panel.date) %>
+  </h3>
+</div>

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -79,7 +79,6 @@ en:
       adult_suspended_prison_sentence: Suspended prison sentence
       adult_prison_sentence: Prison sentence
 
-
   check_your_answers/check:
     kind:
       caution: Caution
@@ -90,6 +89,17 @@ en:
       results:
         show:
           page_title: When your caution or conviction is spent
+
+  # Multiple cautions or convictions (feature-flagged, still WIP)
+  results/shared/spent_date_panel:
+    spent:
+      title_html: This %{kind} was spent on <span class="nowrap">%{date}</span>
+    not_spent:
+      title_html: This %{kind} will be spent on <span class="nowrap">%{date}</span>
+    never_spent:
+      title_html: This %{kind} will never be spent
+    no_record:
+      title_html: This fixed penalty notice (FPN) was not a conviction
 
   results/caution:
     kind:

--- a/spec/presenters/check_answers_presenter_spec.rb
+++ b/spec/presenters/check_answers_presenter_spec.rb
@@ -14,12 +14,44 @@ RSpec.describe CheckAnswersPresenter do
 
   describe '#summary' do
     let(:summary) { subject.summary }
+
+    context 'calculate the spent dates of the whole report' do
+      context 'when the report is still in progress' do
+        it 'does not process the offenses just yet' do
+          expect(subject.calculator).not_to receive(:process!)
+          summary
+        end
+      end
+
+      context 'when the report is completed' do
+        before do
+          allow(disclosure_report).to receive(:completed?).and_return(true)
+        end
+
+        it 'processes the offenses for later use' do
+          expect(subject.calculator).to receive(:process!)
+          summary
+        end
+      end
+    end
+
     context 'for a single youth caution' do
       it 'returns CheckGroupPresenter' do
         expect(summary.size).to eq(1)
         expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
         expect(summary[0].number).to eql(1)
         expect(summary[0].check_group).to eql(disclosure_check.check_group)
+        expect(summary[0].spent_date).to be_nil
+      end
+
+      context 'when there is a spent date for the group' do
+        before do
+          allow(subject.calculator).to receive(:spent_date_for).and_return('date')
+        end
+
+        it 'returns CheckGroupPresenter' do
+          expect(summary[0].spent_date).to eq('date')
+        end
       end
     end
   end

--- a/spec/presenters/check_group_presenter_spec.rb
+++ b/spec/presenters/check_group_presenter_spec.rb
@@ -1,8 +1,16 @@
 RSpec.describe CheckGroupPresenter do
   let!(:disclosure_check) { create(:disclosure_check, :completed) }
   let(:number) { 1 }
+  let(:spent_date) { nil }
 
-  subject { described_class.new(number, disclosure_check.check_group, scope: 'some/path') }
+  subject {
+    described_class.new(
+      number,
+      disclosure_check.check_group,
+      spent_date: spent_date,
+      scope: 'some/path'
+    )
+  }
 
   describe '#to_partial_path' do
     it { expect(subject.to_partial_path).to eq('check_your_answers/shared/check') }
@@ -16,6 +24,22 @@ RSpec.describe CheckGroupPresenter do
         expect(summary[0]).to be_an_instance_of(CheckPresenter)
         expect(summary[0].disclosure_check).to eql(disclosure_check)
       end
+    end
+  end
+
+  describe '#spent_date_panel' do
+    let(:spent_date) { 'date' }
+
+    before do
+      allow(subject).to receive(:first_check_kind).and_return('caution')
+    end
+
+    it 'builds a SpentDatePanel instance with the correct attributes' do
+      panel = subject.spent_date_panel
+
+      expect(panel).to be_an_instance_of(SpentDatePanel)
+      expect(panel.spent_date).to eq(spent_date)
+      expect(panel.kind).to eq('caution')
     end
   end
 

--- a/spec/presenters/spent_date_panel_spec.rb
+++ b/spec/presenters/spent_date_panel_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe SpentDatePanel do
+  subject { described_class.new(spent_date: spent_date, kind: 'caution') }
+
+  let(:spent_date) { nil }
+  let(:partial_path) { 'results/shared/spent_date_panel' }
+
+  describe '#to_partial_path' do
+    it { expect(subject.to_partial_path).to eq(partial_path) }
+  end
+
+  describe '#scope' do
+    context 'for a past date' do
+      let(:spent_date) { Date.yesterday }
+      it { expect(subject.scope).to eq([partial_path, :spent]) }
+    end
+
+    context 'for a future date' do
+      let(:spent_date) { Date.tomorrow }
+      it { expect(subject.scope).to eq([partial_path, :not_spent]) }
+    end
+
+    context 'when offense will never be spent' do
+      let(:spent_date) { :never_spent }
+      it { expect(subject.scope).to eq([partial_path, :never_spent]) }
+    end
+
+    context 'when offense has no record' do
+      let(:spent_date) { :no_record }
+      it { expect(subject.scope).to eq([partial_path, :no_record]) }
+    end
+  end
+
+  describe '#date' do
+    context 'it is a date instance' do
+      let(:spent_date) { Date.new(2018, 10, 31) }
+      it { expect(subject.date).to eq('31 October 2018') }
+    end
+
+    context 'it is not a date instance' do
+      let(:spent_date) { :never_spent }
+      it { expect(subject.date).to be_nil }
+    end
+  end
+end

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -34,5 +34,10 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
       expect(subject.spent_date_for(check_group1)).to eq('date_Calculators::Multiples::SameProceedings')
       expect(subject.spent_date_for(check_group2)).to eq('date_Calculators::Multiples::SeparateProceedings')
     end
+
+    it 'returns nil if no date was found' do
+      group = double('group', id: 'foobar')
+      expect(subject.spent_date_for(group)).to be_nil
+    end
   end
 end

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -238,6 +238,13 @@ RSpec.shared_examples 'a completion step controller' do
           expect(controller).to receive(:mark_report_completed)
           get :show, session: { disclosure_check_id: '123' }
         end
+
+        it 'calls the `purge_incomplete_checks` method' do
+          expect(controller).to receive(:mark_report_completed)
+
+          expect(controller).to receive(:purge_incomplete_checks)
+          get :show, session: { disclosure_check_id: '123' }
+        end
       end
 
       context 'when the report is already marked as `completed`' do
@@ -245,6 +252,11 @@ RSpec.shared_examples 'a completion step controller' do
 
         it 'does not call the `mark_report_completed` method' do
           expect(controller).not_to receive(:mark_report_completed)
+          get :show, session: { disclosure_check_id: '123' }
+        end
+
+        it 'does not call the `purge_incomplete_checks` method' do
+          expect(controller).not_to receive(:purge_incomplete_checks)
           get :show, session: { disclosure_check_id: '123' }
         end
       end


### PR DESCRIPTION
For each of the different groups in the results page, we retrieve the spent date from the `multiple_offenses_calculator` and build little `SpentDatePanel` instances to hold the logic to know what to show in the results page.

Still to do in following PR(s): remaining copy in the results page, specially, the header must be dynamic depending if we have or not spent convictions.

<img width="383" alt="Screen Shot 2019-10-28 at 09 47 58" src="https://user-images.githubusercontent.com/687910/67674736-3c51e280-f975-11e9-95a9-43f6bbdaf7b2.png">
<img width="345" alt="Screen Shot 2019-10-28 at 09 48 09" src="https://user-images.githubusercontent.com/687910/67674737-3cea7900-f975-11e9-8bb7-5eb52531b87e.png">
<img width="354" alt="Screen Shot 2019-10-28 at 09 48 20" src="https://user-images.githubusercontent.com/687910/67674738-3cea7900-f975-11e9-9d4a-de34a1532d81.png">
