### PR TITLE
Fix the order of bail time calculations

### DIFF
--- a/app/services/base_calculator.rb
+++ b/app/services/base_calculator.rb
@@ -29,18 +29,14 @@ class BaseCalculator
     (end_date.year - start_date.year) * 12 + end_date.month - start_date.month - (end_date.day >= start_date.day ? 0 : 1)
   end
 
-  def sentence_length_in_months(length, length_unit, offset_days: 0)
-    months = case length_unit
-             when 'weeks'
-               length / WEEKS_IN_A_MONTH
-             when 'years'
-               length * MONTHS_IN_A_YEAR
-             when 'months'
-               length
-             end
-
-    # If there is a negative number of days to subtract (bail time), otherwise 0
-    seconds = (months * SECONDS_IN_A_MONTH) + offset_days.days.to_i
-    (seconds / SECONDS_IN_A_MONTH).to_i
+  def sentence_length_in_months(length, length_unit)
+    case length_unit
+    when 'weeks'
+      length / WEEKS_IN_A_MONTH
+    when 'years'
+      length * MONTHS_IN_A_YEAR
+    when 'months'
+      length
+    end
   end
 end

--- a/features/adults/conviction_custodial_sentence.feature
+++ b/features/adults/conviction_custodial_sentence.feature
@@ -15,20 +15,20 @@ Feature: Conviction
     And I click the "Continue" button
     Then I should see "<known_date_header>"
 
-    And I enter a valid date
+    And I enter the following date 01-01-2020
     Then I should see "<length_type_header>"
 
-    And  I choose "Years"
+    And  I choose "Months"
     Then I should see "<length_header>"
-    And I fill in "Number of years" with "2"
+    And I fill in "Number of months" with "22"
 
     Then I click the "Continue" button
-    And I should be on "<result>"
+    And I should see "<result>"
 
     Examples:
-      | subtype                   | known_date_header            | length_type_header                                              | length_header                        | result               |
-      | Prison sentence           | When did the sentence start? | Was the length of the sentence given in weeks, months or years? | What was the length of the sentence? | /steps/check/results |
-      | Suspended prison sentence | When did the sentence start? | Was the length of the sentence given in weeks, months or years? | What was the length of the sentence? | /steps/check/results |
+      | subtype                   | known_date_header            | length_type_header                                              | length_header                        | result                                           |
+      | Prison sentence           | When did the sentence start? | Was the length of the sentence given in weeks, months or years? | What was the length of the sentence? | This conviction will be spent on 21 October 2025 |
+      | Suspended prison sentence | When did the sentence start? | Was the length of the sentence given in weeks, months or years? | What was the length of the sentence? | This conviction will be spent on 21 October 2025 |
 
 
   @happy_path

--- a/features/youth/conviction_custodial_sentence.feature
+++ b/features/youth/conviction_custodial_sentence.feature
@@ -11,24 +11,24 @@ Feature: Conviction
     And I choose "Yes"
     Then I should see "How many days spent with an electronic tag counted towards your sentence?"
 
-    And I fill in "Number of days" with "10"
+    And I fill in "Number of days" with "46"
     And I click the "Continue" button
     Then I should see "<known_date_header>"
 
-    And I enter a valid date
+    And I enter the following date 12-09-2019
     Then I should see "<length_type_header>"
 
-    And  I choose "Years"
+    And  I choose "Months"
     Then I should see "<length_header>"
-    And I fill in "Number of years" with "2"
+    And I fill in "Number of months" with "24"
 
     Then I click the "Continue" button
-    And I should be on "<result>"
+    And I should see "<result>"
 
     Examples:
-      | subtype                            | known_date_header             | length_type_header                                               | length_header                         | result               |
-      | Detention and training order (DTO) | When did the DTO start?       | Was the length of the DTO given in weeks, months or years?       | What was the length of the DTO?       | /steps/check/results |
-      | Detention                          | When did the detention start? | Was the length of the detention given in weeks, months or years? | What was the length of the detention? | /steps/check/results |
+      | subtype                            | known_date_header             | length_type_header                                               | length_header                         | result                                        |
+      | Detention and training order (DTO) | When did the DTO start?       | Was the length of the DTO given in weeks, months or years?       | What was the length of the DTO?       | This conviction will be spent on 27 July 2023 |
+      | Detention                          | When did the detention start? | Was the length of the detention given in weeks, months or years? | What was the length of the detention? | This conviction will be spent on 27 July 2023 |
 
 
   @happy_path

--- a/spec/services/base_calculator_spec.rb
+++ b/spec/services/base_calculator_spec.rb
@@ -92,15 +92,4 @@ RSpec.describe BaseCalculator do
       expect(subject.sentence_length_in_months(25, 'years')).to eq 300
     end
   end
-
-  context '#sentence_distance_in_months when using a bail offset' do
-    it { expect(subject.sentence_length_in_months(5, 'weeks')).to eq(1) }
-    it { expect(subject.sentence_length_in_months(5, 'weeks', offset_days: -6)).to eq(0) }
-
-    it { expect(subject.sentence_length_in_months(3, 'months')).to eq(3) }
-    it { expect(subject.sentence_length_in_months(3, 'months', offset_days: -1)).to eq(2) }
-
-    it { expect(subject.sentence_length_in_months(1, 'years')).to eq(12) }
-    it { expect(subject.sentence_length_in_months(1, 'years', offset_days: -1)).to eq(11) }
-  end
 end

--- a/spec/services/calculators/sentence_calculator_spec.rb
+++ b/spec/services/calculators/sentence_calculator_spec.rb
@@ -60,23 +60,6 @@ RSpec.describe Calculators::SentenceCalculator do
         it { expect(subject.valid?).to eq(false) }
         it { expect { subject.expiry_date }.to raise_exception(BaseCalculator::InvalidCalculation) }
       end
-
-      # Just one example is enough as all other types of sentences behave the same
-      describe 'sentence with bail time' do
-        context 'when bail time would have avoided the upper limit' do
-          let(:bail_days) { 300 }
-          let(:conviction_months) { 25 } # the upper limit in this conviction is 24 months
-
-          it { expect(subject.valid?).to eq(false) }
-          it { expect { subject.expiry_date }.to raise_exception(BaseCalculator::InvalidCalculation) }
-        end
-
-        context 'conviction length of 6 months or less' do
-          let(:conviction_months) { 5 }
-          let(:bail_days) { 20 } # equals to 20 days less in the spent date
-          it { expect(subject.expiry_date.to_s).to eq('2018-08-27') }
-        end
-      end
     end
   end
 
@@ -107,6 +90,15 @@ RSpec.describe Calculators::SentenceCalculator do
         it { expect(subject.valid?).to eq(true) }
         it { expect { subject.expiry_date }.not_to raise_exception(BaseCalculator::InvalidCalculation) }
       end
+    end
+
+    # Just one example is enough as all other types of sentences behave the same
+    context '#expiry_date - with bail time' do
+      let(:known_date) { Date.new(2019, 12, 18) }
+      let(:conviction_months) { 31 }
+      let(:bail_days) { 50 } # equals to 50 days less in the spent date
+
+      it { expect(subject.expiry_date.to_s).to eq('2029-05-28') }
     end
   end
 


### PR DESCRIPTION
Note: bail is not yet "visible" in production. This can be tested on dev/staging environments.

Previously, we deducted the bail time before we looked at the rehabilitation periods.

This is incorrect - the rehabilitation period should be determined on the basis of the full sentence as given by the court, irrespective of any bail time.

Changed the order of the calculations for bail to reflect the correct policy.

Extended and improved some of the tests.