### PR TITLE
Update daily_tasks to cleanup reports

### DIFF
--- a/app/forms/form_attribute_methods.rb
+++ b/app/forms/form_attribute_methods.rb
@@ -22,12 +22,9 @@ module FormAttributeMethods
   end
 
   module ClassMethods
-    # :nocov:
-    # TODO: This will be removed once we use non generic yes or no answers
     def attribute_names
       attribute_set.map(&:name)
     end
-    # :nocov:
 
     # Iterates through all declared attributes in the form object, mapping its values
     def attributes_map(origin)

--- a/app/models/disclosure_check.rb
+++ b/app/models/disclosure_check.rb
@@ -6,12 +6,4 @@ class DisclosureCheck < ApplicationRecord
     in_progress: 0,
     completed: 10,
   }
-
-  # TODO: once the new data models are in place, we would do the purge
-  # through the DisclosureReport model, instead of here, and we will be
-  # able to remove this method and spec.
-  #
-  def self.purge!(date)
-    where('created_at <= :date', date: date).destroy_all
-  end
 end

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -1,10 +1,10 @@
 task daily_tasks: :environment do
   log 'Starting daily tasks'
-  log "Checks count: #{DisclosureCheck.count}"
+  log "Checks count: #{DisclosureReport.count}"
 
   Rake::Task['purge:checks'].invoke
 
-  log "Checks count: #{DisclosureCheck.count}"
+  log "Checks count: #{DisclosureReport.count}"
   log 'Finished daily tasks'
 end
 
@@ -13,13 +13,13 @@ namespace :purge do
     # incomplete checks
     expire_after = Rails.configuration.x.checks.incomplete_purge_after_days
     log "Purging incomplete checks older than #{expire_after} days"
-    purged = DisclosureCheck.in_progress.purge!(expire_after.days.ago)
+    purged = DisclosureReport.in_progress.purge!(expire_after.days.ago)
     log "Purged #{purged.size} incomplete checks"
 
     # complete checks
     expire_after = Rails.configuration.x.checks.complete_purge_after_days
     log "Purging complete checks older than #{expire_after} days"
-    purged = DisclosureCheck.completed.purge!(expire_after.days.ago)
+    purged = DisclosureReport.completed.purge!(expire_after.days.ago)
     log "Purged #{purged.size} complete checks"
   end
 end

--- a/spec/models/disclosure_check_spec.rb
+++ b/spec/models/disclosure_check_spec.rb
@@ -4,27 +4,4 @@ RSpec.describe DisclosureCheck, type: :model do
   subject { described_class.new(attributes) }
 
   let(:attributes) { {} }
-
-  describe '.purge!' do
-    let(:finder_double) { double.as_null_object }
-
-    before do
-      travel_to Time.now
-    end
-
-    it 'picks records equal to or older than the passed-in date' do
-      expect(described_class).to receive(:where).with(
-        'created_at <= :date', date: 28.days.ago
-      ).and_return(finder_double)
-
-      described_class.purge!(28.days.ago)
-    end
-
-    it 'calls #destroy_all on the records it finds' do
-      allow(described_class).to receive(:where).and_return(finder_double)
-      expect(finder_double).to receive(:destroy_all)
-
-      described_class.purge!(28.days.ago)
-    end
-  end
 end


### PR DESCRIPTION
Instead of doing the cleanup through the `DisclosureCheck` model, we can now do it through the `DisclosureReport` as all records will have this model as the enclosure and dependents will be destroyed.