### PR TITLE
Add contact page and link from header

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,4 +1,6 @@
 class AboutController < ApplicationController
+  def contact; end
+
   def cookies; end
 
   def privacy; end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -63,18 +63,6 @@ module ApplicationHelper
     title ''
   end
 
-  def link_to_feedback(text)
-    query = {
-      page: request.path,
-      check: transaction_sku,
-      youth: youth_check,
-    }.to_query
-
-    url = [Rails.configuration.x.surveys.feedback, query].join('?')
-
-    link_to text, url, class: 'govuk-link govuk-link--no-visited-state', rel: 'external', target: '_blank'
-  end
-
   def link_button(text, href, attributes = {})
     link_to t("helpers.buttons.#{text}"), href, {
       class: 'govuk-button',

--- a/app/views/about/contact.en.html.erb
+++ b/app/views/about/contact.en.html.erb
@@ -1,0 +1,24 @@
+<% title 'Get in touch' %>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Get in touch</h1>
+
+        <p class="govuk-body">If you’d like to report a problem or you have a suggestion to help improve this online
+          tool for others, get in touch by sending an email to:</p>
+
+        <p class="govuk-body-l">
+          <a href="mailto:disclosure.checker@digital.justice.gov.uk?subject=Feedback" class="govuk-link govuk-link--no-visited-state">
+            disclosure.checker@digital.justice.gov.uk
+          </a>
+        </p>
+
+        <p class="govuk-body">This email address should only be used for feedback about this online tool.</p>
+
+        <p class="govuk-body">We cannot answer any questions about other services or about the Ministry of Justice in general.</p>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/layouts/_phase_banner.html.erb
+++ b/app/views/layouts/_phase_banner.html.erb
@@ -1,6 +1,6 @@
 <p class="govuk-phase-banner__content">
   <strong class="govuk-tag govuk-phase-banner__content__tag ">alpha</strong>
   <span class="govuk-phase-banner__text">
-    <%=t '.feedback.banner_html', link: link_to_feedback(t '.feedback.link_text') %>
+    <%=t '.feedback.banner_html', link: about_contact_path %>
   </span>
 </p>

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -10,5 +10,4 @@ en:
       accessibility: Accessibility
     phase_banner:
       feedback:
-        banner_html: We’re testing this service before it launches - please %{link} if you have any feedback on this page.
-        link_text: tell us
+        banner_html: We’re testing this service before it launches – please <a href="%{link}" class="govuk-link govuk-link--no-visited-state">share your feedback</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
 
   get 'home/index'
 
+  get 'about/contact'
   get 'about/cookies'
   get 'about/privacy'
   get 'about/terms_and_conditions'

--- a/spec/controllers/about_controller_spec.rb
+++ b/spec/controllers/about_controller_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe AboutController do
+  describe '#contact' do
+    it 'renders the expected page' do
+      get :contact
+      expect(response).to render_template(:contact)
+    end
+  end
+
   describe '#cookies' do
     it 'renders the expected page' do
       get :cookies
@@ -19,6 +26,13 @@ RSpec.describe AboutController do
     it 'renders the expected page' do
       get :terms_and_conditions
       expect(response).to render_template(:terms_and_conditions)
+    end
+  end
+
+  describe '#accessibility' do
+    it 'renders the expected page' do
+      get :accessibility
+      expect(response).to render_template(:accessibility)
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -154,23 +154,6 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#link_to_feedback' do
-    before do
-      allow(helper).to receive(:transaction_sku).and_return('conviction')
-      allow(helper).to receive(:youth_check).and_return('yes')
-      allow(controller.request).to receive(:path).and_return('/steps/foo/bar')
-    end
-
-    it 'builds the link markup including tracking params' do
-      expect(
-        helper.link_to_feedback('click here')
-      ).to eq(
-        '<a class="govuk-link govuk-link--no-visited-state" rel="external" target="_blank"' + \
-        ' href="https://example.com?check=conviction&amp;page=%2Fsteps%2Ffoo%2Fbar&amp;youth=yes">click here</a>'
-      )
-    end
-  end
-
   describe '#link_button' do
     it 'builds the link markup styled as a button' do
       expect(


### PR DESCRIPTION
Same to what we did on C100, we link to a contact page where we give instructions on how to contact us to provide feedback.