### PR TITLE
Reorganise Motoring Calculator

### DIFF
--- a/app/services/calculators/motoring/adult/disqualification.rb
+++ b/app/services/calculators/motoring/adult/disqualification.rb
@@ -1,0 +1,52 @@
+module Calculators
+  module Motoring
+    module Adult
+      # If a lifetime ban was given:
+      #  - never spent
+      # If no end_date was given: Start date + 5 years
+      #  - Start date + 5 years
+      # If an endorsement was received
+      #  - If (end_date - start_date) is less than or equal to 5 years: start_date + 5 years
+      #  - If (end_date - start_date) is greater than 5 years: end_date
+
+      # If an endorsement was not received
+      # If no end_date was given:
+      #  - Start date + 2 years
+      # with an End date
+      #  - End date
+      class Disqualification < MotoringCalculator
+        FIVE_YEARS_ADDED_TIME = { months: 60 }.freeze
+        TWO_YEARS_ADDED_TIME = { months: 24 }.freeze
+
+        def expiry_date
+          return :never_spent if GenericYesNo.new(disclosure_check.motoring_lifetime_ban).yes?
+          return conviction_start_date.advance(missing_end_date_spent_time) if motoring_disqualification_end_date.nil?
+
+          spent_time
+        end
+
+        private
+
+        def spent_time
+          return conviction_start_date.advance(FIVE_YEARS_ADDED_TIME) if motoring_endorsement? && within_endorsement_threshold?
+
+          motoring_disqualification_end_date
+        end
+
+        def missing_end_date_spent_time
+          return FIVE_YEARS_ADDED_TIME if motoring_endorsement?
+
+          TWO_YEARS_ADDED_TIME
+        end
+
+        def motoring_disqualification_end_date
+          @motoring_disqualification_end_date ||= disclosure_check.motoring_disqualification_end_date
+        end
+
+        def within_endorsement_threshold?
+          distance_in_months(conviction_start_date, motoring_disqualification_end_date) <= ENDORSEMENT_THRESHOLD
+        end
+      end
+    end
+  end
+end

--- a/app/services/calculators/motoring/adult/disqualification.rb
+++ b/app/services/calculators/motoring/adult/disqualification.rb
@@ -44,7 +44,7 @@ module Calculators
         end
 
         def within_endorsement_threshold?
-          distance_in_months(conviction_start_date, motoring_disqualification_end_date) <= ENDORSEMENT_THRESHOLD
+          distance_in_months(conviction_start_date, motoring_disqualification_end_date) <= ADULT_ENDORSEMENT_THRESHOLD
         end
       end
     end

--- a/app/services/calculators/motoring/adult/fine.rb
+++ b/app/services/calculators/motoring/adult/fine.rb
@@ -1,0 +1,20 @@
+module Calculators
+  module Motoring
+    module Adult
+      # If an endorsement was received
+      # start_date + 5 years
+      # If an endorsement was not received
+      # start_date + 1 year
+      class Fine < MotoringCalculator
+        REHABILITATION_1 = { months: 60 }.freeze
+        REHABILITATION_2 = { months: 12 }.freeze
+
+        def expiry_date
+          return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
+
+          conviction_start_date.advance(REHABILITATION_2)
+        end
+      end
+    end
+  end
+end

--- a/app/services/calculators/motoring/adult/penalty_notice.rb
+++ b/app/services/calculators/motoring/adult/penalty_notice.rb
@@ -1,0 +1,20 @@
+module Calculators
+  module Motoring
+    module Adult
+      # If an endorsement was received
+      # start_date + 5 years
+
+      # If an endorsement was not received
+      # Go to different result page: https://moj-disclosure-checker.herokuapp.com/motoring/v3/fpn-no-conviction
+      class PenaltyNotice < MotoringCalculator
+        REHABILITATION_1 = { months: 60 }.freeze
+
+        def expiry_date
+          return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
+
+          :no_record
+        end
+      end
+    end
+  end
+end

--- a/app/services/calculators/motoring/adult/penalty_points.rb
+++ b/app/services/calculators/motoring/adult/penalty_points.rb
@@ -1,0 +1,20 @@
+module Calculators
+  module Motoring
+    module Adult
+      # If an endorsement was received:
+      # start_date + 5 years
+      # If an endorsement was not received:
+      # start_date + 3 years
+      class PenaltyPoints < MotoringCalculator
+        REHABILITATION_1 = { months: 60 }.freeze
+        REHABILITATION_2 = { months: 36 }.freeze
+
+        def expiry_date
+          return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
+
+          conviction_start_date.advance(REHABILITATION_2)
+        end
+      end
+    end
+  end
+end

