### PR TITLE
Bump GOV.UK Frontend v3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "^3.5.0"
+    "govuk-frontend": "^3.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-govuk-frontend@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.5.0.tgz#040e6fd0227f65d3e5820f8a05a9932ffdfb2a9e"
-  integrity sha512-4tNKgcChO1bMNsrTz2UsK4fDMmU9R87UDxy/KhKIMbnhsuJLVuArDveYLkZuUsZ6B3eaCbl5gmI8i/Q/Mi680A==
+govuk-frontend@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.7.0.tgz#2eb2130c3c9f7c701c7ecdb300cc91106275a414"
+  integrity sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg==


### PR DESCRIPTION
A new version has been released:
https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0

There should not be any breaking changes, and the only noticeable change is the Back link styling, as indicated in the changelog.

<img width="234" alt="Screen Shot 2020-06-01 at 16 13 20" src="https://user-images.githubusercontent.com/687910/83496261-bec4f680-a4b0-11ea-8ebb-f61f2417b704.png">
