### PR TITLE
Add calculation of bail time to SentenceCalculator

### DIFF
--- a/app/services/base_calculator.rb
+++ b/app/services/base_calculator.rb
@@ -1,6 +1,7 @@
 class BaseCalculator
   class InvalidCalculation < RuntimeError; end
 
+  SECONDS_IN_A_MONTH = ActiveSupport::Duration::SECONDS_PER_MONTH
   WEEKS_IN_A_MONTH = 52 / 12.0
   MONTHS_IN_A_YEAR = 12
 
@@ -28,14 +29,18 @@ class BaseCalculator
     (end_date.year - start_date.year) * 12 + end_date.month - start_date.month - (end_date.day >= start_date.day ? 0 : 1)
   end
 
-  def sentence_length_in_months(length, conviction_length_type)
-    case conviction_length_type
-    when 'weeks'
-      length / WEEKS_IN_A_MONTH
-    when 'years'
-      length * MONTHS_IN_A_YEAR
-    when 'months'
-      length
-    end
+  def sentence_length_in_months(length, length_unit, offset_days: 0)
+    months = case length_unit
+             when 'weeks'
+               length / WEEKS_IN_A_MONTH
+             when 'years'
+               length * MONTHS_IN_A_YEAR
+             when 'months'
+               length
+             end
+
+    # If there is a negative number of days to subtract (bail time), otherwise 0
+    seconds = (months * SECONDS_IN_A_MONTH) + offset_days.days.to_i
+    (seconds / SECONDS_IN_A_MONTH).to_i
   end
 end

--- a/spec/services/base_calculator_spec.rb
+++ b/spec/services/base_calculator_spec.rb
@@ -3,16 +3,12 @@ require 'rails_helper'
 RSpec.describe BaseCalculator do
   subject { described_class.new(disclosure_check) }
 
-
-   let(:disclosure_check) { build(:disclosure_check,
-                                 known_date: known_date) }
-
+  let(:disclosure_check) { build(:disclosure_check, known_date: known_date) }
   let(:known_date) { Date.new(2018, 10, 31) }
 
   before(:each) do
     described_class.send(:public, *described_class.private_instance_methods)
   end
-
 
   it 'distance_in_months' do
     expect(subject.distance_in_months(Date.new(2017, 8, 12), Date.new(2017, 8, 12))).to eq 0
@@ -44,7 +40,6 @@ RSpec.describe BaseCalculator do
     expect(subject.distance_in_months(Date.new(2017, 2, 1), Date.new(2017, 3, 1))).to eq 1
   end
 
-
   context '#sentence_distance_in_months' do
     it 'in weeks' do
       expect(subject.sentence_length_in_months(4, 'weeks')).to be < 1
@@ -60,7 +55,6 @@ RSpec.describe BaseCalculator do
       expect(subject.sentence_length_in_months(25, 'weeks')).to be < 6
       expect(subject.sentence_length_in_months(26, 'weeks')).to be >= 6
 
-
       # 25 months
       expect(subject.sentence_length_in_months(108, 'weeks')).to be < 25
       expect(subject.sentence_length_in_months(109, 'weeks')).to be >= 25
@@ -70,23 +64,22 @@ RSpec.describe BaseCalculator do
       expect(subject.sentence_length_in_months(130, 'weeks')).to be >= 30
     end
 
-
     it 'in months' do
-       # 3 months
+      # 3 months
       expect(subject.sentence_length_in_months(3, 'months')).to eq 3
 
       # 6 months
       expect(subject.sentence_length_in_months(6, 'months')).to eq 6
 
       # 25 months
-     expect(subject.sentence_length_in_months(25, 'months')).to eq 25
+      expect(subject.sentence_length_in_months(25, 'months')).to eq 25
 
       # 30 months
       expect(subject.sentence_length_in_months(30, 'months')).to eq 30
     end
 
     it 'in years' do