--- a/app/services/calculators/motoring/youth/disqualification.rb
+++ b/app/services/calculators/motoring/youth/disqualification.rb
@@ -1,0 +1,53 @@
+module Calculators
+  module Motoring
+    module Youth
+      # If a lifetime ban was given:
+      #  - never spent
+      # If no end_date was given:
+      #  - Start date + 2 years
+      # If an endorsement was received
+      #  - If (end_date - start_date) is less than or equal to 2.5 years: start_date + 2.5 years
+      #  - If (end_date - start_date) is greater than 2.5 years: end_date
+
+      # If an endorsement was not received
+      # If no end_date was given:
+      #  - Start date + 2 years
+      # with an End date
+      #  - End date
+      class Disqualification < MotoringCalculator
+        FIVE_YEARS_ADDED_TIME = { months: 60 }.freeze
+        TWO_AND_HALF_YEARS_ADDED_TIME = { months: 30 }.freeze
+        TWO_YEARS_ADDED_TIME = { months: 24 }.freeze
+
+        def expiry_date
+          return :never_spent if GenericYesNo.new(disclosure_check.motoring_lifetime_ban).yes?
+          return conviction_start_date.advance(missing_end_date_spent_time) if motoring_disqualification_end_date.nil?
+
+          spent_time
+        end
+
+        private
+
+        def spent_time
+          return conviction_start_date.advance(TWO_AND_HALF_YEARS_ADDED_TIME) if motoring_endorsement? && within_endorsement_threshold?
+
+          motoring_disqualification_end_date
+        end
+
+        def missing_end_date_spent_time
+          return TWO_AND_HALF_YEARS_ADDED_TIME if motoring_endorsement?
+
+          TWO_YEARS_ADDED_TIME
+        end
+
+        def motoring_disqualification_end_date
+          @motoring_disqualification_end_date ||= disclosure_check.motoring_disqualification_end_date
+        end
+
+        def within_endorsement_threshold?
+          distance_in_months(conviction_start_date, motoring_disqualification_end_date) <= YOUTH_ENDORSEMENT_THRESHOLD
+        end
+      end
+    end
+  end
+end

--- a/app/services/calculators/motoring/youth/fine.rb
+++ b/app/services/calculators/motoring/youth/fine.rb
@@ -1,0 +1,20 @@
+module Calculators
+  module Motoring
+    module Youth
+      # If an endorsement was received
+      # start_date + 2.5 years
+      # If an endorsement was not received
+      # start_date + 6 months
+      class Fine < MotoringCalculator
+        REHABILITATION_1 = { months: 30 }.freeze
+        REHABILITATION_2 = { months: 6 }.freeze
+
+        def expiry_date
+          return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
+
+          conviction_start_date.advance(REHABILITATION_2)
+        end
+      end
+    end
+  end
+end

--- a/app/services/calculators/motoring/youth/penalty_notice.rb
+++ b/app/services/calculators/motoring/youth/penalty_notice.rb
@@ -1,0 +1,20 @@
+module Calculators
+  module Motoring
+    module Youth
+      # If an endorsement was received
+      # start_date + 2.5 years
+
+      # If an endorsement was not received
+      # Go to different result page: https://moj-disclosure-checker.herokuapp.com/motoring/v3/fpn-no-conviction
+      class PenaltyNotice < MotoringCalculator
+        REHABILITATION_1 = { months: 30 }.freeze
+
+        def expiry_date
+          return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
+
+          :no_record
+        end
+      end
+    end
+  end
+end

--- a/app/services/calculators/motoring/youth/penalty_points.rb
+++ b/app/services/calculators/motoring/youth/penalty_points.rb
@@ -1,0 +1,20 @@
+module Calculators
+  module Motoring
+    module Youth
+      # If an endorsement was received:
+      # start_date + 3 years
+      # If an endorsement was not received:
+      # start_date + 3 years
+      # Because the Youth endorsement is 2.5 years and penalty points are 3 years,
+      # even if there is an endorsement, the penalty points have a longer duration
+      # hence being 3 years always
+      class PenaltyPoints < MotoringCalculator
+        REHABILITATION_1 = { months: 36 }.freeze
+
+        def expiry_date
+          conviction_start_date.advance(REHABILITATION_1)
+        end
+      end
+    end
+  end
+end

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -5,23 +5,6 @@ module Calculators
 
     # If an endorsement was received
     # start_date + 5 years
-
-    # If an endorsement was not received
-    # Go to different result page: https://moj-disclosure-checker.herokuapp.com/motoring/v3/fpn-no-conviction
-    class PenaltyNotice < MotoringCalculator
-      REHABILITATION_1 = { months: 60 }.freeze
-      TWO_AND_HALF_YEARS_ADDED_TIME = { months: 30 }.freeze
-
-      def expiry_date
-        return conviction_start_date.advance(TWO_AND_HALF_YEARS_ADDED_TIME) if (under_age? && motoring_endorsement?)
-        return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
-
-        :no_record
-      end
-    end
-
-    # If an endorsement was received
-    # start_date + 5 years
     # If an endorsement was not received
     # start_date + 1 year
     # If under age start_date + 6 months

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -3,26 +3,6 @@ module Calculators
     ENDORSEMENT_THRESHOLD = 60
     YOUTH_ENDORSEMENT_THRESHOLD = 30
 
-    # If an endorsement was received
-    # start_date + 5 years
-    # If an endorsement was not received
-    # start_date + 1 year
-    # If under age start_date + 6 months
-    class MotoringFine < MotoringCalculator
-      REHABILITATION_1 = { months: 60 }.freeze
-      REHABILITATION_2 = { months: 12 }.freeze
-      UNDER_AGE_REHABILITATION_1 = { months: 30 }.freeze
-      UNDER_AGE_REHABILITATION_2 = { months: 6 }.freeze
-
-      def expiry_date
-        return conviction_start_date.advance(self.class::REHABILITATION_1) if motoring_endorsement? && !under_age?
-        return conviction_start_date.advance(self.class::UNDER_AGE_REHABILITATION_1) if motoring_endorsement? && under_age?
-        return conviction_start_date.advance(self.class::UNDER_AGE_REHABILITATION_2) if under_age?
-
-        conviction_start_date.advance(self.class::REHABILITATION_2)
-      end
-    end
-
     # If an endorsement was received:
     # start_date + 5 years
     # If an endorsement was not received:

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -1,11 +1,7 @@
 module Calculators
   class MotoringCalculator < BaseCalculator
