### PR TITLE
Make multiple results header dynamic

### DIFF
--- a/app/presenters/check_answers_presenter.rb
+++ b/app/presenters/check_answers_presenter.rb
@@ -3,11 +3,11 @@ class CheckAnswersPresenter
 
   def initialize(disclosure_report)
     @disclosure_report = disclosure_report
+
+    calculator.process! if disclosure_report.completed?
   end
 
   def summary
-    calculator.process! if disclosure_report.completed?
-
     disclosure_report.check_groups.with_completed_checks.map.with_index(1) do |check_group, i|
       CheckGroupPresenter.new(
         i,

--- a/app/services/base_multiples_calculator.rb
+++ b/app/services/base_multiples_calculator.rb
@@ -5,6 +5,10 @@ class BaseMultiplesCalculator
     @check_group = check_group
   end
 
+  def kind
+    CheckKind.find_constant(disclosure_checks.first.kind)
+  end
+
   # :nocov:
   def spent_date
     raise 'implement in subclasses'
@@ -12,6 +16,10 @@ class BaseMultiplesCalculator
   # :nocov:
 
   private
+
+  def disclosure_checks
+    @_disclosure_checks ||= check_group.disclosure_checks
+  end
 
   def expiry_date_for(check)
     CheckResult.new(disclosure_check: check).expiry_date

--- a/app/services/base_multiples_calculator.rb
+++ b/app/services/base_multiples_calculator.rb
@@ -9,6 +9,13 @@ class BaseMultiplesCalculator
     CheckKind.find_constant(disclosure_checks.first.kind)
   end
 
+  def spent?
+    return false if spent_date == :never_spent
+    return true  if spent_date == :no_record
+
+    spent_date.past?
+  end
+
   # :nocov:
   def spent_date
     raise 'implement in subclasses'

--- a/app/services/calculators/multiples/multiple_offenses_calculator.rb
+++ b/app/services/calculators/multiples/multiple_offenses_calculator.rb
@@ -17,6 +17,10 @@ module Calculators
         results[check_group.id]&.spent_date
       end
 
+      def all_spent?
+        results.values.all?(&:spent?)
+      end
+
       private
 
       def process_group(check_group)

--- a/app/services/calculators/multiples/same_proceedings.rb
+++ b/app/services/calculators/multiples/same_proceedings.rb
@@ -16,7 +16,7 @@ module Calculators
       private
 
       def expiry_dates
-        @_expiry_dates ||= check_group.disclosure_checks.map(
+        @_expiry_dates ||= disclosure_checks.map(
           &method(:expiry_date_for)
         ) - excluded_dates
       end

--- a/app/services/calculators/multiples/separate_proceedings.rb
+++ b/app/services/calculators/multiples/separate_proceedings.rb
@@ -14,7 +14,7 @@ module Calculators
 
       # The only check inside this group
       def disclosure_check
-        @_disclosure_check ||= check_group.disclosure_checks.first
+        @_disclosure_check ||= disclosure_checks.first
       end
     end
   end

--- a/app/views/steps/check/results/show.en.html+multiples.erb
+++ b/app/views/steps/check/results/show.en.html+multiples.erb
@@ -6,9 +6,12 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-        <!-- TODO: Make this header dynamic depending if we really have or not unspent offenses -->
         <h1 class="govuk-heading-xl">
-          You have unspent cautions or convictions
+          <% if @presenter.calculator.all_spent? %>
+            Your cautions or convictions are spent
+          <% else %>
+            You have unspent cautions or convictions
+          <% end %>
         </h1>
 
         <div class="govuk-inset-text">

--- a/spec/presenters/check_answers_presenter_spec.rb
+++ b/spec/presenters/check_answers_presenter_spec.rb
@@ -4,6 +4,26 @@ RSpec.describe CheckAnswersPresenter do
 
   subject { described_class.new(disclosure_report) }
 
+  describe '.initialize' do
+    context 'calculate the spent dates of the whole report' do
+      context 'when the report is still in progress' do
+        it 'does not process the offenses just yet' do
+          expect(subject.calculator.results).to be_empty
+        end
+      end
+
+      context 'when the report is completed' do
+        before do
+          allow(disclosure_report).to receive(:completed?).and_return(true)
+        end
+
+        it 'processes the offenses for later use' do
+          expect(subject.calculator.results).not_to be_empty
+        end
+      end
+    end
+  end
+
   describe '#to_partial_path' do
     it { expect(subject.to_partial_path).to eq('check_your_answers/check') }
   end
@@ -14,26 +34,6 @@ RSpec.describe CheckAnswersPresenter do
 
   describe '#summary' do
     let(:summary) { subject.summary }
-
-    context 'calculate the spent dates of the whole report' do
-      context 'when the report is still in progress' do
-        it 'does not process the offenses just yet' do
-          expect(subject.calculator).not_to receive(:process!)
-          summary
-        end
-      end
-
-      context 'when the report is completed' do
-        before do
-          allow(disclosure_report).to receive(:completed?).and_return(true)
-        end
-
-        it 'processes the offenses for later use' do
-          expect(subject.calculator).to receive(:process!)
-          summary
-        end
-      end
-    end
 
     context 'for a single youth caution' do
       it 'returns CheckGroupPresenter' do

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -40,4 +40,44 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
       expect(subject.spent_date_for(group)).to be_nil
     end
   end
+
+  describe '#all_spent?' do
+    before do
+      BaseMultiplesCalculator.subclasses.each do |klass|
+        allow_any_instance_of(klass).to receive(:spent_date).and_return(*spent_dates)
+      end
+    end
+
+    context 'when there is an offence that will never be spent' do
+      let(:spent_dates) { [:never_spent, Date.yesterday] }
+
+      it 'returns false' do
+        expect(subject.all_spent?).to eq(false)
+      end
+    end
+
+    context 'when there is an offence with `no_record`' do
+      let(:spent_dates) { [:no_record, Date.tomorrow] }
+
+      it 'considers the no_record as spent, and check the other dates' do
+        expect(subject.all_spent?).to eq(false)
+      end
+    end
+
+    context 'when there are dates' do
+      let(:spent_dates) { [Date.yesterday, Date.tomorrow] }
+
+      it 'checks if all the dates are in the past' do
+        expect(subject.all_spent?).to eq(false)
+      end
+    end
+
+    context 'when there are dates' do
+      let(:spent_dates) { [Date.yesterday, Date.yesterday-3.days] }
+
+      it 'checks if all the dates are in the past' do
+        expect(subject.all_spent?).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/services/calculators/multiples/same_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/same_proceedings_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Calculators::Multiples::SameProceedings do
 
   let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check1, disclosure_check2, disclosure_check3]) }
 
