### PR TITLE
Change bail offset from half a day to a whole day

### DIFF
--- a/app/services/calculators/sentence_calculator.rb
+++ b/app/services/calculators/sentence_calculator.rb
@@ -1,7 +1,7 @@
 module Calculators
   class SentenceCalculator < BaseCalculator
     NEVER_SPENT_THRESHOLD = 48
-    BAIL_OFFSET = -0.5 # half a day
+    BAIL_OFFSET = -1.0
 
     # If conviction length is 6 months or less: start date + length + 18 months
     # If conviction length is over 6 months and less than or equal to 30 months: start date + length + 2 years
@@ -91,8 +91,8 @@ module Calculators
       )
     end
 
-    # Each full day spent on bail with a tag offsets half a day from the sentence length
-    # Attribute can be blank or nil, but `#to_i` makes it safe.
+    # Each full day spent on bail with a tag offsets the value of `BAIL_OFFSET` from
+    # the sentence length. Attribute can be blank or nil, but `#to_i` makes it safe.
     #
     def bail_offset_days
       disclosure_check.conviction_bail_days.to_i * BAIL_OFFSET

--- a/app/views/steps/check/results/shared/_summary.en.html.erb
+++ b/app/views/steps/check/results/shared/_summary.en.html.erb
@@ -26,6 +26,6 @@
 
   <p class="govuk-body">
     Your result and spent date include the number of days you said you spent on bail with an electronic tag that counted
-    towards your sentence. Each full day offsets half a day from the total length of your sentence.
+    towards your sentence. Each full day offsets a day from the total length of your sentence.
   </p>
 <% end %>

--- a/spec/services/calculators/sentence_calculator_spec.rb
+++ b/spec/services/calculators/sentence_calculator_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe Calculators::SentenceCalculator do
 
         context 'conviction length of 6 months or less' do
           let(:conviction_months) { 5 }
-          let(:bail_days) { 20 } # equals to 10 days less in the spent date
-          it { expect(subject.expiry_date.to_s).to eq('2018-09-09') }
+          let(:bail_days) { 20 } # equals to 20 days less in the spent date
+          it { expect(subject.expiry_date.to_s).to eq('2018-08-27') }
         end
       end
     end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/19868485

This is an urgent change as per sentencing policy:
Courts already calculate days on bail into the sentence, to keep calculations accurate we need to have a whole day taken off the spent date for each day spent on bail tag.

Instead of half a day as before, now the bail time substract the total amount (of bail time) from the sentence which effectively is equivalent to multiply by -1.