-    ENDORSEMENT_THRESHOLD = 60
+    ADULT_ENDORSEMENT_THRESHOLD = 60
     YOUTH_ENDORSEMENT_THRESHOLD = 30
-
-    def under_age?
-      GenericYesNo.new(disclosure_check.under_age).yes?
-    end
 
     def motoring_endorsement?
       GenericYesNo.new(disclosure_check.motoring_endorsement).yes?

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -1,6 +1,7 @@
 module Calculators
   class MotoringCalculator < BaseCalculator
     ENDORSEMENT_THRESHOLD = 60
+    YOUTH_ENDORSEMENT_THRESHOLD = 30
 
     # If a lifetime ban was given:
     #  - never spent

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -3,55 +3,6 @@ module Calculators
     ENDORSEMENT_THRESHOLD = 60
     YOUTH_ENDORSEMENT_THRESHOLD = 30
 
-    # If a lifetime ban was given:
-    #  - never spent
-    # If no end_date was given: Start date + 5 years
-    #  - Start date + 5 years
-    # If an endorsement was received
-    #  - If (end_date - start_date) is less than or equal to 5 years: start_date + 5 years
-    #  - If (end_date - start_date) is greater than 5 years: end_date
-
-    # If an endorsement was not received
-    # If no end_date was given:
-    #  - Start date + 2 years
-    # with an End date
-    #  - End date
-    class Disqualification < MotoringCalculator
-      FIVE_YEARS_ADDED_TIME = { months: 60 }.freeze
-      TWO_AND_HALF_YEARS_ADDED_TIME = { months: 30 }.freeze
-      TWO_YEARS_ADDED_TIME = { months: 24 }.freeze
-
-      def expiry_date
-        return :never_spent if GenericYesNo.new(disclosure_check.motoring_lifetime_ban).yes?
-        return conviction_start_date.advance(missing_end_date_spent_time) if motoring_disqualification_end_date.nil?
-
-        spent_time
-      end
-
-      private
-
-      def spent_time
-        return conviction_start_date.advance(TWO_AND_HALF_YEARS_ADDED_TIME) if (under_age? && motoring_endorsement?) && within_endorsement_threshold?
-        return conviction_start_date.advance(FIVE_YEARS_ADDED_TIME) if motoring_endorsement? && within_endorsement_threshold?
-
-        motoring_disqualification_end_date
-      end
-
-      def missing_end_date_spent_time
-        return FIVE_YEARS_ADDED_TIME if motoring_endorsement?
-
-        TWO_YEARS_ADDED_TIME
-      end
-
-      def motoring_disqualification_end_date
-        @motoring_disqualification_end_date ||= disclosure_check.motoring_disqualification_end_date
-      end
-
-      def within_endorsement_threshold?
-        distance_in_months(conviction_start_date, motoring_disqualification_end_date) <= ENDORSEMENT_THRESHOLD
-      end
-    end
-
     # If an endorsement was received
     # start_date + 5 years
 

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -58,8 +58,10 @@ module Calculators
     # Go to different result page: https://moj-disclosure-checker.herokuapp.com/motoring/v3/fpn-no-conviction
     class PenaltyNotice < MotoringCalculator
       REHABILITATION_1 = { months: 60 }.freeze
+      TWO_AND_HALF_YEARS_ADDED_TIME = { months: 30 }.freeze
 
       def expiry_date
+        return conviction_start_date.advance(TWO_AND_HALF_YEARS_ADDED_TIME) if (under_age? && motoring_endorsement?)
         return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
 
         :no_record

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -99,7 +99,7 @@ module Calculators
     end
 
     def expiry_date
-      return conviction_start_date.advance(self.class::REHABILITATION_1) if motoring_endorsement? && !under_age?
+      return conviction_start_date.advance(self.class::REHABILITATION_1) if motoring_endorsement?
 
       conviction_start_date.advance(self.class::REHABILITATION_2)
     end

--- a/app/services/calculators/motoring_calculator.rb
+++ b/app/services/calculators/motoring_calculator.rb
@@ -3,21 +3,6 @@ module Calculators
     ENDORSEMENT_THRESHOLD = 60
     YOUTH_ENDORSEMENT_THRESHOLD = 30
 
-    # If an endorsement was received:
-    # start_date + 5 years
-    # If an endorsement was not received:
-    # start_date + 3 years
-    class PenaltyPoints < MotoringCalculator
-      REHABILITATION_1 = { months: 60 }.freeze
-      REHABILITATION_2 = { months: 36 }.freeze
-    end
-
-    def expiry_date
-      return conviction_start_date.advance(self.class::REHABILITATION_1) if motoring_endorsement?
-
-      conviction_start_date.advance(self.class::REHABILITATION_2)
-    end
-
     def under_age?
       GenericYesNo.new(disclosure_check.under_age).yes?
     end

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -97,7 +97,7 @@ class ConvictionType < ValueObject
     ADULT_SERVICE_DETENTION             = new(:adult_service_detention,            parent: ADULT_MILITARY, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusTwelveMonths),
 
     ADULT_DISQUALIFICATION              = new(:adult_disqualification,             parent: ADULT_MOTORING, calculator_class: Calculators::Motoring::Adult::Disqualification),