-  let(:disclosure_check1) { instance_double(DisclosureCheck) }
-  let(:disclosure_check2) { instance_double(DisclosureCheck) }
-  let(:disclosure_check3) { instance_double(DisclosureCheck) }
+  let(:disclosure_check1) { instance_double(DisclosureCheck, kind: 'conviction') }
+  let(:disclosure_check2) { instance_double(DisclosureCheck, kind: 'conviction') }
+  let(:disclosure_check3) { instance_double(DisclosureCheck, kind: 'conviction') }
 
   let(:check_result1) { instance_double(CheckResult, expiry_date: Date.new(2015, 10, 31)) }
   let(:check_result2) { instance_double(CheckResult, expiry_date: Date.new(2018, 10, 31)) }
@@ -15,6 +15,12 @@ RSpec.describe Calculators::Multiples::SameProceedings do
 
   let(:check_never_spent) { instance_double(CheckResult, expiry_date: :never_spent) }
   let(:check_no_record) { instance_double(CheckResult, expiry_date: :no_record) }
+
+  describe '#kind' do
+    it 'is always conviction for same proceedings' do
+      expect(subject.kind).to eq(CheckKind::CONVICTION)
+    end
+  end
 
   context '#spent_date' do
     context 'when there is at least one `never_spent` date' do

--- a/spec/services/calculators/multiples/separate_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/separate_proceedings_spec.rb
@@ -4,10 +4,23 @@ RSpec.describe Calculators::Multiples::SeparateProceedings do
   subject { described_class.new(check_group) }
 
   let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check]) }
-  let(:disclosure_check) { instance_double(DisclosureCheck) }
+  let(:disclosure_check) { instance_double(DisclosureCheck, kind: kind) }
 
   let(:check_result) { instance_double(CheckResult, expiry_date: expiry_date) }
   let(:expiry_date) { Date.new(2018, 10, 31) }
+  let(:kind) { nil }
+
+  describe '#kind' do
+    context 'for a caution' do
+      let(:kind) { 'caution' }
+      it { expect(subject.kind).to eq(CheckKind::CAUTION) }
+    end
+
+    context 'for a conviction' do
+      let(:kind) { 'conviction' }
+      it { expect(subject.kind).to eq(CheckKind::CONVICTION) }
+    end
+  end
 
   context '#spent_date' do
     before do


### PR DESCRIPTION
Depending on whether there are spent or unspent cautions/convictions.

As a pending refinment, the copy should be singular if there is only a caution or a conviction, and plural when there are multiple cautions and/or convictions.
But this is not priority right now.

<img width="697" alt="Screen Shot 2019-10-28 at 16 04 04" src="https://user-images.githubusercontent.com/687910/67695208-97e39680-f99c-11e9-8466-58e00f4bf74c.png">
