### PR TITLE
Feature-flag the approximate date check boxes

### DIFF
--- a/app/helpers/experiments_helper.rb
+++ b/app/helpers/experiments_helper.rb
@@ -1,4 +1,9 @@
 module ExperimentsHelper
+  # Approximate date check boxes only active on local/staging envs
+  def approximate_dates_enabled?
+    Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')
+  end
+
   # Bail journey only active on local/staging envs
   def bail_enabled?
     Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')

--- a/app/views/steps/caution/conditional_end_date/edit.html.erb
+++ b/app/views/steps/caution/conditional_end_date/edit.html.erb
@@ -11,7 +11,10 @@
 
         <%= step_form @form_object do |f| %>
           <%= f.gov_uk_date_field :conditional_end_date %>
-          <%= f.check_box_fieldset :approximate_conditional_end_date, [:approximate_conditional_end_date], { small: true, no_legend: true } %>
+
+          <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
+            form: f, attribute: :approximate_conditional_end_date
+          } %>
 
           <details class="govuk-details" data-module="govuk-details">
             <summary class="govuk-details__summary">

--- a/app/views/steps/caution/known_date/edit.html.erb
+++ b/app/views/steps/caution/known_date/edit.html.erb
@@ -11,7 +11,10 @@
 
         <%= step_form @form_object do |f| %>
           <%= f.gov_uk_date_field :known_date %>
-          <%= f.check_box_fieldset :approximate_known_date, [:approximate_known_date], { small: true, no_legend: true } %>
+
+          <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
+            form: f, attribute: :approximate_known_date
+          } %>
 
           <%= f.continue_button %>
         <% end %>

--- a/app/views/steps/conviction/compensation_payment_date/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_date/edit.html.erb
@@ -12,7 +12,10 @@
 
         <%= step_form @form_object do |f| %>
           <%= f.gov_uk_date_field :compensation_payment_date %>
-          <%= f.check_box_fieldset :approximate_compensation_payment_date, [:approximate_compensation_payment_date], { small: true, no_legend: true } %>
+
+          <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
+            form: f, attribute: :approximate_compensation_payment_date
+          } %>
 
           <%= f.continue_button %>
         <% end %>

--- a/app/views/steps/conviction/known_date/edit.html.erb
+++ b/app/views/steps/conviction/known_date/edit.html.erb
@@ -12,7 +12,10 @@
 
         <%= step_form @form_object do |f| %>
           <%= f.gov_uk_date_field :known_date, i18n_attribute: @form_object.conviction_subtype %>
-          <%= f.check_box_fieldset :approximate_known_date, [:approximate_known_date], { small: true, no_legend: true } %>
+
+          <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
+            form: f, attribute: :approximate_known_date
+          } %>
 
           <%= f.continue_button %>
         <% end %>

--- a/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
+++ b/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
@@ -12,7 +12,10 @@
 
         <%= step_form @form_object do |f| %>
           <%= f.gov_uk_date_field :motoring_disqualification_end_date %>
-          <%= f.check_box_fieldset :approximate_motoring_disqualification_end_date, [:approximate_motoring_disqualification_end_date], { small: true, no_legend: true } %>
+
+          <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
+            form: f, attribute: :approximate_motoring_disqualification_end_date
+          } %>
 
           <%= f.continue_button %>
         <% end %>

--- a/app/views/steps/shared/_approx_date_checkbox.html.erb
+++ b/app/views/steps/shared/_approx_date_checkbox.html.erb
@@ -1,0 +1,3 @@
+<% if approximate_dates_enabled? %>
+<%= form.check_box_fieldset attribute, [attribute], { small: true, no_legend: true } %>
+<% end %>

--- a/spec/helpers/experiments_helper_spec.rb
+++ b/spec/helpers/experiments_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ExperimentsHelper, type: :helper do
+  describe '#approximate_dates_enabled?' do
+    let(:dev_tools_enabled) { true }
+    let(:development_env) { true }
+
+    before do
+      allow(ENV).to receive(:key?).with('DEV_TOOLS_ENABLED').and_return(dev_tools_enabled)
+      allow(Rails.env).to receive(:development?).and_return(development_env)
+    end
+
+    context 'on development environments' do
+      it { expect(helper.approximate_dates_enabled?).to eq(true) }
+    end
+
+    context 'on production environments with DEV_TOOLS_ENABLED' do
+      let(:dev_tools_enabled) { true }
+      let(:development_env) { false }
+
+      it { expect(helper.approximate_dates_enabled?).to eq(true) }
+    end
+
+    context 'on production environments without DEV_TOOLS_ENABLED' do
+      let(:dev_tools_enabled) { false }
+      let(:development_env) { false }
+
+      it { expect(helper.approximate_dates_enabled?).to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
We don't want this showing on production just yet, but we want it on staging/local.

Same as we did with bail, we are going to feature-flag it based on the environment.