-    ADULT_MOTORING_FINE                 = new(:adult_motoring_fine,                parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::MotoringFine),
+    ADULT_MOTORING_FINE                 = new(:adult_motoring_fine,                parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Adult::Fine),
     ADULT_PENALTY_NOTICE                = new(:adult_penalty_notice,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Adult::PenaltyNotice),
     ADULT_PENALTY_POINTS                = new(:adult_penalty_points,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyPoints),
 

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -98,7 +98,7 @@ class ConvictionType < ValueObject
 
     ADULT_DISQUALIFICATION              = new(:adult_disqualification,             parent: ADULT_MOTORING, calculator_class: Calculators::Motoring::Adult::Disqualification),
     ADULT_MOTORING_FINE                 = new(:adult_motoring_fine,                parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::MotoringFine),
-    ADULT_PENALTY_NOTICE                = new(:adult_penalty_notice,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyNotice),
+    ADULT_PENALTY_NOTICE                = new(:adult_penalty_notice,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Adult::PenaltyNotice),
     ADULT_PENALTY_POINTS                = new(:adult_penalty_points,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyPoints),
 
     ADULT_HOSPITAL_ORDER                = new(:adult_hospital_order,               parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -99,7 +99,7 @@ class ConvictionType < ValueObject
     ADULT_DISQUALIFICATION              = new(:adult_disqualification,             parent: ADULT_MOTORING, calculator_class: Calculators::Motoring::Adult::Disqualification),
     ADULT_MOTORING_FINE                 = new(:adult_motoring_fine,                parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Adult::Fine),
     ADULT_PENALTY_NOTICE                = new(:adult_penalty_notice,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Adult::PenaltyNotice),
-    ADULT_PENALTY_POINTS                = new(:adult_penalty_points,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyPoints),
+    ADULT_PENALTY_POINTS                = new(:adult_penalty_points,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Adult::PenaltyPoints),
 
     ADULT_HOSPITAL_ORDER                = new(:adult_hospital_order,               parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_PRISON_SENTENCE               = new(:adult_prison_sentence,              parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::Prison),

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -96,7 +96,7 @@ class ConvictionType < ValueObject
     ADULT_SERVICE_COMMUNITY_ORDER       = new(:adult_service_community_order,      parent: ADULT_MILITARY, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
     ADULT_SERVICE_DETENTION             = new(:adult_service_detention,            parent: ADULT_MILITARY, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusTwelveMonths),
 
-    ADULT_DISQUALIFICATION              = new(:adult_disqualification,             parent: ADULT_MOTORING, calculator_class: Calculators::MotoringCalculator::Disqualification),
+    ADULT_DISQUALIFICATION              = new(:adult_disqualification,             parent: ADULT_MOTORING, calculator_class: Calculators::Motoring::Adult::Disqualification),
     ADULT_MOTORING_FINE                 = new(:adult_motoring_fine,                parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::MotoringFine),
     ADULT_PENALTY_NOTICE                = new(:adult_penalty_notice,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyNotice),
     ADULT_PENALTY_POINTS                = new(:adult_penalty_points,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyPoints),

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -66,7 +66,7 @@ class ConvictionType < ValueObject
     RESTRAINING_ORDER                  = new(:restraining_order,                parent: PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     SEXUAL_HARM_PREVENTION_ORDER       = new(:sexual_harm_prevention_order,     parent: PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 
-    YOUTH_DISQUALIFICATION             = new(:youth_disqualification,           parent: YOUTH_MOTORING, calculator_class: Calculators::MotoringCalculator::Disqualification),
+    YOUTH_DISQUALIFICATION             = new(:youth_disqualification,           parent: YOUTH_MOTORING, calculator_class: Calculators::Motoring::Youth::Disqualification),
     YOUTH_MOTORING_FINE                = new(:youth_motoring_fine,              parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::MotoringFine),
     YOUTH_PENALTY_NOTICE               = new(:youth_penalty_notice,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyNotice),
     YOUTH_PENALTY_POINTS               = new(:youth_penalty_points,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyPoints),

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -69,7 +69,7 @@ class ConvictionType < ValueObject
     YOUTH_DISQUALIFICATION             = new(:youth_disqualification,           parent: YOUTH_MOTORING, calculator_class: Calculators::Motoring::Youth::Disqualification),
     YOUTH_MOTORING_FINE                = new(:youth_motoring_fine,              parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Youth::Fine),
     YOUTH_PENALTY_NOTICE               = new(:youth_penalty_notice,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Youth::PenaltyNotice),
-    YOUTH_PENALTY_POINTS               = new(:youth_penalty_points,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyPoints),
+    YOUTH_PENALTY_POINTS               = new(:youth_penalty_points,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Youth::PenaltyPoints),
 
     ######################
     # Adults convictions #

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -68,7 +68,7 @@ class ConvictionType < ValueObject
 
     YOUTH_DISQUALIFICATION             = new(:youth_disqualification,           parent: YOUTH_MOTORING, calculator_class: Calculators::Motoring::Youth::Disqualification),
     YOUTH_MOTORING_FINE                = new(:youth_motoring_fine,              parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::MotoringFine),
-    YOUTH_PENALTY_NOTICE               = new(:youth_penalty_notice,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyNotice),
+    YOUTH_PENALTY_NOTICE               = new(:youth_penalty_notice,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Youth::PenaltyNotice),
     YOUTH_PENALTY_POINTS               = new(:youth_penalty_points,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyPoints),
 
     ######################

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -67,7 +67,7 @@ class ConvictionType < ValueObject
     SEXUAL_HARM_PREVENTION_ORDER       = new(:sexual_harm_prevention_order,     parent: PREVENTION_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 
     YOUTH_DISQUALIFICATION             = new(:youth_disqualification,           parent: YOUTH_MOTORING, calculator_class: Calculators::Motoring::Youth::Disqualification),
-    YOUTH_MOTORING_FINE                = new(:youth_motoring_fine,              parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::MotoringFine),
+    YOUTH_MOTORING_FINE                = new(:youth_motoring_fine,              parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Youth::Fine),
     YOUTH_PENALTY_NOTICE               = new(:youth_penalty_notice,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Youth::PenaltyNotice),
     YOUTH_PENALTY_POINTS               = new(:youth_penalty_points,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::MotoringCalculator::PenaltyPoints),
 

--- a/features/youth/conviction_motoring.feature
+++ b/features/youth/conviction_motoring.feature
@@ -26,24 +26,26 @@ Feature: Youth Conviction
     And I enter the following date 01-01-2020
 
     Then I should see "<motoring_disqualification_end_date_header>"
-    And I enter the following date 01-01-2020
+    And I enter the following date <disqualification_date>
 
     Then I should be on "<result>"
-    And I should see "This conviction will be spent on 1 July 2022"
+    And I should see "<spent_date>"
 
     Examples:
-      | subtype           | known_date_header          | motoring_disqualification_end_date_header | result               |
-      | Disqualification  | When did the ban start?    | When did your disqualification end?       | /steps/check/results |
+      | subtype           | known_date_header          | motoring_disqualification_end_date_header | disqualification_date | result               | spent_date                                   |
+      | Disqualification  | When did the ban start?    | When did your disqualification end?       | 01-06-2020            | /steps/check/results | This conviction will be spent on 1 July 2022 |
+      | Disqualification  | When did the ban start?    | When did your disqualification end?       | 22-05-2023            | /steps/check/results | This conviction will be spent on 22 May 2023 |
 
   @happy_path
   Scenario Outline: Motoring convictions without length
     When I choose "<subtype>"
+
     Then I should see "Did you get an endorsement?"
-
     And I choose "<endorsement>"
-    Then I should see "<known_date_header>"
 
+    Then I should see "<known_date_header>"
     And I enter the following date 01-01-2020
+
     Then I should be on "<result>"
     And I should see "<spent_date>"
 
@@ -51,7 +53,7 @@ Feature: Youth Conviction
       | subtype                    | endorsement | known_date_header                        | result               | spent_date                                      |
       | Fine                       | Yes         | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 July 2022    |
       | Fine                       | No          | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 July 2020    |
-      | Fixed Penalty notice (FPN) | Yes         | When was the endorsement given?          | /steps/check/results | This conviction will be spent on 1 January 2025 |
+      | Fixed Penalty notice (FPN) | Yes         | When was the endorsement given?          | /steps/check/results | This conviction will be spent on 1 July 2022    |
       | Penalty points             | Yes         | When were you given the penalty points?  | /steps/check/results | This conviction will be spent on 1 January 2023 |
 
   @happy_path

--- a/features/youth/conviction_motoring.feature
+++ b/features/youth/conviction_motoring.feature
@@ -55,6 +55,7 @@ Feature: Youth Conviction
       | Fine                       | No          | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 July 2020    |
       | Fixed Penalty notice (FPN) | Yes         | When was the endorsement given?          | /steps/check/results | This conviction will be spent on 1 July 2022    |
       | Penalty points             | Yes         | When were you given the penalty points?  | /steps/check/results | This conviction will be spent on 1 January 2023 |
+      | Penalty points             | No          | When were you given the penalty points?  | /steps/check/results | This conviction will be spent on 1 January 2023 |
 
   @happy_path
   Scenario: Fixed Penalty notice (FPN) convictions without endorsement

--- a/spec/services/calculators/motoring/adult/disqualification_spec.rb
+++ b/spec/services/calculators/motoring/adult/disqualification_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Motoring::Adult::Disqualification do
+  subject { described_class.new(disclosure_check) }
+
+  let(:disclosure_check) { build(:disclosure_check,
+                                 under_age: under_age,
+                                 known_date: known_date,
+                                 motoring_endorsement: motoring_endorsement,
+                                 motoring_disqualification_end_date: motoring_disqualification_end_date,
+                                 motoring_lifetime_ban: motoring_lifetime_ban) }
+
+  let(:under_age) { GenericYesNo::NO }
+  let(:known_date) { Date.new(2018, 10, 31) }
+  let(:motoring_endorsement) { GenericYesNo::NO }
+  let(:motoring_disqualification_end_date) { Date.new(2020, 10, 31) }
+  let(:motoring_lifetime_ban) { nil }
+
+  describe '#expiry_date' do
+    context 'with a motoring lifetime ban' do
+      let(:motoring_lifetime_ban) { GenericYesNo::YES }
+      it { expect(subject.expiry_date).to eq(:never_spent) }
+    end
+
+    context 'without a motoring lifetime ban' do
+      let(:motoring_lifetime_ban) { GenericYesNo::NO }
+
+      context 'with a motoring_disqualification_end_date' do
+        context 'with a motoring endorsement ' do
+          let(:motoring_endorsement) { GenericYesNo::YES }
+
+          context 'less than or equal 5 years' do
+            it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+          end
+
+          context 'greater than 5 years' do
+            let(:motoring_disqualification_end_date) { Date.new(2025, 10, 31) }
+            it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+          end
+        end
+
+        context 'without a motoring endorsement ' do
+          it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+        end
+      end
+
+      context 'without a motoring_disqualification_end_date' do
+        let(:motoring_disqualification_end_date) { nil }
+        context 'with a motoring endorsement ' do
+          let(:motoring_endorsement) { GenericYesNo::YES }
+          it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+        end
+
+        context 'without a motoring endorsement ' do
+          it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/calculators/motoring/adult/fine_spec.rb
+++ b/spec/services/calculators/motoring/adult/fine_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Motoring::Adult::Fine do
+  subject { described_class.new(disclosure_check) }
+
+  let(:disclosure_check) { build(:disclosure_check,
+                                 under_age: under_age,
+                                 known_date: known_date,
+                                 motoring_endorsement: motoring_endorsement) }
+
+  let(:under_age) { GenericYesNo::NO }
+  let(:known_date) { Date.new(2018, 10, 31) }
+  let(:motoring_endorsement) { GenericYesNo::NO }
+
+  describe '#expiry_date' do
+    context 'with a motoring endorsement' do
+      let(:motoring_endorsement) { GenericYesNo::YES }
+
+      it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+    end
+
+    context 'without a motoring endorsement' do
+      it { expect(subject.expiry_date.to_s).to eq('2019-10-31') }
+    end
+  end
+end

--- a/spec/services/calculators/motoring/adult/penalty_notice_spec.rb
+++ b/spec/services/calculators/motoring/adult/penalty_notice_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Motoring::Adult::PenaltyNotice do
+  subject { described_class.new(disclosure_check) }
+
+  let(:disclosure_check) { build(:disclosure_check,
+                                 under_age: under_age,
+                                 known_date: known_date,
+                                 motoring_endorsement: motoring_endorsement) }
+
+  let(:under_age) { GenericYesNo::NO }
+  let(:known_date) { Date.new(2018, 10, 31) }
+  let(:motoring_endorsement) { GenericYesNo::NO }
+
+  describe '#expiry_date' do
+    context 'with a motoring endorsement' do
+      let(:motoring_endorsement) { GenericYesNo::YES }
+      it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+    end
+
+    context 'without a motoring endorsement' do
+      it { expect(subject.expiry_date).to eq(:no_record) }
+    end
+  end
+end

--- a/spec/services/calculators/motoring/adult/penalty_points_spec.rb
+++ b/spec/services/calculators/motoring/adult/penalty_points_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Motoring::Adult::PenaltyPoints do
+  subject { described_class.new(disclosure_check) }
+
+  let(:disclosure_check) { build(:disclosure_check,
+                                 under_age: under_age,
+                                 known_date: known_date,
+                                 motoring_endorsement: motoring_endorsement) }
+
+  let(:under_age) { GenericYesNo::NO }
+  let(:known_date) { Date.new(2018, 10, 31) }
+  let(:motoring_endorsement) { GenericYesNo::NO }
+
+  describe '#expiry_date' do
+    context 'with a motoring endorsement ' do
+      let(:motoring_endorsement) { GenericYesNo::YES }
+      it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+    end
+
+    context 'without a motoring endorsement ' do
+      it { expect(subject.expiry_date.to_s).to eq('2021-10-31') }
+    end
+  end
+end

--- a/spec/services/calculators/motoring/youth/disqualification_spec.rb
+++ b/spec/services/calculators/motoring/youth/disqualification_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Motoring::Youth::Disqualification do
+  subject { described_class.new(disclosure_check) }
+
+  let(:disclosure_check) { build(:disclosure_check,
+                                 under_age: under_age,
+                                 known_date: known_date,
+                                 motoring_endorsement: motoring_endorsement,
+                                 motoring_disqualification_end_date: motoring_disqualification_end_date,
+                                 motoring_lifetime_ban: motoring_lifetime_ban) }
+
+  let(:under_age) { GenericYesNo::YES }
+  let(:known_date) { Date.new(2018, 10, 31) }
+  let(:motoring_endorsement) { GenericYesNo::NO }
+  let(:motoring_disqualification_end_date) { Date.new(2020, 10, 31) }
+  let(:motoring_lifetime_ban) { nil }
+
+  describe '#expiry_date' do
+    context 'with a motoring lifetime ban' do
+      let(:motoring_lifetime_ban) { GenericYesNo::YES }
+      it { expect(subject.expiry_date).to eq(:never_spent) }
+    end
+
+    context 'without a motoring lifetime ban' do
+      let(:motoring_lifetime_ban) { GenericYesNo::NO }
+
+      context 'with a motoring_disqualification_end_date' do
+        context 'with a motoring endorsement' do
+          let(:motoring_endorsement) { GenericYesNo::YES }
+
+          context 'less than or equal to 2.5 years' do
+            it { expect(subject.expiry_date.to_s).to eq((known_date + 30.months).to_s) }
+          end
+
+          context 'greater than 2.5 years' do
+            let(:motoring_disqualification_end_date) { Date.new(2025, 10, 31) }
+            it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+          end
+        end
+
+        context 'without a motoring endorsement' do
+          it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+        end
+      end
+
+      context 'without a motoring_disqualification_end_date' do
+        let(:motoring_disqualification_end_date) { nil }
+
+        context 'with a motoring endorsement' do
+          let(:motoring_endorsement) { GenericYesNo::YES }
+          it { expect(subject.expiry_date.to_s).to eq('2021-04-30') }
+        end
+
+        context 'without a motoring endorsement' do
+          it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/calculators/motoring/youth/fine_spec.rb
+++ b/spec/services/calculators/motoring/youth/fine_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Motoring::Youth::Fine do
+  subject { described_class.new(disclosure_check) }
+
+  let(:disclosure_check) { build(:disclosure_check,
+                                 under_age: under_age,
+                                 known_date: known_date,
+                                 motoring_endorsement: motoring_endorsement) }
+
+  let(:under_age) { GenericYesNo::YES }
+  let(:known_date) { Date.new(2018, 10, 31) }
+  let(:motoring_endorsement) { GenericYesNo::NO }
+
+  describe '#expiry_date' do
+    context 'with a motoring endorsement' do
+      let(:motoring_endorsement) { GenericYesNo::YES }
+
+      it { expect(subject.expiry_date.to_s).to eq((known_date + 30.months).to_s) }
+    end
+
+    context 'without a motoring endorsement' do
+      it { expect(subject.expiry_date.to_s).to eq((known_date + 6.months).to_s) }
+    end
+  end
+end

--- a/spec/services/calculators/motoring/youth/penalty_notice_spec.rb
+++ b/spec/services/calculators/motoring/youth/penalty_notice_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Motoring::Youth::PenaltyNotice do
+  subject { described_class.new(disclosure_check) }
+
+  let(:disclosure_check) { build(:disclosure_check,
+                                 under_age: under_age,
+                                 known_date: known_date,
+                                 motoring_endorsement: motoring_endorsement) }
+
+  let(:under_age) { GenericYesNo::YES }
+  let(:known_date) { Date.new(2020, 1, 1) }
+  let(:motoring_endorsement) { GenericYesNo::NO }
+
+  describe '#expiry_date' do
+    context 'with a motoring endorsement' do
+      let(:motoring_endorsement) { GenericYesNo::YES }
+
+      it { expect(subject.expiry_date.to_s).to eq('2022-07-01') }
+    end
+
+    context 'without a motoring endorsement' do
+      it { expect(subject.expiry_date).to eq(:no_record) }
+    end
+  end
+end

--- a/spec/services/calculators/motoring/youth/penalty_points_spec.rb
+++ b/spec/services/calculators/motoring/youth/penalty_points_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Motoring::Youth::PenaltyPoints do
+  subject { described_class.new(disclosure_check) }
+
+  let(:disclosure_check) { build(:disclosure_check,
+                                 under_age: under_age,
+                                 known_date: known_date,
+                                 motoring_endorsement: motoring_endorsement) }
+
+  let(:under_age) { GenericYesNo::YES }
+  let(:known_date) { Date.new(2018, 10, 31) }
+  let(:motoring_endorsement) { GenericYesNo::NO }
+
+  describe '#expiry_date' do
+    context 'with a motoring endorsement' do
+      let(:motoring_endorsement) { GenericYesNo::YES }
+
+      it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
+    end
+
+    context 'without a motoring endorsement' do
+      it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
+    end
+  end
+end

--- a/spec/services/calculators/motoring_calculator_spec.rb
+++ b/spec/services/calculators/motoring_calculator_spec.rb
@@ -3,136 +3,19 @@ require 'rails_helper'
 RSpec.describe Calculators::MotoringCalculator do
   subject { described_class.new(disclosure_check) }
 
-  let(:disclosure_check) { build(:disclosure_check,
-                                 under_age: under_age,
-                                 known_date: known_date,
-                                 motoring_endorsement: motoring_endorsement,
-                                 motoring_disqualification_end_date: motoring_disqualification_end_date,
-                                 motoring_lifetime_ban: motoring_lifetime_ban) }
+  let(:disclosure_check) { build(:disclosure_check, motoring_endorsement: motoring_endorsement) }
 
-  let(:under_age) { GenericYesNo::NO }
-  let(:known_date) { Date.new(2018, 10, 31) }
-  let(:motoring_endorsement) { GenericYesNo::NO }
-  let(:motoring_disqualification_end_date) { Date.new(2020, 10, 31) }
-  let(:motoring_lifetime_ban) { nil }
+  describe '#motoring_endorsement?' do
+    context 'when no motoring endorsement' do
+      let(:motoring_endorsement) { GenericYesNo::NO }
 
-  describe Calculators::MotoringCalculator::Disqualification do
-    context '#expiry_date' do
-      context 'with a motoring lifetime ban' do
-        let(:motoring_lifetime_ban) { GenericYesNo::YES }
-        it { expect(subject.expiry_date).to eq(:never_spent) }
-      end
-
-      context 'without a motoring lifetime ban' do
-        let(:motoring_lifetime_ban) { GenericYesNo::NO }
-        context 'with a motoring_disqualification_end_date' do
-          context 'with a motoring endorsement ' do
-            let(:motoring_endorsement) { GenericYesNo::YES }
-            context 'less than or equal 5 years' do
-              it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
-
-              context 'when under age' do
-                let(:under_age) { GenericYesNo::YES }
-
-                it { expect(subject.expiry_date.to_s).to eq((known_date + 30.months).to_s) }
-              end
-            end
-
-            context 'greater than 5 years' do
-              let(:motoring_disqualification_end_date) { Date.new(2025, 10, 31) }
-              it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
-            end
-          end
-
-          context 'without a motoring endorsement ' do
-            it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
-
-            context 'when under age' do
-              let(:under_age) { GenericYesNo::YES }
-
-              it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
-            end
-          end
-        end
-
-        context 'without a motoring_disqualification_end_date' do
-          let(:motoring_disqualification_end_date) { nil }
-          context 'with a motoring endorsement ' do
-            let(:motoring_endorsement) { GenericYesNo::YES }
-            it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
-          end
-
-          context 'without a motoring endorsement ' do
-            it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
-          end
-        end
-      end
+      it { expect(subject.motoring_endorsement?).to be false }
     end
-  end
 
+    context 'when motoring endorsement' do
+      let(:motoring_endorsement) { GenericYesNo::YES }
 
-  describe Calculators::MotoringCalculator::MotoringFine do
-    context '#expiry_date' do
-      context 'with a motoring endorsement ' do
-        let(:motoring_endorsement) { GenericYesNo::YES }
-        it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
-
-        context 'when under age' do
-          let(:under_age) { GenericYesNo::YES }
-
-          it { expect(subject.expiry_date.to_s).to eq((known_date + 30.months).to_s) }
-        end
-      end
-
-      context 'without a motoring endorsement ' do
-        it { expect(subject.expiry_date.to_s).to eq('2019-10-31') }
-
-        context 'when under age' do
-          let(:under_age) { GenericYesNo::YES }
-
-          it { expect(subject.expiry_date.to_s).to eq((known_date + 6.months).to_s) }
-        end
-      end
-    end
-  end
-
-
-  describe Calculators::MotoringCalculator::PenaltyPoints do
-    context '#expiry_date' do
-      context 'with a motoring endorsement ' do
-        let(:motoring_endorsement) { GenericYesNo::YES }
-        it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
-
-        context 'when under age' do
-          let(:under_age) { GenericYesNo::YES }
-
-          it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
-        end
-      end
-
-      context 'without a motoring endorsement ' do
-        it { expect(subject.expiry_date.to_s).to eq('2021-10-31') }
-
-        context 'when under age' do
-          let(:under_age) { GenericYesNo::YES }
-
-          it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
-        end
-      end
-    end
-  end
-
-
-  describe Calculators::MotoringCalculator::PenaltyNotice do
-    context '#expiry_date' do
-      context 'with a motoring endorsement ' do
-        let(:motoring_endorsement) { GenericYesNo::YES }
-        it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
-      end
-
-      context 'without a motoring endorsement ' do
-        it { expect(subject.expiry_date).to eq(:no_record) }
-      end
+      it { expect(subject.motoring_endorsement?).to be true }
     end
   end
 end

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -427,6 +427,36 @@ RSpec.describe ConvictionType do
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::StartPlusTwelveMonths) }
     end
 
+    # YOUTH_MOTORING
+    #
+    context 'YOUTH_DISQUALIFICATION' do
+      let(:subtype) { 'youth_disqualification' }
+
+      it { expect(conviction_type.skip_length?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Youth::Disqualification) }
+    end
+
+    context 'YOUTH_MOTORING_FINE' do
+      let(:subtype) { 'youth_motoring_fine' }
+
+      it { expect(conviction_type.skip_length?).to eq(true) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Youth::Fine) }
+    end
+
+    context 'YOUTH_PENALTY_NOTICE' do
+      let(:subtype) { 'youth_penalty_notice' }
+
+      it { expect(conviction_type.skip_length?).to eq(true) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Youth::PenaltyNotice) }
+    end
+
+    context 'YOUTH_PENALTY_POINTS' do
+      let(:subtype) { 'youth_penalty_points' }
+
+      it { expect(conviction_type.skip_length?).to eq(true) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Youth::PenaltyPoints) }
+    end
+
     # ADULT_MOTORING
     #
     context 'ADULT_DISQUALIFICATION' do
@@ -456,7 +486,6 @@ RSpec.describe ConvictionType do
       it { expect(conviction_type.skip_length?).to eq(true) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Adult::PenaltyPoints) }
     end
