### PR TITLE
Add days spent on bail step

### DIFF
--- a/app/controllers/steps/conviction/conviction_bail_days_controller.rb
+++ b/app/controllers/steps/conviction/conviction_bail_days_controller.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Conviction
+    class ConvictionBailDaysController < Steps::ConvictionStepController
+      def edit
+        @form_object = ConvictionBailDaysForm.new(
+          disclosure_check: current_disclosure_check,
+          conviction_bail_days: current_disclosure_check.conviction_bail_days
+        )
+      end
+
+      def update
+        update_and_advance(ConvictionBailDaysForm)
+      end
+    end
+  end
+end

--- a/app/forms/steps/conviction/conviction_bail_days_form.rb
+++ b/app/forms/steps/conviction/conviction_bail_days_form.rb
@@ -1,0 +1,19 @@
+module Steps
+  module Conviction
+    class ConvictionBailDaysForm < BaseForm
+      attribute :conviction_bail_days, String
+
+      validates_numericality_of :conviction_bail_days, allow_blank: true, only_integer: true
+
+      private
+
+      def persist!
+        raise DisclosureCheckNotFound unless disclosure_check
+
+        disclosure_check.update(
+          conviction_bail_days: conviction_bail_days
+        )
+      end
+    end
+  end
+end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -22,6 +22,10 @@ class ConvictionDecisionTree < BaseDecisionTree
       after_compensation_paid
     when :motoring_lifetime_ban
       after_motoring_lifetime_ban
+    when :conviction_bail
+      after_conviction_bail
+    when :conviction_bail_days
+      edit(:known_date)
     when :conviction_length, :compensation_payment_date, :motoring_disqualification_end_date
       results
     else
@@ -79,6 +83,12 @@ class ConvictionDecisionTree < BaseDecisionTree
 
   def after_motoring_endorsement
     return results if penalty_notice_without_endorsement?
+
+    edit(:known_date)
+  end
+
+  def after_conviction_bail
+    return edit(:conviction_bail_days) if step_value(:conviction_bail).inquiry.yes?
 
     edit(:known_date)
   end

--- a/app/views/steps/conviction/conviction_bail_days/edit.html.erb
+++ b/app/views/steps/conviction/conviction_bail_days/edit.html.erb
@@ -1,0 +1,28 @@
+<% title t('.page_title') %>
+
+<div class="govuk-width-container">
+  <%= step_header %>
+
+  <main id="main-content" class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= error_summary %>
+        <%= step_subsection %>
+
+        <h1 class="govuk-heading-xl">
+          <%=t '.heading' %>
+        </h1>
+
+        <%= step_form @form_object do |f| %>
+          <%= f.text_field :conviction_bail_days,
+                           input_options: { class: 'govuk-input--width-3', inputmode: :numeric, pattern: '[0-9]*' },
+                           label_options: { page_heading: false, size: 's' } %>
+
+          <%= f.continue_button %>
+        <% end %>
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -77,3 +77,7 @@ en:
       conviction_bail:
         edit:
           page_title: Did you spend any time on bail?
+      conviction_bail_days:
+        edit:
+          page_title: Days spent with an electronic tag
+          heading: How many days spent with an electronic tag counted towards your sentence?

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -59,6 +59,11 @@ en:
           attributes:
             conviction_bail:
               inclusion: Select yes if you spent any time on bail with an electronic tag
+        steps/conviction/conviction_bail_days_form:
+          attributes:
+            conviction_bail_days:
+              not_a_number: The input must be a number, like 3
+              not_an_integer: The input must be a whole number, like 4
 
   errors:
     format: "%{message}"

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -187,6 +187,8 @@ en:
         motoring_disqualification_end_date_html: "Leave this blank if your ban had no end date. <p>For example, 23 9 2018</p>"
       steps_conviction_conviction_bail_form:
         conviction_bail: Time spent on bail with an electronic tag affects the spent date of your conviction. Time spent on bail without a tag does not.
+      steps_conviction_conviction_bail_days_form:
+        conviction_bail_days: This is decided by the court. If you do not know the exact number of days you can enter an approximate number or leave this blank, but it might affect the accuracy of your result.
       radio_buttons:
         kind:
           caution: You were given an official warning by the police
@@ -311,3 +313,5 @@ en:
         day: Day
         month: Month
         year: Year
+      steps_conviction_conviction_bail_days_form:
+        conviction_bail_days: Enter the number of days

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
       edit_step :conviction_length
       edit_step :conviction_length_type
       edit_step :conviction_bail
