### PR TITLE
Introduce under age motoring convictions

### DIFF
--- a/app/decorators/conviction_decorator.rb
+++ b/app/decorators/conviction_decorator.rb
@@ -14,7 +14,8 @@ module ConvictionDecorator
   end
 
   def motoring?
-    ConvictionType::ADULT_MOTORING.eql?(self)
+    ConvictionType::YOUTH_MOTORING.eql?(self) ||
+      ConvictionType::ADULT_MOTORING.eql?(self)
   end
 
   def bailable_offense?

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -47,13 +47,13 @@ class ConvictionDecisionTree < BaseDecisionTree
   def after_conviction_subtype
     return edit(:conviction_bail)   if conviction_subtype.bailable_offense? && !step_name.eql?(:bypass_bail_conviction_subtype)
     return edit(:compensation_paid) if conviction_subtype.compensation?
-    return after_adult_motoring     if conviction_subtype.parent.inquiry.adult_motoring?
+    return after_adult_motoring     if conviction_subtype.parent.inquiry.adult_motoring? || conviction_subtype.parent.inquiry.youth_motoring?
 
     known_date_question
   end
 
   def after_adult_motoring
-    return edit(:motoring_lifetime_ban) if conviction_subtype.inquiry.adult_disqualification?
+    return edit(:motoring_lifetime_ban) if conviction_subtype.inquiry.adult_disqualification? || conviction_subtype.inquiry.youth_disqualification?
 
     edit(:motoring_endorsement)
   end
@@ -66,7 +66,7 @@ class ConvictionDecisionTree < BaseDecisionTree
 
   def after_known_date
     return results if conviction_subtype.skip_length?
-    return edit(:motoring_disqualification_end_date) if conviction_subtype.inquiry.adult_disqualification?
+    return edit(:motoring_disqualification_end_date) if conviction_subtype.inquiry.adult_disqualification? || conviction_subtype.inquiry.youth_disqualification?
 
     edit(:conviction_length_type)
   end
@@ -108,7 +108,7 @@ class ConvictionDecisionTree < BaseDecisionTree
   end
 
   def penalty_notice_without_endorsement?
-    conviction_subtype.inquiry.adult_penalty_notice? && GenericYesNo.new(disclosure_check.motoring_endorsement).no?
+    (conviction_subtype.inquiry.adult_penalty_notice? || conviction_subtype.inquiry.youth_penalty_notice?) && GenericYesNo.new(disclosure_check.motoring_endorsement).no?
   end
 
   def known_date_question

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -21,6 +21,7 @@ class ConvictionType < ValueObject
       FINANCIAL             = new(:financial),
       MILITARY              = new(:military),
       PREVENTION_REPARATION = new(:prevention_reparation),