-
 
     context 'ADULT_BIND_OVER' do
       let(:subtype) { 'adult_bind_over' }

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -433,29 +433,30 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_disqualification' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::Disqualification) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Adult::Disqualification) }
     end
 
     context 'ADULT_MOTORING_FINE' do
       let(:subtype) { 'adult_motoring_fine' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::MotoringFine) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Adult::Fine) }
     end
 
     context 'ADULT_PENALTY_NOTICE' do
       let(:subtype) { 'adult_penalty_notice' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::PenaltyNotice) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Adult::PenaltyNotice) }
     end
 
     context 'ADULT_PENALTY_POINTS' do
       let(:subtype) { 'adult_penalty_points' }
 
       it { expect(conviction_type.skip_length?).to eq(true) }
-      it { expect(conviction_type.calculator_class).to eq(Calculators::MotoringCalculator::PenaltyPoints) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Adult::PenaltyPoints) }
     end
+
 
     context 'ADULT_BIND_OVER' do
       let(:subtype) { 'adult_bind_over' }


### PR DESCRIPTION
I have reorganised the way the MotoringCalculator has been written, I find this was useful and essential to avoid logical problems between Under 18 and Over 18.

Before there was only Over 18 Motoring Calculations, but with the addition of Under 18 https://github.com/ministryofjustice/disclosure-checker/pull/350 it became clear this needed some refactor to accommodate both.

This also gave me the opportunity to spot two bugs on Under 18 which would have been hard to spot before.

There are cucumber features to back up the changes as well as unit tests.
I've tried to make the changes as small as I could in individual commits.

Story: https://mojdigital.teamwork.com/#/tasks/20007708