### PR TITLE
Indicate approximate dates on results page

### DIFF
--- a/app/presenters/question_answer_row.rb
+++ b/app/presenters/question_answer_row.rb
@@ -3,7 +3,7 @@ class QuestionAnswerRow
 
   def initialize(question, answer, scope:)
     @question = question
-    @answer = format_answer(answer)
+    @answer = answer
     @scope = scope
   end
 
@@ -13,11 +13,5 @@ class QuestionAnswerRow
 
   def to_partial_path
     'results/shared/row'
-  end
-
-  private
-
-  def format_answer(value)
-    value.is_a?(Date) ? I18n.l(value) : value
   end
 end

--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -21,7 +21,7 @@ class ResultsPresenter
     question_attributes.map do |item, value|
       QuestionAnswerRow.new(
         item,
-        value || disclosure_check[item],
+        value || format_value(item),
         scope: to_partial_path
       )
     end.select(&:show?)
@@ -51,6 +51,19 @@ class ResultsPresenter
   def result_service
     @_result_service ||= CheckResult.new(
       disclosure_check: disclosure_check
+    )
+  end
+
+  def format_value(attr)
+    value = disclosure_check[attr]
+    return value unless value.is_a?(Date)
+
+    approx_attr = ['approximate', attr].join('_').to_sym
+    format_type = disclosure_check[approx_attr].present? ? 'approximate' : 'exact'
+
+    I18n.translate!(
+      format_type, date: I18n.l(value),
+      scope: 'results/shared/date_format'
     )
   end
 

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -101,6 +101,10 @@ en:
     no_record:
       title_html: This fixed penalty notice (FPN) was not a conviction
 
+  results/shared/date_format:
+    exact: '%{date}'
+    approximate: '%{date} (approximate)'
+
   results/caution:
     known_date:
       question: Date caution was given
@@ -145,4 +149,3 @@ en:
       question: End date
     motoring_lifetime_ban:
       question: Motoring lifetime ban
-

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -60,6 +60,18 @@ RSpec.describe CautionResultPresenter do
         expect(summary[3].answer).to eq('25 December 2018')
       end
     end
+
+    context 'when there are approximate dates' do
+      let(:disclosure_check) { build(:disclosure_check, :youth_conditional_caution, approximate_known_date: true) }
+
+      it 'formats the date to indicate it is approximate' do
+        expect(summary[2].question).to eql(:known_date)
+        expect(summary[2].answer).to eq('31 October 2018 (approximate)')
+
+        expect(summary[3].question).to eql(:conditional_end_date)
+        expect(summary[3].answer).to eq('25 December 2018')
+      end
+    end
   end
 
   describe '#expiry_date' do

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -85,6 +85,18 @@ RSpec.describe ConvictionResultPresenter do
       end
     end
 
+    context 'when there are approximate dates' do
+      let(:disclosure_check) { build(:disclosure_check, :compensation, approximate_compensation_payment_date: true) }
+
+      it 'formats the date to indicate it is approximate' do
+        expect(summary[2].question).to eql(:known_date)
+        expect(summary[2].answer).to eq('31 October 2018')
+
+        expect(summary[3].question).to eql(:compensation_payment_date)
+        expect(summary[3].answer).to eq('31 October 2019 (approximate)')
+      end
+    end
+
     context 'when there is time on bail' do
       let(:disclosure_check) { build(:disclosure_check, :dto_conviction, conviction_bail_days: 15) }
 

--- a/spec/presenters/question_answer_row_spec.rb
+++ b/spec/presenters/question_answer_row_spec.rb
@@ -13,14 +13,7 @@ RSpec.describe QuestionAnswerRow do
   end
 
   describe '#answer' do
-    context 'for a date answer' do
-      let(:answer) { Date.new(2018, 10, 31) }
-      it { expect(subject.answer).to eq('31 October 2018') }
-    end
-
-    context 'for an answer of other type' do
-      it { expect(subject.answer).to eq('answer') }
-    end
+    it { expect(subject.answer).to eq('answer') }
   end
 
   describe '#show?' do


### PR DESCRIPTION
If any of the dates given entered by the user are marked as being approximate, then we show this next to the date in the results page answer table.

<img width="610" alt="Screen Shot 2019-11-28 at 12 09 28" src="https://user-images.githubusercontent.com/687910/69805146-fa1bfb00-11d7-11ea-9b97-da7a45bfc49f.png">
