### PR TITLE
Amend some date hint text

### DIFF
--- a/app/views/steps/conviction/compensation_payment_date/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_date/edit.html.erb
@@ -10,13 +10,8 @@
         <%= error_summary %>
         <%= step_subsection %>
 
-        <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
-
-        <p class="govuk-body"><%=t '.lead_text' %></p>
-
         <%= step_form @form_object do |f| %>
-          <%= f.gov_uk_date_field :compensation_payment_date,
-                                  legend_options: { page_heading: false, visually_hidden: true } %>
+          <%= f.gov_uk_date_field :compensation_payment_date %>
 
           <%= render partial: 'steps/shared/unknown_date_details', locals: { ga_label: 'compensation unknown date' } %>
 

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -62,8 +62,6 @@ en:
       compensation_payment_date:
         edit:
           page_title: Compensation payment date
-          heading: When did you pay the compensation in full?
-          lead_text: If you paid the compensation in stages, enter the date you made the final payment.
       motoring_endorsement:
         edit:
           page_title: Motoring Endorsement

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -1,6 +1,13 @@
 ---
 en:
   dictionary:
+    court_sentence_hint_text: &court_sentence_hint_text |
+      This is usually the day you were sentenced in court.
+      <span class='nowrap'>For example, 23 9 2018</span>
+    order_started_hint_text: &order_started_hint_text |
+      Enter the date your sentence or order started. This might be the day you were sentenced in court or the first day you were held on remand.
+      <span class='nowrap'>For example, 23 9 2018</span>
+
     CAUTION_TYPES: &CAUTION_TYPES
       youth_simple_caution: Youth caution
       youth_conditional_caution: Youth conditional caution
@@ -175,11 +182,16 @@ en:
         conditional_end_date_html: "Enter the date you agreed the conditions would end. This might have included paying a fine or compensation. <span class='nowrap'>For example, 23 9 2018</span>"
       steps_conviction_known_date_form:
         # default key
-        known_date_html: "Enter the date your sentence or order started. This might be the day you were sentenced in court or the first day you were held on remand. <span class='nowrap'>For example, 23 9 2018</span>"
+        known_date_html: *court_sentence_hint_text
         # alternative keys defined with `i18_attribute`
         referral_order_html: Enter the date of your first youth offender panel meeting. <span class='nowrap'>For example, 23 9 2018</span>
+        detention_training_order_html: *order_started_hint_text
+        detention_html: *order_started_hint_text
+        adult_prison_sentence_html: *order_started_hint_text
+        adult_suspended_prison_sentence_html: *order_started_hint_text
+        adult_disqualification: For example, 23 9 2018
       steps_conviction_compensation_payment_date_form:
-        compensation_payment_date: For example, 23 9 2018
+        compensation_payment_date_html: If you paid the compensation in stages, enter the date you made the final payment. <span class='nowrap'>For example, 23 9 2018</span>
       steps_conviction_motoring_endorsement_form:
         motoring_endorsement: An endorsement means that your conviction is recorded on your driving licence. Endorsements are usually given by courts.
       steps_conviction_motoring_disqualification_end_date_form:


### PR DESCRIPTION
After a copy audit, we detected some hint text needed amendments to be consistent with the type of offense they were referring to.