### PR TITLE
Add a separate results survey for adults

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -36,6 +36,12 @@ module AnalyticsHelper
       current_disclosure_check.kind
   end
 
+  # Used for surveys, we return 'yes' or 'no' depending if we know
+  # the current check is for under 18s or over 18s.
+  def youth_check
+    current_disclosure_check&.under_age.presence || 'unknown'
+  end
+
   private
 
   # Custom dimensions on Google Analytics are named `dimensionX` where X

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,6 +67,7 @@ module ApplicationHelper
     query = {
       page: request.path,
       check: transaction_sku,
+      youth: youth_check,
     }.to_query
 
     url = [Rails.configuration.x.surveys.feedback, query].join('?')

--- a/app/views/steps/check/results/shared/_feedback.en.html.erb
+++ b/app/views/steps/check/results/shared/_feedback.en.html.erb
@@ -8,6 +8,14 @@
   This will help us to improve the service.
 </p>
 
+<%
+  survey_file = if current_disclosure_check.under_age.inquiry.yes?
+                  'tRaiETqnLgj758hTBazgd_2Bo7LRXsbd1AcAFHQu4ukGzukG3bvIXELhbfUTio3i90'
+                else
+                  'tRaiETqnLgj758hTBazgd6NBO_2By7HeCVIjOSkE2u6sDH2S6srYblwb6DaI4Zc9w5'
+                end
+%>
+
 <!-- BEGIN survey monkey embedded satisfaction -->
 <style>
   div.smcx-embed { border: 1px solid #ffffff; height: 720px; overflow: hidden; }
@@ -15,7 +23,7 @@
 <script>
   (function (t, e, s, n) {
     var o, a, c;
-    t.SMCX = t.SMCX || [], e.getElementById(n) || (o = e.getElementsByTagName(s), a = o[o.length - 1], c = e.createElement(s), c.type = "text/javascript", c.async = !0, c.id = n, c.src = ["https:" === location.protocol ? "https://" : "http://", "widget.surveymonkey.com/collect/website/js/tRaiETqnLgj758hTBazgd_2Bo7LRXsbd1AcAFHQu4ukGzukG3bvIXELhbfUTio3i90.js"].join(""), a.parentNode.insertBefore(c, a))
+    t.SMCX = t.SMCX || [], e.getElementById(n) || (o = e.getElementsByTagName(s), a = o[o.length - 1], c = e.createElement(s), c.type = "text/javascript", c.async = !0, c.id = n, c.src = ["https:" === location.protocol ? "https://" : "http://", "widget.surveymonkey.com/collect/website/js/<%= survey_file -%>.js"].join(""), a.parentNode.insertBefore(c, a))
   })(window, document, "script", "smcx-sdk");
 </script>
 <!-- END survey monkey embedded satisfaction -->

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe AnalyticsHelper, type: :helper do
-  let(:record) { DisclosureCheck.new(kind: kind) }
+  let(:record) { DisclosureCheck.new(kind: kind, under_age: under_age) }
   let(:kind) { CheckKind::CAUTION }
+  let(:under_age) { nil }
 
   before do
     allow(helper).to receive(:current_disclosure_check).and_return(record)
@@ -75,6 +76,23 @@ RSpec.describe AnalyticsHelper, type: :helper do
     context '`current_disclosure_check` is present, but `kind` is not present' do
       let(:kind) { nil }
       it { expect(helper.transaction_sku).to eq('unknown') }
+    end
+  end
+
+  describe '#youth_check' do
+    context '`current_disclosure_check` is not present' do
+      let(:record) { nil }
+      it { expect(helper.youth_check).to eq('unknown') }
+    end
+
+    context '`current_disclosure_check` is present, but `under_age` is not present' do
+      let(:under_age) { nil }
+      it { expect(helper.youth_check).to eq('unknown') }
+    end
+
+    context '`under_age` is present' do
+      let(:under_age) { 'yes' }
+      it { expect(helper.youth_check).to eq('yes') }
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe '#link_to_feedback' do
     before do
       allow(helper).to receive(:transaction_sku).and_return('conviction')
+      allow(helper).to receive(:youth_check).and_return('yes')
       allow(controller.request).to receive(:path).and_return('/steps/foo/bar')
     end
 
@@ -165,7 +166,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         helper.link_to_feedback('click here')
       ).to eq(
         '<a class="govuk-link govuk-link--no-visited-state" rel="external" target="_blank"' + \
-        ' href="https://example.com?check=conviction&amp;page=%2Fsteps%2Ffoo%2Fbar">click here</a>'
+        ' href="https://example.com?check=conviction&amp;page=%2Fsteps%2Ffoo%2Fbar&amp;youth=yes">click here</a>'
       )
     end
   end


### PR DESCRIPTION
And propagate an extra parameter in the survey link in the header, whether it was a check for under-18 or over-18 (only if we know it, otherwise we pass `unknown`).