### PR TITLE
add page for compensation over £100

### DIFF
--- a/app/controllers/steps/conviction/compensation_paid_amount_controller.rb
+++ b/app/controllers/steps/conviction/compensation_paid_amount_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Conviction
+    class CompensationPaidAmountController < Steps::ConvictionStepController
+      def edit
+        @form_object = CompensationPaidAmountForm.build(current_disclosure_check)
+      end
+
+      def update
+        update_and_advance(CompensationPaidAmountForm)
+      end
+    end
+  end
+end

--- a/app/forms/steps/conviction/compensation_paid_amount_form.rb
+++ b/app/forms/steps/conviction/compensation_paid_amount_form.rb
@@ -1,0 +1,9 @@
+module Steps
+  module Conviction
+    class CompensationPaidAmountForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :compensation_payment_over_100
+    end
+  end
+end

--- a/app/views/steps/conviction/compensation_paid_amount/edit.html.erb
+++ b/app/views/steps/conviction/compensation_paid_amount/edit.html.erb
@@ -1,0 +1,23 @@
+<% title t('.page_title') %>
+
+<div class="govuk-width-container">
+  <%= step_header %>
+
+  <main id="main-content" class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= error_summary %>
+        <%= step_subsection %>
+
+        <!-- The header is part of the radios legend by default, but can be configured -->
+
+        <%= step_form @form_object do |f| %>
+          <%= f.radio_button_fieldset :compensation_payment_over_100, inline: true, choices: GenericYesNo.values %>
+          <%= f.continue_button %>
+        <% end %>
+      </div>
+    </div>
+
+  </main>
+</div>

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -59,6 +59,9 @@ en:
       compensation_paid:
         edit:
           page_title: Compensation paid
+      compensation_paid_amount:
+        edit:
+          page_title: Compensation order amount
       compensation_payment_date:
         edit:
           page_title: Compensation payment date

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -172,6 +172,8 @@ en:
         adult_disqualification: Was the length of the disqualification given in weeks, months or years?
       steps_conviction_compensation_paid_form:
         compensation_paid: Have you paid the compensation in full?
+      steps_conviction_compensation_paid_amount_form:
+        compensation_payment_over_100: Was the compensation order amount over £100?
       steps_conviction_compensation_payment_date_form:
         compensation_payment_date: When did you pay the compensation in full?
       steps_conviction_motoring_endorsement_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
       edit_step :conviction_bail
       edit_step :conviction_bail_days
       edit_step :compensation_paid
+      edit_step :compensation_paid_amount
       edit_step :compensation_payment_date
       show_step :compensation_not_paid
       edit_step :motoring_endorsement

--- a/spec/controllers/steps/conviction/compensation_paid_amount_controller_spec.rb
+++ b/spec/controllers/steps/conviction/compensation_paid_amount_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Conviction::CompensationPaidAmountController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Conviction::CompensationPaidAmountForm, ConvictionDecisionTree
+end


### PR DESCRIPTION
Depends on https://github.com/ministryofjustice/disclosure-checker/pull/340

This PR is to add a new page in the journey to ask whether the compensation payment was over £100, this will then be used later in the journey to ask if there's a receipt (if it was over £100).