### PR TITLE
Simplify results summary tables

### DIFF
--- a/app/presenters/caution_result_presenter.rb
+++ b/app/presenters/caution_result_presenter.rb
@@ -7,7 +7,6 @@ class CautionResultPresenter < ResultsPresenter
 
   def question_attributes
     [
-      :kind,
       :caution_type,
       :under_age,
       :known_date,

--- a/app/presenters/conviction_result_presenter.rb
+++ b/app/presenters/conviction_result_presenter.rb
@@ -7,8 +7,6 @@ class ConvictionResultPresenter < ResultsPresenter
 
   def question_attributes
     [
-      :kind,
-      :conviction_type,
       :conviction_subtype,
       :under_age,
       :known_date,

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -102,10 +102,6 @@ en:
       title_html: This fixed penalty notice (FPN) was not a conviction
 
   results/caution:
-    kind:
-      question: Criminal record type
-      answers:
-        caution: Caution
     known_date:
       question: Date caution was given
     conditional_end_date:
@@ -121,16 +117,8 @@ en:
         <<: *CAUTION_TYPES
 
   results/conviction:
-    kind:
-      question: Criminal record type
-      answers:
-        conviction: Conviction
-    conviction_type:
-      question: Type of conviction
-      answers:
-        <<: *CONVICTION_TYPES
     conviction_subtype:
-      question: Name of conviction
+      question: Type of conviction
       answers:
         <<: *CONVICTION_SUBTYPES
     under_age:

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -23,14 +23,6 @@ RSpec.describe 'I18n' do
       )
     end
 
-    it 'convictions types in `helpers.yml` matches convictions types in `results.yml`' do
-      expect(
-        i18n.tree('en.helpers.label.steps_conviction_conviction_type_form.conviction_type').to_hash
-      ).to eq(
-        i18n.tree('en.results/conviction.conviction_type.answers').to_hash
-      )
-    end
-
     it 'convictions subtypes in `helpers.yml` matches convictions subtypes in `results.yml`' do
       expect(
         i18n.tree('en.helpers.label.steps_conviction_conviction_subtype_form.conviction_subtype').to_hash

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -28,19 +28,16 @@ RSpec.describe CautionResultPresenter do
 
     context 'for a youth caution' do
       it 'returns the correct question-answer pairs' do
-        expect(summary.size).to eq(4)
+        expect(summary.size).to eq(3)
 
-        expect(summary[0].question).to eql(:kind)
-        expect(summary[0].answer).to eql('caution')
+        expect(summary[0].question).to eql(:caution_type)
+        expect(summary[0].answer).to eql('youth_simple_caution')
 
-        expect(summary[1].question).to eql(:caution_type)
-        expect(summary[1].answer).to eql('youth_simple_caution')
+        expect(summary[1].question).to eql(:under_age)
+        expect(summary[1].answer).to eql('yes')
 
-        expect(summary[2].question).to eql(:under_age)
-        expect(summary[2].answer).to eql('yes')
-
-        expect(summary[3].question).to eql(:known_date)
-        expect(summary[3].answer).to eq('31 October 2018')
+        expect(summary[2].question).to eql(:known_date)
+        expect(summary[2].answer).to eq('31 October 2018')
       end
     end
 
@@ -48,22 +45,19 @@ RSpec.describe CautionResultPresenter do
       let(:disclosure_check) { build(:disclosure_check, :youth_conditional_caution) }
 
       it 'returns the correct question-answer pairs' do
-        expect(summary.size).to eq(5)
+        expect(summary.size).to eq(4)
 
-        expect(summary[0].question).to eql(:kind)
-        expect(summary[0].answer).to eql('caution')
+        expect(summary[0].question).to eql(:caution_type)
+        expect(summary[0].answer).to eql('youth_conditional_caution')
 
-        expect(summary[1].question).to eql(:caution_type)
-        expect(summary[1].answer).to eql('youth_conditional_caution')
+        expect(summary[1].question).to eql(:under_age)
+        expect(summary[1].answer).to eql('yes')
 
-        expect(summary[2].question).to eql(:under_age)
-        expect(summary[2].answer).to eql('yes')
+        expect(summary[2].question).to eql(:known_date)
+        expect(summary[2].answer).to eq('31 October 2018')
 
-        expect(summary[3].question).to eql(:known_date)
-        expect(summary[3].answer).to eq('31 October 2018')
-
-        expect(summary[4].question).to eql(:conditional_end_date)
-        expect(summary[4].answer).to eq('25 December 2018')
+        expect(summary[3].question).to eql(:conditional_end_date)
+        expect(summary[3].answer).to eq('25 December 2018')
       end
     end
   end

--- a/spec/presenters/check_presenter_spec.rb
+++ b/spec/presenters/check_presenter_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe CheckPresenter do
     it { expect(subject.to_partial_path).to eq('check_your_answers/shared/check_row') }
   end
 
-
   describe '#summary' do
     let(:summary) { subject.summary }
+
     context 'for a single youth caution' do
       it 'returns CheckRow' do
         expect(summary).to be_an_instance_of(CheckRow)
-        expect(summary.question_answers.size).to eq(4)
+        expect(summary.question_answers.size).to eq(3)
       end
     end
   end

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -37,25 +37,19 @@ RSpec.describe ConvictionResultPresenter do
     let(:summary) { subject.summary }
 
     it 'returns the correct question-answer pairs' do
-      expect(summary.size).to eq(6)
+      expect(summary.size).to eq(4)
 
-      expect(summary[0].question).to eql(:kind)
-      expect(summary[0].answer).to eql('conviction')
+      expect(summary[0].question).to eql(:conviction_subtype)
+      expect(summary[0].answer).to eql('detention_training_order')
 
-      expect(summary[1].question).to eql(:conviction_type)
-      expect(summary[1].answer).to eql('custodial_sentence')
+      expect(summary[1].question).to eql(:under_age)
+      expect(summary[1].answer).to eql('yes')
 
-      expect(summary[2].question).to eql(:conviction_subtype)
-      expect(summary[2].answer).to eql('detention_training_order')
+      expect(summary[2].question).to eql(:known_date)
+      expect(summary[2].answer).to eq('31 October 2018')
 
-      expect(summary[3].question).to eql(:under_age)
-      expect(summary[3].answer).to eql('yes')
-
-      expect(summary[4].question).to eql(:known_date)
-      expect(summary[4].answer).to eq('31 October 2018')
-
-      expect(summary[5].question).to eql(:conviction_length)
-      expect(summary[5].answer).to eq('9 weeks')
+      expect(summary[3].question).to eql(:conviction_length)
+      expect(summary[3].answer).to eq('9 weeks')
     end
 
     context 'when no length given' do
@@ -64,10 +58,10 @@ RSpec.describe ConvictionResultPresenter do
       }
 
       it 'returns the correct question-answer pairs' do
-        expect(summary.size).to eq(6)
+        expect(summary.size).to eq(4)
 
-        expect(summary[5].question).to eql(:conviction_length)
-        expect(summary[5].answer).to eq('No length was given')
+        expect(summary[3].question).to eql(:conviction_length)
+        expect(summary[3].answer).to eq('No length was given')
       end
     end
 
@@ -75,25 +69,19 @@ RSpec.describe ConvictionResultPresenter do
       let(:disclosure_check) { build(:disclosure_check, :compensation) }
 
       it 'returns the correct question-answer pairs' do
-        expect(summary.size).to eq(6)
+        expect(summary.size).to eq(4)
 
-        expect(summary[0].question).to eql(:kind)
-        expect(summary[0].answer).to eql('conviction')
+        expect(summary[0].question).to eql(:conviction_subtype)
+        expect(summary[0].answer).to eql('compensation_to_a_victim')
 
-        expect(summary[1].question).to eql(:conviction_type)
-        expect(summary[1].answer).to eql('financial')
+        expect(summary[1].question).to eql(:under_age)
+        expect(summary[1].answer).to eql('yes')
 
-        expect(summary[2].question).to eql(:conviction_subtype)
-        expect(summary[2].answer).to eql('compensation_to_a_victim')
+        expect(summary[2].question).to eql(:known_date)
+        expect(summary[2].answer).to eq('31 October 2018')
 
-        expect(summary[3].question).to eql(:under_age)
-        expect(summary[3].answer).to eql('yes')
-
-        expect(summary[4].question).to eql(:known_date)
-        expect(summary[4].answer).to eq('31 October 2018')
-
-        expect(summary[5].question).to eql(:compensation_payment_date)
-        expect(summary[5].answer).to eq('31 October 2019')
+        expect(summary[3].question).to eql(:compensation_payment_date)
+        expect(summary[3].answer).to eq('31 October 2019')
       end
     end
   end


### PR DESCRIPTION
As per Simon new designs for multiples, we are going to partially implement this for the current version of the service, as it makes for a simplified and more easy to understand summary table.

Essentially we remove 1 row in cautions, and 2 rows in convictions.

There is still a change that we might want to do, which is replacing the word `conviction` with `sentence` in the tables, but only for certain conviction types.
This will require some UR so it is not implemented yet.

Adapt the tests and locales.

Cautions:
<img width="624" alt="Screen Shot 2019-11-04 at 13 17 32" src="https://user-images.githubusercontent.com/687910/68124264-d8946000-ff06-11e9-982e-296b98163dce.png">

Convictions:
<img width="564" alt="Screen Shot 2019-11-04 at 13 17 48" src="https://user-images.githubusercontent.com/687910/68124270-dd591400-ff06-11e9-8324-90277b8a0999.png">
