### PR TITLE
Hide military convictions for under 18s

### DIFF
--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -19,7 +19,6 @@ class ConvictionType < ValueObject
       CUSTODIAL_SENTENCE    = new(:custodial_sentence),
       DISCHARGE             = new(:discharge),
       FINANCIAL             = new(:financial),
-      MILITARY              = new(:military),
       PREVENTION_REPARATION = new(:prevention_reparation),
     ].freeze,
 
@@ -35,7 +34,9 @@ class ConvictionType < ValueObject
     # Quick way of enabling/disabling convictions. These will not show in the interface to users.
     # If there are cucumber test, tag the affected scenarios with `@skip`.
     #
-    DISABLED_PARENT_TYPES = [].freeze,
+    DISABLED_PARENT_TYPES = [
+      MILITARY = new(:military),
+    ].freeze,
 
     #####################
     # Youth convictions #

--- a/features/youth/conviction_military.feature
+++ b/features/youth/conviction_military.feature
@@ -1,3 +1,4 @@
+@skip
 Feature: Conviction
 
   @happy_path

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe ConvictionType do
         custodial_sentence
         discharge
         financial
-        military
         prevention_reparation
       ))
     end


### PR DESCRIPTION
This was enabled briefly to test it and make any amendments if needed, but we do not intend to deploy to production just yet.

After the testing is done, we are making this hidden again, so staging and prod environments are the same.