### PR TITLE
Enable approximate dates check box

### DIFF
--- a/app/helpers/experiments_helper.rb
+++ b/app/helpers/experiments_helper.rb
@@ -1,9 +1,4 @@
 module ExperimentsHelper
-  # Approximate date check boxes only active on local/staging envs
-  def approximate_dates_enabled?
-    Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')
-  end
-
   # Bail journey only active on local/staging envs
   def bail_enabled?
     Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')

--- a/app/views/steps/shared/_approx_date_checkbox.html.erb
+++ b/app/views/steps/shared/_approx_date_checkbox.html.erb
@@ -1,3 +1,1 @@
-<% if approximate_dates_enabled? %>
 <%= form.check_box_fieldset attribute, [attribute], { small: true, no_legend: true } %>
-<% end %>

--- a/spec/helpers/experiments_helper_spec.rb
+++ b/spec/helpers/experiments_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ExperimentsHelper, type: :helper do
-  describe '#approximate_dates_enabled?' do
+  describe '#bail_enabled?' do
     let(:dev_tools_enabled) { true }
     let(:development_env) { true }
 
@@ -11,21 +11,21 @@ RSpec.describe ExperimentsHelper, type: :helper do
     end
 
     context 'on development environments' do
-      it { expect(helper.approximate_dates_enabled?).to eq(true) }
+      it { expect(helper.bail_enabled?).to eq(true) }
     end
 
     context 'on production environments with DEV_TOOLS_ENABLED' do
       let(:dev_tools_enabled) { true }
       let(:development_env) { false }
 
-      it { expect(helper.approximate_dates_enabled?).to eq(true) }
+      it { expect(helper.bail_enabled?).to eq(true) }
     end
 
     context 'on production environments without DEV_TOOLS_ENABLED' do
       let(:dev_tools_enabled) { false }
       let(:development_env) { false }
 
-      it { expect(helper.approximate_dates_enabled?).to eq(false) }
+      it { expect(helper.bail_enabled?).to eq(false) }
     end
   end
 end


### PR DESCRIPTION
This was previously hidden on production envs.
Now we can enable it.