### PR TITLE
Update results page for bail

### DIFF
--- a/app/forms/steps/conviction/conviction_bail_days_form.rb
+++ b/app/forms/steps/conviction/conviction_bail_days_form.rb
@@ -3,7 +3,8 @@ module Steps
     class ConvictionBailDaysForm < BaseForm
       attribute :conviction_bail_days, String
 
-      validates_numericality_of :conviction_bail_days, allow_blank: true, only_integer: true
+      validates_numericality_of :conviction_bail_days,
+                                greater_than: 0, allow_blank: true, only_integer: true
 
       private
 

--- a/app/presenters/conviction_result_presenter.rb
+++ b/app/presenters/conviction_result_presenter.rb
@@ -9,6 +9,7 @@ class ConvictionResultPresenter < ResultsPresenter
     [
       :conviction_subtype,
       :under_age,
+      :conviction_bail_days,
       :known_date,
       [:conviction_length, i18n_conviction_length],
       :compensation_payment_date,

--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -31,6 +31,10 @@ class ResultsPresenter
     result_service.expiry_date
   end
 
+  def time_on_bail?
+    disclosure_check.conviction_bail_days.to_i.positive?
+  end
+
   def variant
     tense = if expiry_date.instance_of?(Date)
               expiry_date.past? ? :spent : :not_spent

--- a/app/views/steps/check/results/shared/_summary.en.html.erb
+++ b/app/views/steps/check/results/shared/_summary.en.html.erb
@@ -10,14 +10,22 @@
 </ul>
 
 <p class="govuk-body">
-  This table shows the information you’ve given us, which has been used to work out your result.
+  This table shows the information you’ve given us, which has been used to work out your result. If you need to change
+  any information, or if you have another caution or conviction you’d like to check,
+  <%= link_to 'use the service again', root_path, class: 'govuk-link govuk-link--no-visited-state ga-pageLink', data: { ga_category: 'results', ga_label: 'new check' } %>.
 </p>
 
 <dl class="govuk-summary-list">
   <%= render result.summary %>
 </dl>
 
-<p class="govuk-body">
-  If you need to change any information, or if you have another caution or conviction you’d like to
-  check, <%= link_to 'use the service again', root_path, class: 'govuk-link govuk-link--no-visited-state ga-pageLink', data: { ga_category: 'results', ga_label: 'new check' } %>.
-</p>
+<% if result.time_on_bail? %>
+  <h2 class="govuk-heading-m">
+    Time spent on bail with an electronic tag
+  </h2>
+
+  <p class="govuk-body">
+    Your result and spent date include the number of days you said you spent on bail with an electronic tag that counted
+    towards your sentence. Each full day offsets half a day from the total length of your sentence.
+  </p>
+<% end %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -40,7 +40,7 @@ en:
         steps/conviction/conviction_length_form:
           attributes:
             conviction_length:
-              greater_than: The length must be 1 or more
+              greater_than: The length must be greater than zero
               not_a_number: The length must be a number, like 3
               not_an_integer: The length must be a whole number, like 4
               invalid_sentence: The length of the sentence is invalid for this conviction
@@ -62,6 +62,7 @@ en:
         steps/conviction/conviction_bail_days_form:
           attributes:
             conviction_bail_days:
+              greater_than: The input must be greater than zero, or left blank
               not_a_number: The input must be a number, like 3
               not_an_integer: The input must be a whole number, like 4
 

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -126,6 +126,8 @@ en:
       answers:
         'yes': Under 18
         'no': 18 or over
+    conviction_bail_days:
+      question: Days on bail
     known_date:
       question: Start date
     conviction_length:

--- a/spec/forms/steps/conviction/conviction_bail_days_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_bail_days_form_spec.rb
@@ -65,6 +65,19 @@ RSpec.describe Steps::Conviction::ConvictionBailDaysForm do
           expect(subject.errors.details[:conviction_bail_days][0][:error]).to eq(:not_an_integer)
         end
       end
+
+      context 'is not greater than zero' do
+        let(:conviction_bail_days) { 0 }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.details[:conviction_bail_days][0][:error]).to eq(:greater_than)
+        end
+      end
     end
   end
 end

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -71,4 +71,13 @@ RSpec.describe CautionResultPresenter do
       expect(subject.expiry_date).to eq('foobar')
     end
   end
+
+  describe '#time_on_bail?' do
+    let(:disclosure_check) { build(:disclosure_check, conviction_bail_days: bail_days) }
+
+    context 'it is always false for cautions, as there is no bail question' do
+      let(:bail_days) { nil }
+      it { expect(subject.time_on_bail?).to eq(false) }
+    end
+  end
 end

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -84,6 +84,28 @@ RSpec.describe ConvictionResultPresenter do
         expect(summary[3].answer).to eq('31 October 2019')
       end
     end
+
+    context 'when there is time on bail' do
+      let(:disclosure_check) { build(:disclosure_check, :dto_conviction, conviction_bail_days: 15) }
+
+      it 'returns the correct question-answer pairs' do
+        expect(summary.size).to eq(5)
+
+        expect(summary[0].question).to eql(:conviction_subtype)
+        expect(summary[0].answer).to eql('detention_training_order')
+
+        expect(summary[1].question).to eql(:under_age)
+        expect(summary[1].answer).to eql('yes')
+
+        expect(summary[2].question).to eql(:conviction_bail_days)
+        expect(summary[2].answer).to eq(15)
+
+        expect(summary[3].question).to eql(:known_date)
+        expect(summary[3].answer).to eq('31 October 2018')
+
+        # ignoring following rows as they are the same as in other tests
+      end
+    end
   end
 
   describe '#expiry_date' do
@@ -93,6 +115,25 @@ RSpec.describe ConvictionResultPresenter do
 
     it 'delegates the method to the calculator' do
       expect(subject.expiry_date).to eq('foobar')
+    end
+  end
+
+  describe '#time_on_bail?' do
+    let(:disclosure_check) { build(:disclosure_check, :dto_conviction, conviction_bail_days: bail_days) }
+
+    context 'when there is time on bail' do
+      let(:bail_days) { 5 }
+      it { expect(subject.time_on_bail?).to eq(true) }
+    end
+
+    context 'when there is no time on bail' do
+      let(:bail_days) { nil }
+      it { expect(subject.time_on_bail?).to eq(false) }
+    end
+
+    context 'when time on bail is zero' do
+      let(:bail_days) { 0 }
+      it { expect(subject.time_on_bail?).to eq(false) }
     end
   end
 end


### PR DESCRIPTION
We show a message when we detect there is time spent on bail.

Also, added a validation to the `ConvictionBailDaysForm` to enter a number greater than zero. But can still be left blank if the user doesn't know this information.