-       # 1 year = 12 months
+      # 1 year = 12 months
       expect(subject.sentence_length_in_months(1, 'years')).to eq 12
 
       # 2 years = 24 months
@@ -98,5 +91,16 @@ RSpec.describe BaseCalculator do
       # 25 years = 300 months
       expect(subject.sentence_length_in_months(25, 'years')).to eq 300
     end
+  end
+
+  context '#sentence_distance_in_months when using a bail offset' do
+    it { expect(subject.sentence_length_in_months(5, 'weeks')).to eq(1) }
+    it { expect(subject.sentence_length_in_months(5, 'weeks', offset_days: -6)).to eq(0) }
+
+    it { expect(subject.sentence_length_in_months(3, 'months')).to eq(3) }
+    it { expect(subject.sentence_length_in_months(3, 'months', offset_days: -1)).to eq(2) }
+
+    it { expect(subject.sentence_length_in_months(1, 'years')).to eq(12) }
+    it { expect(subject.sentence_length_in_months(1, 'years', offset_days: -1)).to eq(11) }
   end
 end

--- a/spec/services/calculators/sentence_calculator_spec.rb
+++ b/spec/services/calculators/sentence_calculator_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe Calculators::SentenceCalculator do
 
   let(:disclosure_check) { build(:disclosure_check,
                                  known_date: known_date,
+                                 conviction_bail_days: bail_days,
                                  conviction_length: conviction_months,
                                  conviction_length_type: ConvictionLengthType::MONTHS.to_s) }
 
   let(:known_date) { Date.new(2016, 10, 20) }
   let(:conviction_months) { nil }
+  let(:bail_days) { nil }
 
   describe Calculators::SentenceCalculator::Detention do
     context '#expiry_date' do
@@ -37,6 +39,43 @@ RSpec.describe Calculators::SentenceCalculator do
         let(:conviction_months) { 120 } # obscene number of months
         it { expect(subject.valid?).to eq(true) }
         it { expect { subject.expiry_date }.not_to raise_exception(BaseCalculator::InvalidCalculation) }
+      end
+    end
+  end
+
+  describe Calculators::SentenceCalculator::DetentionTraining do
+    context '#expiry_date' do
+      context 'conviction length of 6 months or less' do
+        let(:conviction_months) { 5 }
+        it { expect(subject.expiry_date.to_s).to eq('2018-09-19') }
+      end
+
+      context 'conviction length of 7 to 24 months' do
+        let(:conviction_months) { 24 }
+        it { expect(subject.expiry_date.to_s).to eq('2020-10-19') }
+      end
+
+      context 'there is an upper limit' do
+        let(:conviction_months) { 25 } # the upper limit in this conviction is 24 months
+        it { expect(subject.valid?).to eq(false) }
+        it { expect { subject.expiry_date }.to raise_exception(BaseCalculator::InvalidCalculation) }
+      end
+
+      # Just one example is enough as all other types of sentences behave the same
+      describe 'sentence with bail time' do
+        context 'when bail time would have avoided the upper limit' do
+          let(:bail_days) { 300 }
+          let(:conviction_months) { 25 } # the upper limit in this conviction is 24 months
+
+          it { expect(subject.valid?).to eq(false) }
+          it { expect { subject.expiry_date }.to raise_exception(BaseCalculator::InvalidCalculation) }
+        end
+
+        context 'conviction length of 6 months or less' do
+          let(:conviction_months) { 5 }
+          let(:bail_days) { 20 } # equals to 10 days less in the spent date
+          it { expect(subject.expiry_date.to_s).to eq('2018-09-09') }
+        end
       end
     end
   end


### PR DESCRIPTION
Each full day spent on bail with a tag offsets half a day from the sentence length.

We must take this into consideration also to calculate the different rehabilitation bands or periods.

Updated the method `#sentence_length_in_months` so we can pass an offset (negative number of days, or zero) to subtract.