### PR TITLE
Bypass bail journey on prod envs

### DIFF
--- a/app/controllers/steps/conviction/conviction_subtype_controller.rb
+++ b/app/controllers/steps/conviction/conviction_subtype_controller.rb
@@ -9,7 +9,14 @@ module Steps
       end
 
       def update
-        update_and_advance(ConvictionSubtypeForm)
+        update_and_advance(ConvictionSubtypeForm, as: as_name)
+      end
+
+      private
+
+      # TODO: temporary feature-flag, to be removed when no needed
+      def as_name
+        bail_enabled? ? :conviction_subtype : :bypass_bail_conviction_subtype
       end
     end
   end

--- a/app/helpers/experiments_helper.rb
+++ b/app/helpers/experiments_helper.rb
@@ -1,4 +1,9 @@
 module ExperimentsHelper
+  # Bail journey only active on local/staging envs
+  def bail_enabled?
+    Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')
+  end
+
   def motoring_enabled?
     cookies[:motoring_enabled].present?
   end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -9,7 +9,7 @@ class ConvictionDecisionTree < BaseDecisionTree
     case step_name
     when :conviction_type, :bypass_motoring_conviction_type
       after_conviction_type
-    when :conviction_subtype
+    when :conviction_subtype, :bypass_bail_conviction_subtype
       after_conviction_subtype
     when :motoring_endorsement
       after_motoring_endorsement
@@ -43,7 +43,7 @@ class ConvictionDecisionTree < BaseDecisionTree
   end
 
   def after_conviction_subtype
-    return edit(:conviction_bail)   if conviction_subtype.bailable_offense?
+    return edit(:conviction_bail)   if conviction_subtype.bailable_offense? && !step_name.eql?(:bypass_bail_conviction_subtype)
     return edit(:compensation_paid) if conviction_subtype.compensation?
     return after_adult_motoring     if conviction_subtype.parent.inquiry.adult_motoring?
 


### PR DESCRIPTION
We are going to leave this enabled on local/staging envs but for the time being we will not show the bail questions on production as this is still WIP.

This way we can continue deploying fixes and copy changes to prod without opening this to the public.