### PR TITLE
Stop using ministryofjustice/docker-templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,56 @@
-FROM ministryofjustice/ruby:2.6.3-webapp-onbuild
+FROM ruby:2.6.3-alpine
+MAINTAINER UCPD Cross Justice Delivery
 
-# The following ENV variables need to be present by the time the assets precompile run
-ENV SECRET_KEY_BASE needed_for_assets_precompile
-ENV EXTERNAL_URL    needed_for_assets_precompile
-ENV RAILS_ENV       production
+# build dependencies:
+#   - virtual: create virtual package for later deletion
+#   - build-base for alpine fundamentals
+#   - libxml2-dev/libxslt-dev for nokogiri, at least
+#   - postgresql-dev for pg/activerecord gems
+#   - git for installing gems referred to use a git:// uri
+#
+RUN apk --no-cache add --virtual build-deps \
+  build-base \
+  libxml2-dev \
+  libxslt-dev \
+  postgresql-dev \
+  git \
+  bash \
+  curl \
+&& apk --no-cache add \
+  postgresql-client \
+  linux-headers \
+  xz-libs \
+  tzdata \
+  nodejs \
+  yarn
 
-RUN touch /etc/inittab
+# ensure everything is executable
+RUN chmod +x /usr/local/bin/*
 
-RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    curl -sL https://deb.nodesource.com/setup_10.x | bash -
+# add non-root user and group with alpine first available uid, 1000
+RUN addgroup -g 1000 -S appgroup && \
+    adduser -u 1000 -S appuser -G appgroup
 
-RUN apt-get update && apt-get install yarn nodejs
+# create app directory in conventional, existing dir /usr/src
+RUN mkdir -p /usr/src/app && mkdir -p /usr/src/app/tmp
+WORKDIR /usr/src/app
 
+COPY Gemfile* ./
+
+RUN gem install bundler -v 1.17.3 && \
+    bundle config --global without test:development && \
+    bundle install --frozen --jobs 2 --retry 3
+
+COPY . .
+
+# The following are ENV variables that need to be present by the time
+# the assets pipeline run, but doesn't matter their value.
+#
+ENV EXTERNAL_URL            replace_this_at_build_time
+ENV SECRET_KEY_BASE         replace_this_at_build_time
+ENV GOVUK_NOTIFY_API_KEY    replace_this_at_build_time
+
+ENV RAILS_ENV production
 RUN bundle exec rake assets:precompile
 
 # Copy fonts and images (without digest) along with the digested ones,
@@ -20,6 +58,19 @@ RUN bundle exec rake assets:precompile
 # that will not be able to use the rails digest mechanism.
 RUN cp node_modules/govuk-frontend/govuk/assets/fonts/*  public/assets/govuk-frontend/govuk/assets/fonts
 RUN cp node_modules/govuk-frontend/govuk/assets/images/* public/assets/govuk-frontend/govuk/assets/images
+
+# tidy up installation
+RUN apk del build-deps && rm -rf /tmp/*
+
+# non-root/appuser should own only what they need to
+RUN chown -R appuser:appgroup log tmp db
+
+# Download RDS certificates bundle -- needed for SSL verification
+# We set the path to the bundle in the ENV, and use it in `/config/database.yml`
+#
+ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/rds-combined-ca-bundle.pem
+ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem $RDS_COMBINED_CA_BUNDLE
+RUN chmod +r $RDS_COMBINED_CA_BUNDLE
 
 ARG APP_BUILD_DATE
 ENV APP_BUILD_DATE ${APP_BUILD_DATE}
@@ -29,20 +80,6 @@ ENV APP_BUILD_TAG ${APP_BUILD_TAG}
 
 ARG APP_GIT_COMMIT
 ENV APP_GIT_COMMIT ${APP_GIT_COMMIT}
-
-# Download RDS certificates bundle -- needed for SSL verification
-# We set the path to the bundle in the ENV, and use it in `/config/database.yml`
-#
-ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/rds-combined-ca-bundle.pem
-ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem $RDS_COMBINED_CA_BUNDLE
-RUN chmod +r $RDS_COMBINED_CA_BUNDLE
-
-# Run the application as user `moj` (created in the base image)
-# uid=1000(moj) gid=1000(moj) groups=1000(moj)
-# Some directories/files need to be chowned otherwise we get Errno::EACCES
-#
-RUN mkdir -p ./usr/src/app/log ./usr/src/app/tmp && \
-    chown -R $APPUSER:$APPUSER /usr/src/app/log /usr/src/app/tmp
 
 ENV APPUID 1000
 USER $APPUID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ volumes:
 services:
   db:
     image: postgres
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   webapp:
     build: .

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 cd /usr/src/app
 
 bundle exec rake db:create db:migrate

--- a/worker.sh
+++ b/worker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 cd /usr/src/app
 
 bundle exec rake daily_tasks


### PR DESCRIPTION
The Dockerfiles in the repo docker-templates [1] is being deprecated and it is recommended to keep Dockerfiles and docker images as lightweight and simple as possible.

In this case we are going to refactor the Dockerfile to use an alpine image and add dependencies on top.

[1] https://github.com/ministryofjustice/docker-templates