+      edit_step :conviction_bail_days
       edit_step :compensation_paid
       edit_step :compensation_payment_date
       show_step :compensation_not_paid

--- a/db/migrate/20191120120826_add_conviction_bail_days_to_disclosure_check.rb
+++ b/db/migrate/20191120120826_add_conviction_bail_days_to_disclosure_check.rb
@@ -1,0 +1,5 @@
+class AddConvictionBailDaysToDisclosureCheck < ActiveRecord::Migration[5.2]
+  def change
+    add_column :disclosure_checks, :conviction_bail_days, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_110442) do
+ActiveRecord::Schema.define(version: 2019_11_20_120826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2019_11_20_110442) do
     t.string "motoring_lifetime_ban"
     t.uuid "check_group_id"
     t.string "conviction_bail"
+    t.integer "conviction_bail_days"
     t.index ["check_group_id"], name: "index_disclosure_checks_on_check_group_id"
     t.index ["status"], name: "index_disclosure_checks_on_status"
   end

--- a/lib/govuk_components/form_builder.rb
+++ b/lib/govuk_components/form_builder.rb
@@ -34,11 +34,13 @@ module GovukComponents
     # by side with the old gem.
     #
     def text_field(attribute, options = {})
+      value = object.public_send(attribute)
+
       content_tag(:div, class: form_group_classes(attribute)) do
         concat input_label(attribute, options)
         concat hint(attribute, options)
         concat error(attribute)
-        concat @template.text_field(@object_name, attribute, input_options(attribute, options))
+        concat @template.text_field(@object_name, attribute, input_options(attribute, options).merge(value: value))
       end
     end
 

--- a/spec/controllers/steps/conviction/conviction_bail_days_controller_spec.rb
+++ b/spec/controllers/steps/conviction/conviction_bail_days_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Conviction::ConvictionBailDaysController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Conviction::ConvictionBailDaysForm, ConvictionDecisionTree
+end

--- a/spec/forms/steps/conviction/conviction_bail_days_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_bail_days_form_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Conviction::ConvictionBailDaysForm do
+  let(:arguments) { {
+    disclosure_check: disclosure_check,
+    conviction_bail_days: conviction_bail_days
+  } }
+  let(:disclosure_check) { instance_double(DisclosureCheck, conviction_bail_days: nil) }
+  let(:conviction_bail_days) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when form is valid' do
+      it 'saves the record' do
+        expect(disclosure_check).to receive(:update).with(
+          conviction_bail_days: conviction_bail_days
+        ).and_return(true)
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+
+  describe 'validations' do
+    context 'allows blank' do
+      let(:conviction_bail_days) { '' }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'allows nil' do
+      let(:conviction_bail_days) { nil }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'when `conviction_bail_days` is invalid' do
+      context 'is not a number' do
+        let(:conviction_bail_days) { 'sss' }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.details[:conviction_bail_days][0][:error]).to eq(:not_a_number)
+        end
+      end
+
+      context 'is not an whole number' do
+        let(:conviction_bail_days) { 1.5 }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.details[:conviction_bail_days][0][:error]).to eq(:not_an_integer)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -179,4 +179,23 @@ RSpec.describe ConvictionDecisionTree do
     let(:step_params) { { bypass_motoring_conviction_type: conviction_type } }
     it { is_expected.to have_destination(:exit_motoring, :show) }
   end
+
+  context 'when the step is `conviction_bail`' do
+    let(:step_params) { { conviction_bail: answer } }
+
+    context 'and the answer is yes' do
+      let(:answer) { GenericYesNo::YES }
+      it { is_expected.to have_destination(:conviction_bail_days, :edit) }
+    end
+
+    context 'and the answer is no' do
+      let(:answer) { GenericYesNo::NO }
+      it { is_expected.to have_destination(:known_date, :edit) }
+    end
+  end
+
+  context 'when the step is `conviction_bail_days`' do
+    let(:step_params) { { conviction_bail_days: 'whatever' } }
+    it { is_expected.to have_destination(:known_date, :edit) }
+  end
 end


### PR DESCRIPTION
As part of the bail journey, this is the follow-up question after the previous yes-no question.

It is not yet visible in the "normal" journey but can be accessed directly knowing the URL.

Fixed an issue in our custom form builder where a `text_field` would not maintain their value between reloads.

<img width="666" alt="Screen Shot 2019-11-20 at 16 22 52" src="https://user-images.githubusercontent.com/687910/69257348-d68efa00-0bb2-11ea-9ae5-ce77a79e8a6a.png">
