### PR TITLE
Enable bail journey in all environments

### DIFF
--- a/app/controllers/steps/conviction/conviction_subtype_controller.rb
+++ b/app/controllers/steps/conviction/conviction_subtype_controller.rb
@@ -9,14 +9,7 @@ module Steps
       end
 
       def update
-        update_and_advance(ConvictionSubtypeForm, as: as_name)
-      end
-
-      private
-
-      # TODO: temporary feature-flag, to be removed when no needed
-      def as_name
-        bail_enabled? ? :conviction_subtype : :bypass_bail_conviction_subtype
+        update_and_advance(ConvictionSubtypeForm, as: :conviction_subtype)
       end
     end
   end

--- a/app/helpers/experiments_helper.rb
+++ b/app/helpers/experiments_helper.rb
@@ -1,9 +1,4 @@
 module ExperimentsHelper
-  # Bail journey only active on local/staging envs
-  def bail_enabled?
-    Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')
-  end
-
   def multiples_enabled?
     cookies[:multiples_enabled].present?
   end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -10,7 +10,7 @@ class ConvictionDecisionTree < BaseDecisionTree
     case step_name
     when :conviction_type
       edit(:conviction_subtype)
-    when :conviction_subtype, :bypass_bail_conviction_subtype
+    when :conviction_subtype
       after_conviction_subtype
     when :motoring_endorsement
       after_motoring_endorsement
@@ -45,8 +45,8 @@ class ConvictionDecisionTree < BaseDecisionTree
   private
 
   def after_conviction_subtype
-    return edit(:conviction_bail)   if conviction_subtype.bailable_offense? && !step_name.eql?(:bypass_bail_conviction_subtype)
-    return edit(:compensation_paid) if conviction_subtype.compensation?
+    return edit(:conviction_bail)    if conviction_subtype.bailable_offense?
+    return edit(:compensation_paid)  if conviction_subtype.compensation?
     return after_motoring_conviction if conviction_type.motoring?
 
     known_date_question

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -29,7 +29,6 @@
 
         <ul class="govuk-list govuk-list--bullet">
           <li>were given more than one caution, sentence or disposal as part of a conviction</li>
-          <li>were released on bail</li>
           <li>want to check a caution or conviction given outside England and Wales</li>
         </ul>
 

--- a/app/views/steps/check/results/shared/_disclaimer.en.html.erb
+++ b/app/views/steps/check/results/shared/_disclaimer.en.html.erb
@@ -13,7 +13,6 @@
     <li>did not serve your sentence in full as the court ordered you to</li>
     <li>did not stick to the conditions of your sentence</li>
     <li>have more than one caution, sentence or disposal for one conviction</li>
-    <li>were released on bail at any time</li>
 </ul>
 
 <p class="govuk-body">

--- a/app/views/steps/check/results/show.en.html+multiples.erb
+++ b/app/views/steps/check/results/show.en.html+multiples.erb
@@ -84,7 +84,6 @@
           <li>entered any incorrect information, such as approximate dates</li>
           <li>did not serve your sentence in full as the court ordered you to, or</li>
           <li>did not stick to the conditions of your sentence</li>
-          <li>were released on bail at any time</li>
         </ul>
 
         <div class="govuk-inset-text">

--- a/spec/helpers/experiments_helper_spec.rb
+++ b/spec/helpers/experiments_helper_spec.rb
@@ -1,31 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe ExperimentsHelper, type: :helper do
-  describe '#bail_enabled?' do
-    let(:dev_tools_enabled) { true }
-    let(:development_env) { true }
-
-    before do
-      allow(ENV).to receive(:key?).with('DEV_TOOLS_ENABLED').and_return(dev_tools_enabled)
-      allow(Rails.env).to receive(:development?).and_return(development_env)
-    end
-
-    context 'on development environments' do
-      it { expect(helper.bail_enabled?).to eq(true) }
-    end
-
-    context 'on production environments with DEV_TOOLS_ENABLED' do
-      let(:dev_tools_enabled) { true }
-      let(:development_env) { false }
-
-      it { expect(helper.bail_enabled?).to eq(true) }
-    end
-
-    context 'on production environments without DEV_TOOLS_ENABLED' do
-      let(:dev_tools_enabled) { false }
-      let(:development_env) { false }
-
-      it { expect(helper.bail_enabled?).to eq(false) }
-    end
-  end
 end


### PR DESCRIPTION
This was behind a feature flag and only visible on dev/staging envs up until now.

Minor copy changes to remove references to bail that we no longer need after enabling this.