### PR TITLE
Update motoring results page copy

### DIFF
--- a/app/views/steps/check/results/shared/_motoring.en.html.erb
+++ b/app/views/steps/check/results/shared/_motoring.en.html.erb
@@ -3,14 +3,13 @@
 </h2>
 
 <p class="govuk-body">
-  This tool and your results tell you whether cautions or convictions are spent, but insurance companies may also check your driving record (as well as your criminal record).
+  This checker tells you whether cautions or convictions are spent. However, some motoring endorsements stay on your driving record after the caution or conviction is spent.
 </p>
 
 <p class="govuk-body">
-  You can <a class="govuk-link" href="https://www.gov.uk/view-driving-licence" rel="external" target="_blank">view your driving record</a> to find out what information the DVLA holds about you.
+  Your driving record is maintained by the Driver and Vehicle Licensing Agency (DVLA). You can <a href="https://www.gov.uk/view-driving-licence" class="govuk-link" rel="external" target="_blank">view your driving licence information</a>, including your driving record, on GOV.UK.
 </p>
 
-
-
-
-
+<p class="govuk-body">
+  See <a href="https://www.gov.uk/penalty-points-endorsements" class="govuk-link" rel="external" target="_blank">gov.uk/penalty-points-endorsements</a> for more information about driving records.
+</p>

--- a/app/views/steps/check/results/show.en.html+conviction_never_spent.erb
+++ b/app/views/steps/check/results/show.en.html+conviction_never_spent.erb
@@ -31,6 +31,8 @@
             record check</a>.
         </p>
 
+        <%= render partial: 'steps/check/results/shared/motoring' if @presenter.conviction_type.motoring? %>
+
         <%= render partial: 'steps/check/results/shared/summary', locals: { result: @presenter } %>
 
         <%= render partial: 'steps/check/results/shared/disclaimer' %>


### PR DESCRIPTION
https://mojdigital.teamwork.com/#/tasks/19966291

Minor copy changes to motoring convictions in the results page.

Added the motoring partial also to the never spent results page, as even when never spent, the information and links in the partial is valuable and still apply.

<img width="1015" alt="Screen Shot 2020-04-20 at 10 40 36" src="https://user-images.githubusercontent.com/687910/79737573-6ddbb300-82f3-11ea-954e-ba470ea3b7d6.png">
