### PR TITLE
Update daily task to use DisclosureReport

### DIFF
--- a/app/models/disclosure_check.rb
+++ b/app/models/disclosure_check.rb
@@ -12,6 +12,6 @@ class DisclosureCheck < ApplicationRecord
   # able to remove this method and spec.
   #
   def self.purge!(date)
-    where('created_at <= :date', date: date).destroy_all
+    where('created_at <= :date', date: date).where(check_group_id: nil).destroy_all
   end
 end

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -1,26 +1,50 @@
 task daily_tasks: :environment do
   log 'Starting daily tasks'
-  log "Checks count: #{DisclosureCheck.count}"
+
+  #TODO remove once all checks without a check group have been deleted.
+  log "Check count: #{DisclosureCheck.where(check_group_id: nil).count }"
+
+  log "Reports count: #{DisclosureReport.count}"
 
   Rake::Task['purge:checks'].invoke
 
-  log "Checks count: #{DisclosureCheck.count}"
+  #TODO remove once all checks without a check group have been deleted.
+  log "Checks count: #{DisclosureCheck.where(check_group_id: nil).count }"
+
+  log "Reports count: #{DisclosureReport.count}"
   log 'Finished daily tasks'
 end
 
 namespace :purge do
   task checks: :environment do
-    # incomplete checks
+
     expire_after = Rails.configuration.x.checks.incomplete_purge_after_days
-    log "Purging incomplete checks older than #{expire_after} days"
+
+    #TODO remove once all checks without a check group have been deleted.
+    # incomplete disclosure checks
+    log "Purging incomplete checks without a check group id older than #{expire_after} days"
+
+    byebug
     purged = DisclosureCheck.in_progress.purge!(expire_after.days.ago)
     log "Purged #{purged.size} incomplete checks"
 
-    # complete checks
+    # incomplete disclosure Reports
+    log "Purging incomplete checks older than #{expire_after} days"
+    purged = DisclosureReport.in_progress.purge!(expire_after.days.ago)
+    log "Purged #{purged.size} incomplete reports"
+
+    #TODO remove once all checks without a check group have been deleted.
+    # complete disclosure checks
     expire_after = Rails.configuration.x.checks.complete_purge_after_days
     log "Purging complete checks older than #{expire_after} days"
     purged = DisclosureCheck.completed.purge!(expire_after.days.ago)
     log "Purged #{purged.size} complete checks"
+
+    # complete disclosure Reports
+    expire_after = Rails.configuration.x.checks.complete_purge_after_days
+    log "Purging complete checks older than #{expire_after} days"
+    purged = DisclosureReport.completed.purge!(expire_after.days.ago)
+    log "Purged #{purged.size} complete reports"
   end
 end
 

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -24,7 +24,6 @@ namespace :purge do
     # incomplete disclosure checks
     log "Purging incomplete checks without a check group id older than #{expire_after} days"
 
-    byebug
     purged = DisclosureCheck.in_progress.purge!(expire_after.days.ago)
     log "Purged #{purged.size} incomplete checks"
 


### PR DESCRIPTION
Update daily_task rake task to use the new data model DisclosureReport and it will delete all the underlying relations.

As we will have several records in DisclosureCheck model with out a check_group_id, we need to remove these for the next 60 days. To do this the purge method in DisclosureCheck had to be updated to remove any records less or equal to a given date and without a check group id and