### PR TITLE
Show military convictions for under 18s

### DIFF
--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -19,6 +19,7 @@ class ConvictionType < ValueObject
       CUSTODIAL_SENTENCE    = new(:custodial_sentence),
       DISCHARGE             = new(:discharge),
       FINANCIAL             = new(:financial),
+      MILITARY              = new(:military),
       PREVENTION_REPARATION = new(:prevention_reparation),
     ].freeze,
 
@@ -34,9 +35,7 @@ class ConvictionType < ValueObject
     # Quick way of enabling/disabling convictions. These will not show in the interface to users.
     # If there are cucumber test, tag the affected scenarios with `@skip`.
     #
-    DISABLED_PARENT_TYPES = [
-      MILITARY = new(:military),
-    ].freeze,
+    DISABLED_PARENT_TYPES = [].freeze,
 
     #####################
     # Youth convictions #

--- a/features/youth/conviction_military.feature
+++ b/features/youth/conviction_military.feature
@@ -1,4 +1,3 @@
-@skip
 Feature: Conviction
 
   @happy_path

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ConvictionType do
         custodial_sentence
         discharge
         financial
+        military
         prevention_reparation
       ))
     end


### PR DESCRIPTION
We can enable this now, so we revert the commit where we hide these convictions.

This reverts commit d79e8a5f9d2da8a5fac39008ade7a277a68e5183, reversing
changes made to 065554690cba6e3d4bf01b8204271dad6b5004e7.