### PR TITLE
Update the error message when user does not select a radio button

### DIFF
--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -84,6 +84,10 @@ en:
         inclusion: Select caution type
       compensation_paid:
         inclusion: Select yes or no
+      compensation_payment_over_100:
+        inclusion: Select yes or no
+      compensation_receipt_sent:
+        inclusion: Select yes or no
 
     check_completed:
       page_title: Check completed

--- a/features/adults/conviction_financial.feature
+++ b/features/adults/conviction_financial.feature
@@ -37,6 +37,16 @@ Feature: Conviction
 
     Then I should be on "/steps/check/results"
 
+  Scenario: Conviction Financial penalty - Does not select a radio button on over £100 screen
+    When I choose "Compensation to a victim"
+    Then I should see "Have you paid the compensation in full?"
+    And I choose "Yes"
+
+    Then I should see "Was the compensation order amount over £100?"
+    And I click the "Continue" button
+
+    Then I should see "Select yes or no"
+
   @happy_path
   Scenario: Conviction Financial penalty - Did not send payment receipt
     When I choose "Compensation to a victim"
@@ -53,6 +63,22 @@ Feature: Conviction
     And I choose "No"
 
     Then I should be on "/steps/conviction/compensation_unable_to_tell"
+
+  Scenario: Conviction Financial penalty - Does not select radio button on DBS screen
+    When I choose "Compensation to a victim"
+    Then I should see "Have you paid the compensation in full?"
+    And I choose "Yes"
+
+    Then I should see "Was the compensation order amount over £100?"
+    And I choose "Yes"
+
+    Then I should see "When did you pay the compensation in full?"
+    When I enter a valid date
+
+    Then I should see "Did you send the payment receipt to the Disclosure and Barring (DBS) service?"
+    And I click the "Continue" button
+
+    Then I should see "Select yes or no"
 
   @happy_path
   Scenario: Conviction Financial penalty - Compensation not paid in full


### PR DESCRIPTION
This commit updates the radio button error message to be more specific instead
of using a generic phrase.

I decided to use cucumber to test that the error message is correct, but happy to discuss this if you think it's too much.

### before

![image](https://user-images.githubusercontent.com/136777/78133911-2f02bd80-7417-11ea-9fec-95bba7d6de36.png)


### after

![image](https://user-images.githubusercontent.com/136777/78133834-11cdef00-7417-11ea-8638-71e8d9de5702.png)
