### PR TITLE
Enable postgres `verify-full` SSL mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,13 @@ ENV APP_BUILD_TAG ${APP_BUILD_TAG}
 ARG APP_GIT_COMMIT
 ENV APP_GIT_COMMIT ${APP_GIT_COMMIT}
 
+# Download RDS certificates bundle -- needed for SSL verification
+# We set the path to the bundle in the ENV, and use it in `/config/database.yml`
+#
+ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/rds-combined-ca-bundle.pem
+ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem $RDS_COMBINED_CA_BUNDLE
+RUN chmod +r $RDS_COMBINED_CA_BUNDLE
+
 # Run the application as user `moj` (created in the base image)
 # uid=1000(moj) gid=1000(moj) groups=1000(moj)
 # Some directories/files need to be chowned otherwise we get Errno::EACCES

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,8 @@
-# This file is only present to fix a Jenkins
-# build error that started to occur after
-# adding devise, but which we could not
-# reproduce on our local machines
+# Note: in production we are forcing SSL and certificate verification.
+# The RDS certificates bundle is downloaded in the Dockerfile.
+#
+# Refer to https://www.postgresql.org/docs/current/libpq-ssl.html for more information.
+#
 default: &default
   adapter: postgresql
 
@@ -11,3 +12,5 @@ test:
   <<: *default
 production:
   <<: *default
+  sslmode: <%= ENV.fetch('DATABASE_SSLMODE', 'verify-full') %>
+  sslrootcert: <%= ENV['RDS_COMBINED_CA_BUNDLE'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,8 +56,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = ENV.key?('DISABLE_SSL') ? false : true
+  # Force HTTPS (but allow disabling it, when running locally via docker-compose)
+  config.force_ssl = ENV.key?('DISABLE_HTTPS') ? false : true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,8 @@ services:
       - DATABASE_URL=postgresql://postgres@db/disclosure-checker
       - EXTERNAL_URL=http://localhost:8080
       - SECRET_KEY_BASE=c263472f8aa91f4a277002e9652f86f330e636358e2090d86ab4a4f0684cefe2
-      - DISABLE_SSL=1
+      - DATABASE_SSLMODE=disable
+      - DISABLE_HTTPS=1
     depends_on:
       - db
     expose:


### PR DESCRIPTION
For production environments we are going to force the verify-full SSL mode in all connections to the database.

It will be overriden (`DATABASE_SSLMODE=disable`) when using docker-compose so we are still able to run and test the application locally.

This follows best practices and guidance from Cloud Platforms here:

https://user-guide.cloud-platform.service.justice.gov.uk/tasks.html#ssl-connections-with-rds