+      YOUTH_MOTORING        = new(:youth_motoring),
     ].freeze,
 
     ADULT_PARENT_TYPES = [
@@ -64,6 +65,11 @@ class ConvictionType < ValueObject
     REPARATION_ORDER                   = new(:reparation_order,                 parent: PREVENTION_REPARATION, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
     RESTRAINING_ORDER                  = new(:restraining_order,                parent: PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     SEXUAL_HARM_PREVENTION_ORDER       = new(:sexual_harm_prevention_order,     parent: PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+
+    YOUTH_DISQUALIFICATION             = new(:youth_disqualification,           parent: YOUTH_MOTORING, calculator_class: Calculators::MotoringCalculator::Disqualification),
+    YOUTH_MOTORING_FINE                = new(:youth_motoring_fine,              parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::MotoringFine),
+    YOUTH_PENALTY_NOTICE               = new(:youth_penalty_notice,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyNotice),
+    YOUTH_PENALTY_POINTS               = new(:youth_penalty_points,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyPoints),
 
     ######################
     # Adults convictions #

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -33,6 +33,7 @@ en:
       financial: Financial penalty
       military: Military
       prevention_reparation: Prevention or reparation order
+      youth_motoring: Motoring
       # adults
       adult_community_reparation: Community, prevention or reparation order
       adult_discharge: Discharge
@@ -88,6 +89,11 @@ en:
       adult_motoring_fine: Fine
       adult_penalty_notice: Fixed Penalty notice (FPN)
       adult_penalty_points: Penalty points
+      # adult_motoring
+      youth_disqualification: Disqualification
+      youth_motoring_fine: Fine
+      youth_penalty_notice: Fixed Penalty notice (FPN)
+      youth_penalty_points: Penalty points
       # adult_discharge
       adult_bind_over: Bind over
       adult_absolute_discharge: Absolute discharge
@@ -143,6 +149,10 @@ en:
         adult_motoring_fine: When were you given the fine?
         adult_penalty_notice: When was the endorsement given?
         adult_penalty_points: When were you given the penalty points?
+        youth_disqualification: When did the ban start?
+        youth_motoring_fine: When were you given the fine?
+        youth_penalty_notice: When was the endorsement given?
+        youth_penalty_points: When were you given the penalty points?
       steps_conviction_conviction_type_form:
         conviction_type: What type of conviction did you get?
       steps_conviction_conviction_subtype_form:
@@ -156,6 +166,7 @@ en:
         military: What was your military conviction?
         adult_military: What was your military conviction?
         adult_motoring: What was your motoring conviction?
+        youth_motoring: What was your motoring conviction?
         adult_community_reparation: What was your community, prevention or reparation order?
         adult_discharge: What discharge were you given?
         adult_custodial_sentence: What sentence were you given?
@@ -214,6 +225,7 @@ en:
         adult_prison_sentence_html: *order_started_hint_text
         adult_suspended_prison_sentence_html: *order_started_hint_text
         adult_disqualification_html: If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>
+        youth_disqualification_html: If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>
       steps_conviction_compensation_payment_date_form:
         compensation_payment_date_html: If you paid the compensation in stages, enter the date you made the final payment. If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>
         approximate_compensation_payment_date: *approximate_date_hint
@@ -245,6 +257,7 @@ en:
           financial: For example, paying a fine or compensation that was not part of a community order or youth rehabilitation order
           military: For example, a dismissal or service detention
           prevention_reparation: For example, a restraining order or sexual harm prevention order
+          youth_motoring: For example, penalty points or a driving ban
           # adults
           adult_community_reparation: For example, a sexual prevention order or a restraining order. You might have been asked to wear a tag as part of your order
           adult_discharge: For example, a conditional discharge order or bind over
@@ -299,6 +312,11 @@ en:
           adult_motoring_fine: A court gave you a fine that was not a fixed penalty notice (FPN)
           adult_penalty_notice: You were given a fine ‘on the spot’ or by post
           adult_penalty_points: You were given a number of penalty points for a driving offence
+          # youth motoring
+          youth_disqualification: You were banned from driving
+          youth_motoring_fine: A court gave you a fine that was not a fixed penalty notice (FPN)
+          youth_penalty_notice: You were given a fine ‘on the spot’ or by post
+          youth_penalty_points: You were given a number of penalty points for a driving offence
           # adult_discharge
           adult_bind_over: Your sentence was postponed as long as you kept to certain conditions
           adult_absolute_discharge: You were found guilty of a crime but did not get sentenced

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -70,6 +70,11 @@ en:
       adult_motoring_fine: Fine
       adult_penalty_notice: Fixed Penalty notice (FPN)
       adult_penalty_points: Penalty points
+      # youth_motoring
+      youth_disqualification: Disqualification
+      youth_motoring_fine: Fine
+      youth_penalty_notice: Fixed Penalty notice (FPN)
+      youth_penalty_points: Penalty points
       # adult_discharge
       adult_bind_over: Bind over
       adult_absolute_discharge: Absolute discharge

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -77,3 +77,10 @@ When(/^I enter a valid date$/) do
   step %[I fill in "Year" with "1999"]
   step %[I click the "Continue" button]
 end
+
+When(/^I enter the following date (\d+)\-(\d+)\-(\d+)$/) do |day, month, year|
+  step %[I fill in "Day" with "#{day}"]
+  step %[I fill in "Month" with "#{month}"]
+  step %[I fill in "Year" with "#{year}"]
+  step %[I click the "Continue" button]
+end

--- a/features/youth/conviction_motoring.feature
+++ b/features/youth/conviction_motoring.feature
@@ -1,0 +1,65 @@
+Feature: Youth Conviction
+  Background:
+    Given I am completing a basic under 18 "Motoring" conviction
+    Then I should see "What was your motoring conviction?"
+
+  @happy_path
+  Scenario: Lifetime Motoring convictions
+    When I choose "Disqualification"
+
+    Then I should see "Were you given a lifetime ban?"
+    And I choose "Yes"
+
+    Then I should be on "/steps/check/results"
+    And I should see "This conviction will never be spent"
+
+  @happy_path
+  Scenario Outline: Motoring convictions
+    When I choose "<subtype>"
+    Then I should see "Were you given a lifetime ban?"
+    And I choose "No"
+
+    Then I should see "Did you get an endorsement?"
+    And I choose "Yes"
+
+    Then I should see "<known_date_header>"
+    And I enter the following date 01-01-2020
+
+    Then I should see "<motoring_disqualification_end_date_header>"
+    And I enter the following date 01-01-2020
+
+    Then I should be on "<result>"
+    And I should see "This conviction will be spent on 1 July 2022"
+
+    Examples:
+      | subtype           | known_date_header          | motoring_disqualification_end_date_header | result               |
+      | Disqualification  | When did the ban start?    | When did your disqualification end?       | /steps/check/results |
+
+  @happy_path
+  Scenario Outline: Motoring convictions without length
+    When I choose "<subtype>"
+    Then I should see "Did you get an endorsement?"
+
+    And I choose "<endorsement>"
+    Then I should see "<known_date_header>"
+
+    And I enter the following date 01-01-2020
+    Then I should be on "<result>"
+    And I should see "<spent_date>"
+
+    Examples:
+      | subtype                    | endorsement | known_date_header                        | result               | spent_date                                      |
+      | Fine                       | Yes         | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 July 2022    |
+      | Fine                       | No          | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 July 2020    |
+      | Fixed Penalty notice (FPN) | Yes         | When was the endorsement given?          | /steps/check/results | This conviction will be spent on 1 January 2025 |
+      | Penalty points             | Yes         | When were you given the penalty points?  | /steps/check/results | This conviction will be spent on 1 January 2023 |
+
+  @happy_path
+  Scenario: Fixed Penalty notice (FPN) convictions without endorsement
+    When I choose "Fixed Penalty notice (FPN)"
+
+    Then I should see "Did you get an endorsement?"
+    And I choose "No"
+
+    Then I should be on "/steps/check/results"
+    And I should see "This fixed penalty notice (FPN) was not a conviction"

--- a/spec/decorators/conviction_decorator_spec.rb
+++ b/spec/decorators/conviction_decorator_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe ConvictionDecorator do
       it { expect(subject.motoring?).to eq(false) }
     end
 
+    context 'for a youth `ConvictionType::YOUTH_MOTORING` conviction type' do
+      subject { ConvictionType::YOUTH_MOTORING }
+      it { expect(subject.motoring?).to eq(true) }
+    end
+
     context 'for an adult `ConvictionType::ADULT_MOTORING` conviction type' do
       subject { ConvictionType::ADULT_MOTORING }
       it { expect(subject.motoring?).to eq(true) }

--- a/spec/services/calculators/motoring_calculator_spec.rb
+++ b/spec/services/calculators/motoring_calculator_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe Calculators::MotoringCalculator do
   subject { described_class.new(disclosure_check) }
 
   let(:disclosure_check) { build(:disclosure_check,
+                                 under_age: under_age,
                                  known_date: known_date,
                                  motoring_endorsement: motoring_endorsement,
                                  motoring_disqualification_end_date: motoring_disqualification_end_date,
                                  motoring_lifetime_ban: motoring_lifetime_ban) }
 
+  let(:under_age) { GenericYesNo::NO }
   let(:known_date) { Date.new(2018, 10, 31) }
   let(:motoring_endorsement) { GenericYesNo::NO }
   let(:motoring_disqualification_end_date) { Date.new(2020, 10, 31) }
@@ -28,6 +30,12 @@ RSpec.describe Calculators::MotoringCalculator do
             let(:motoring_endorsement) { GenericYesNo::YES }
             context 'less than or equal 5 years' do
               it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+
+              context 'when under age' do
+                let(:under_age) { GenericYesNo::YES }
+
+                it { expect(subject.expiry_date.to_s).to eq((known_date + 30.months).to_s) }
+              end
             end
 
             context 'greater than 5 years' do
@@ -38,10 +46,16 @@ RSpec.describe Calculators::MotoringCalculator do
 
           context 'without a motoring endorsement ' do
             it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+
+            context 'when under age' do
+              let(:under_age) { GenericYesNo::YES }
+
+              it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+            end
           end
         end
 
-        context 'with a motoring_disqualification_end_date' do
+        context 'without a motoring_disqualification_end_date' do
           let(:motoring_disqualification_end_date) { nil }
           context 'with a motoring endorsement ' do
             let(:motoring_endorsement) { GenericYesNo::YES }
@@ -62,10 +76,22 @@ RSpec.describe Calculators::MotoringCalculator do
       context 'with a motoring endorsement ' do
         let(:motoring_endorsement) { GenericYesNo::YES }
         it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+
+        context 'when under age' do
+          let(:under_age) { GenericYesNo::YES }
+
+          it { expect(subject.expiry_date.to_s).to eq((known_date + 30.months).to_s) }
+        end
       end
 
       context 'without a motoring endorsement ' do
         it { expect(subject.expiry_date.to_s).to eq('2019-10-31') }
+
+        context 'when under age' do
+          let(:under_age) { GenericYesNo::YES }
+
+          it { expect(subject.expiry_date.to_s).to eq((known_date + 6.months).to_s) }
+        end
       end
     end
   end
@@ -76,10 +102,22 @@ RSpec.describe Calculators::MotoringCalculator do
       context 'with a motoring endorsement ' do
         let(:motoring_endorsement) { GenericYesNo::YES }
         it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+
+        context 'when under age' do
+          let(:under_age) { GenericYesNo::YES }
+
+          it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
+        end
       end
 
       context 'without a motoring endorsement ' do
         it { expect(subject.expiry_date.to_s).to eq('2021-10-31') }
+
+        context 'when under age' do
+          let(:under_age) { GenericYesNo::YES }
+
+          it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
+        end
       end
     end
   end

--- a/spec/services/conviction_length_choices_spec.rb
+++ b/spec/services/conviction_length_choices_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ConvictionLengthChoices do
       ConvictionType.values.size - described_class::SUBTYPES_HIDE_NO_LENGTH_CHOICE.size
     }
 
-    it { expect(total).to eq(48) }
+    it { expect(total).to eq(53) }
   end
 
   describe '.choices' do

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ConvictionType do
         financial
         military
         prevention_reparation
+        youth_motoring
       ))
     end
   end


### PR DESCRIPTION
This commit introduces motoring convictions for under age, it slightly differs from adult motoring convictions,
for under age, the convictions are spent sooner.

The differences are:
- [Endorsement is 2.5 years (30 months)](https://www.gov.uk/guidance/telling-people-about-your-criminal-record#motoring) instead of 5 years (60 months)
- [Fines are 6 months](https://www.gov.uk/guidance/telling-people-about-your-criminal-record#fine) instead of 1 year (12 months)


Story: https://mojdigital.teamwork.com/#/tasks/20007708

### Example

![image](https://user-images.githubusercontent.com/136777/82532794-f7bcad00-9b39-11ea-8796-12375f522d58.png)
