### PR TITLE
Show armed forces, was hidden for YOTs

### DIFF
--- a/app/services/conviction_length_choices.rb
+++ b/app/services/conviction_length_choices.rb
@@ -1,7 +1,5 @@
 class ConvictionLengthChoices
   SUBTYPES_HIDE_NO_LENGTH_CHOICE ||= [
-    ConvictionType::DISMISSAL,
-    ConvictionType::SERVICE_DETENTION,
     ConvictionType::DETENTION,
     ConvictionType::DETENTION_TRAINING_ORDER,
     ConvictionType::ADULT_PRISON_SENTENCE,

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -16,10 +16,10 @@ class ConvictionType < ValueObject
   VALUES = [
     YOUTH_PARENT_TYPES = [
       REFERRAL_SUPERVISION_YRO = new(:referral_supervision_yro),
-      ARMED_FORCES          = new(:armed_forces),
       CUSTODIAL_SENTENCE    = new(:custodial_sentence),
       DISCHARGE             = new(:discharge),
       FINANCIAL             = new(:financial),
+      MILITARY              = new(:military),
       PREVENTION_REPARATION = new(:prevention_reparation),
     ].freeze,
 
@@ -41,11 +41,6 @@ class ConvictionType < ValueObject
     # Youth convictions #
     #####################
     #
-    DISMISSAL                          = new(:dismissal,                        parent: ARMED_FORCES, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
-    OVERSEAS_COMMUNITY_ORDER           = new(:overseas_community_order,         parent: ARMED_FORCES, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
-    SERVICE_COMMUNITY_ORDER            = new(:service_community_order,          parent: ARMED_FORCES, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
-    SERVICE_DETENTION                  = new(:service_detention,                parent: ARMED_FORCES, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
-
     REFERRAL_ORDER                     = new(:referral_order,                   parent: REFERRAL_SUPERVISION_YRO, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     SUPERVISION_ORDER                  = new(:supervision_order,                parent: REFERRAL_SUPERVISION_YRO, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     YOUTH_REHABILITATION_ORDER         = new(:youth_rehabilitation_order,       parent: REFERRAL_SUPERVISION_YRO, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
@@ -60,6 +55,11 @@ class ConvictionType < ValueObject
 
     FINE                               = new(:fine,                             parent: FINANCIAL, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
     COMPENSATION_TO_A_VICTIM           = new(:compensation_to_a_victim,         parent: FINANCIAL, calculator_class: Calculators::CompensationCalculator),
+
+    DISMISSAL                          = new(:dismissal,                        parent: MILITARY, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
+    OVERSEAS_COMMUNITY_ORDER           = new(:overseas_community_order,         parent: MILITARY, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
+    SERVICE_COMMUNITY_ORDER            = new(:service_community_order,          parent: MILITARY, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
+    SERVICE_DETENTION                  = new(:service_detention,                parent: MILITARY, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
 
     REPARATION_ORDER                   = new(:reparation_order,                 parent: PREVENTION_REPARATION, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
     RESTRAINING_ORDER                  = new(:restraining_order,                parent: PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -16,6 +16,7 @@ class ConvictionType < ValueObject
   VALUES = [
     YOUTH_PARENT_TYPES = [
       REFERRAL_SUPERVISION_YRO = new(:referral_supervision_yro),
+      ARMED_FORCES          = new(:armed_forces),
       CUSTODIAL_SENTENCE    = new(:custodial_sentence),
       DISCHARGE             = new(:discharge),
       FINANCIAL             = new(:financial),
@@ -34,18 +35,16 @@ class ConvictionType < ValueObject
     # Quick way of enabling/disabling convictions. These will not show in the interface to users.
     # If there are cucumber test, tag the affected scenarios with `@skip`.
     #
-    PARENT_TYPES_DISABLED_FOR_MVP = [
-      ARMED_FORCES = new(:armed_forces),
-    ].freeze,
+    DISABLED_PARENT_TYPES = [].freeze,
 
     #####################
     # Youth convictions #
     #####################
     #
     DISMISSAL                          = new(:dismissal,                        parent: ARMED_FORCES, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
+    OVERSEAS_COMMUNITY_ORDER           = new(:overseas_community_order,         parent: ARMED_FORCES, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
+    SERVICE_COMMUNITY_ORDER            = new(:service_community_order,          parent: ARMED_FORCES, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
     SERVICE_DETENTION                  = new(:service_detention,                parent: ARMED_FORCES, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
-    SERVICE_COMMUNITY_ORDER            = new(:service_community_order,          parent: ARMED_FORCES, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
-    OVERSEAS_COMMUNITY_ORDER           = new(:overseas_community_order,         parent: ARMED_FORCES, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
 
     REFERRAL_ORDER                     = new(:referral_order,                   parent: REFERRAL_SUPERVISION_YRO, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     SUPERVISION_ORDER                  = new(:supervision_order,                parent: REFERRAL_SUPERVISION_YRO, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -9,11 +9,11 @@ en:
 
     CONVICTION_TYPES: &CONVICTION_TYPES
       # youth
-      armed_forces: Armed forces
       referral_supervision_yro: Referral or youth rehabilitation order (YRO)
       custodial_sentence: Custody or hospital order
       discharge: Discharge
       financial: Financial penalty
+      military: Military
       prevention_reparation: Prevention or reparation order
       # adults
       adult_community_reparation: Community, prevention or reparation order
@@ -24,11 +24,6 @@ en:
       adult_custodial_sentence: Custody or hospital order
 
     CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
-      # armed_forces
-      dismissal: Dismissal
-      service_detention: Service detention
-      service_community_order: Service community order
-      overseas_community_order: Overseas community order
       # referral_supervision_yro
       referral_order: Referral order
       supervision_order: Supervision order
@@ -44,6 +39,11 @@ en:
       # financial
       fine: A fine
       compensation_to_a_victim: Compensation to a victim
+      # military
+      dismissal: Dismissal
+      service_detention: Service detention
+      service_community_order: Service community order
+      overseas_community_order: Overseas community order
       # prevention_reparation
       reparation_order: Reparation order
       restraining_order: Restraining order
@@ -194,11 +194,11 @@ en:
           youth_conditional_caution: You agreed to certain conditions, such as paying a fine or learning about the effects of drugs
         conviction_type:
           # youth
-          armed_forces: For example, a dismissal or service detention
           referral_supervision_yro: For example, a curfew or supervision. You might have been asked to wear a tag as part of your order
           custodial_sentence: For example, a detention and training order (DTO) or a hospital order given under the Mental Health Act
           discharge: For example, a conditional discharge order or bind over
           financial: For example, paying a fine or compensation that was not part of a community order or youth rehabilitation order
+          military: For example, a dismissal or service detention
           prevention_reparation: For example, a restraining order or sexual harm prevention order
           # adults
           adult_community_reparation: For example, a curfew, unpaid work or a restraining order. You might have been asked to wear a tag as part of your order
@@ -208,11 +208,6 @@ en:
           adult_motoring: For example, penalty points or a driving ban
           adult_custodial_sentence: For example, a prison sentence, suspended sentence or hospital order given under the Mental Health Act
         conviction_subtype:
-          # armed_forces
-          dismissal: ""
-          service_detention: ""
-          service_community_order: ""
-          overseas_community_order: ""
           # referral_supervision_yro
           referral_order: You were referred to community volunteers and the youth offending team (YOT)
           supervision_order: You were ordered to be supervised by a youth offending team after loitering, soliciting or 'breaching a civil injunction' (previously called an ASBO)
@@ -228,6 +223,11 @@ en:
           # financial
           fine: ""
           compensation_to_a_victim: ""
+          # military
+          dismissal: ""
+          service_detention: ""
+          service_community_order: ""
+          overseas_community_order: ""
           # prevention_reparation
           reparation_order: You were given help understanding the effect your crime had on someone
           restraining_order: You were ordered not to do something, such as approach or contact a certain person

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -194,7 +194,7 @@ en:
           youth_conditional_caution: You agreed to certain conditions, such as paying a fine or learning about the effects of drugs
         conviction_type:
           # youth
-          armed_forces: ""
+          armed_forces: For example, a dismissal or service detention
           referral_supervision_yro: For example, a curfew or supervision. You might have been asked to wear a tag as part of your order
           custodial_sentence: For example, a detention and training order (DTO) or a hospital order given under the Mental Health Act
           discharge: For example, a conditional discharge order or bind over

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -9,11 +9,11 @@ en:
 
     CONVICTION_TYPES: &CONVICTION_TYPES
       # youth
-      armed_forces: Armed forces
       referral_supervision_yro: Referral or youth rehabilitation order (YRO)
       custodial_sentence: Custody or hospital order
       discharge: Discharge
       financial: Financial penalty
+      military: Military
       prevention_reparation: Prevention or reparation order
       # adults
       adult_community_reparation: Community, prevention or reparation order
@@ -24,11 +24,6 @@ en:
       adult_motoring: Motoring
 
     CONVICTION_SUBTYPES: &CONVICTION_SUBTYPES
-      # armed_forces
-      dismissal: Dismissal
-      service_detention: Service detention
-      service_community_order: Service community order
-      overseas_community_order: Overseas community order
       # referral_supervision_yro
       referral_order: Referral order
       supervision_order: Supervision order
@@ -44,6 +39,11 @@ en:
       # financial
       fine: A fine
       compensation_to_a_victim: Compensation to a victim
+      # military
+      dismissal: Dismissal
+      service_detention: Service detention
+      service_community_order: Service community order
+      overseas_community_order: Overseas community order
       # prevention_reparation
       reparation_order: Reparation order
       restraining_order: Restraining order

--- a/features/youth/conviction_armed_forces.feature
+++ b/features/youth/conviction_armed_forces.feature
@@ -1,7 +1,30 @@
 Feature: Conviction
 
-  @skip
-  Scenario Outline: Armed forces
+  @happy_path
+  Scenario Outline: Armed forces convictions with length
+    Given I am completing a basic under 18 "Armed forces" conviction
+    Then I should see "What type of order were you given?"
+
+    When I choose "<subtype>"
+    Then I should see "<known_date_header>"
+
+    And I enter a valid date
+    Then I should see "<length_type_header>"
+
+    And  I choose "Years"
+    Then I should see "<length_header>"
+    And I fill in "Number of years" with "5"
+
+    Then I click the "Continue" button
+    And I should be on "<result>"
+
+    Examples:
+      | subtype                  | known_date_header              | length_type_header                                           | length_header                     | result               |
+      | Overseas community order | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? | /steps/check/results |
+      | Service community order  | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? | /steps/check/results |
+
+  @happy_path
+  Scenario Outline: Armed forces convictions without length
     Given I am completing a basic under 18 "Armed forces" conviction
     Then I should see "What type of order were you given?"
 
@@ -15,5 +38,3 @@ Feature: Conviction
       | subtype                  | known_date_header                  | result               |
       | Dismissal                | When were you given the dismissal? | /steps/check/results |
       | Service detention        | When were you given the detention? | /steps/check/results |
-      | Service community order  | When were you given the order?     | /steps/check/results |
-      | Overseas community order | When were you given the order?     | /steps/check/results |

--- a/features/youth/conviction_military.feature
+++ b/features/youth/conviction_military.feature
@@ -1,8 +1,8 @@
 Feature: Conviction
 
   @happy_path
-  Scenario Outline: Armed forces convictions with length
-    Given I am completing a basic under 18 "Armed forces" conviction
+  Scenario Outline: Military convictions with length
+    Given I am completing a basic under 18 "Military" conviction
     Then I should see "What type of order were you given?"
 
     When I choose "<subtype>"
@@ -24,8 +24,8 @@ Feature: Conviction
       | Service community order  | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? | /steps/check/results |
 
   @happy_path
-  Scenario Outline: Armed forces convictions without length
-    Given I am completing a basic under 18 "Armed forces" conviction
+  Scenario Outline: Military convictions without length
+    Given I am completing a basic under 18 "Military" conviction
     Then I should see "What type of order were you given?"
 
     When I choose "<subtype>"

--- a/spec/services/conviction_length_choices_spec.rb
+++ b/spec/services/conviction_length_choices_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ConvictionLengthChoices do
   end
 
   describe '.choices' do
-    context 'youth armed forces dismissal' do
+    context 'youth military dismissal' do
       let(:conviction_subtype) { ConvictionType::DISMISSAL }
 
       it 'excludes `no_length` in the choices' do
@@ -58,7 +58,7 @@ RSpec.describe ConvictionLengthChoices do
       end
     end
 
-    context 'youth armed forces service detention' do
+    context 'youth military service detention' do
       let(:conviction_subtype) { ConvictionType::SERVICE_DETENTION }
 
       it 'excludes `no_length` in the choices' do

--- a/spec/services/conviction_length_choices_spec.rb
+++ b/spec/services/conviction_length_choices_spec.rb
@@ -25,8 +25,6 @@ RSpec.describe ConvictionLengthChoices do
       expect(
         described_class::SUBTYPES_HIDE_NO_LENGTH_CHOICE
       ).to eq([
-        ConvictionType::DISMISSAL,
-        ConvictionType::SERVICE_DETENTION,
         ConvictionType::DETENTION,
         ConvictionType::DETENTION_TRAINING_ORDER,
         ConvictionType::ADULT_PRISON_SENTENCE,
@@ -46,26 +44,10 @@ RSpec.describe ConvictionLengthChoices do
       ConvictionType.values.size - described_class::SUBTYPES_HIDE_NO_LENGTH_CHOICE.size
     }
 
-    it { expect(total).to eq(46) }
+    it { expect(total).to eq(48) }
   end
 
   describe '.choices' do
-    context 'youth military dismissal' do
-      let(:conviction_subtype) { ConvictionType::DISMISSAL }
-
-      it 'excludes `no_length` in the choices' do
-        expect(subject).to eq(all_choices_except_no_length)
-      end
-    end
-
-    context 'youth military service detention' do
-      let(:conviction_subtype) { ConvictionType::SERVICE_DETENTION }
-
-      it 'excludes `no_length` in the choices' do
-        expect(subject).to eq(all_choices_except_no_length)
-      end
-    end
-
     context 'youth custodial sentence detention' do
       let(:conviction_subtype) { ConvictionType::DETENTION }
 

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe ConvictionType do
     it 'returns top level youth convictions' do
       expect(values).to eq(%w(
         referral_supervision_yro
-        armed_forces
         custodial_sentence
         discharge
         financial
+        military
         prevention_reparation
       ))
     end
@@ -38,8 +38,8 @@ RSpec.describe ConvictionType do
   describe 'Conviction subtypes' do
     let(:values) { described_class.new(conviction_type).children.map(&:to_s) }
 
-    context 'Armed forces' do
-      let(:conviction_type) { :armed_forces }
+    context 'Military' do
+      let(:conviction_type) { :military }
 
       it 'returns subtypes of this conviction type' do
         expect(values).to eq(%w(

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -2,11 +2,14 @@ require 'rails_helper'
 
 RSpec.describe ConvictionType do
   describe 'YOUTH_PARENT_TYPES' do
-    let(:values) { described_class::YOUTH_PARENT_TYPES.map(&:to_s) }
+    let(:values) {
+      (described_class::YOUTH_PARENT_TYPES - described_class::DISABLED_PARENT_TYPES).map(&:to_s)
+    }
 
     it 'returns top level youth convictions' do
       expect(values).to eq(%w(
         referral_supervision_yro
+        armed_forces
         custodial_sentence
         discharge
         financial
@@ -16,7 +19,9 @@ RSpec.describe ConvictionType do
   end
 
   describe 'ADULT_PARENT_TYPES' do
-    let(:values) { described_class::ADULT_PARENT_TYPES.map(&:to_s) }
+    let(:values) {
+      (described_class::ADULT_PARENT_TYPES.map(&:to_s) - described_class::DISABLED_PARENT_TYPES).map(&:to_s)
+    }
 
     it 'returns top level adult convictions' do
       expect(values).to eq(%w(
@@ -30,16 +35,6 @@ RSpec.describe ConvictionType do
     end
   end
 
-  describe 'PARENT_TYPES_DISABLED_FOR_MVP' do
-    let(:values) { described_class::PARENT_TYPES_DISABLED_FOR_MVP.map(&:to_s) }
-
-    it 'returns top level conviction' do
-      expect(values).to eq(%w(
-        armed_forces
-      ))
-    end
-  end
-
   describe 'Conviction subtypes' do
     let(:values) { described_class.new(conviction_type).children.map(&:to_s) }
 
@@ -49,9 +44,9 @@ RSpec.describe ConvictionType do
       it 'returns subtypes of this conviction type' do
         expect(values).to eq(%w(
           dismissal
-          service_detention
-          service_community_order
           overseas_community_order
+          service_community_order
+          service_detention
         ))
       end
     end
@@ -218,15 +213,15 @@ RSpec.describe ConvictionType do
     context 'SERVICE_COMMUNITY_ORDER' do
       let(:subtype) { 'service_community_order' }
 
-      it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::StartPlusSixMonths) }
+      it { expect(conviction_type.skip_length?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusSixMonths) }
     end
 
     context 'OVERSEAS_COMMUNITY_ORDER' do
       let(:subtype) { 'overseas_community_order' }
 
-      it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::StartPlusSixMonths) }
+      it { expect(conviction_type.skip_length?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusSixMonths) }
     end
 
     context 'REFERRAL_ORDER' do


### PR DESCRIPTION
This was already implemented into the service but hidden as for the YOT pilot there was no audience to test with.

Added the hint text, renamed to `military`, reordered alphabetically and fixed a couple of calculations.

Individual commits for an easier review.

This can be deployed to staging for testing, make any further amendments and, if we decide so, release it.
If not, we can use again the `DISABLED_PARENT_TYPES` array to hide it but leave it prepared for a quick release at a later date.