### PR TITLE
Add transaction tracking to "Unable to tell" (exit page)

### DIFF
--- a/app/views/steps/conviction/compensation_unable_to_tell/show.html.erb
+++ b/app/views/steps/conviction/compensation_unable_to_tell/show.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'Compensation unable to tell', category: 'Kickouts' %>
 
 <div class="govuk-width-container">
   <%= step_header %>


### PR DESCRIPTION
We are already tracking some things in this service, with Google Analytics
transactions, because goals can't trigger more than once for the same session and
many users of this service will do multiple checks in one session if they have
multiple convictions etc.

So in order to track those, we use a helper method named `track_transaction`,
and although it tracks automatically completions, it doesn't track exit pages
(or kick outs) out of the box so we have to add the call manually.