### PR TITLE
Remove motoring_lifetime_ban from disclosure checks table

### DIFF
--- a/db/migrate/20200716114413_remove_motoring_lifetime_ban_from_disclosure_checks.rb
+++ b/db/migrate/20200716114413_remove_motoring_lifetime_ban_from_disclosure_checks.rb
@@ -1,0 +1,5 @@
+class RemoveMotoringLifetimeBanFromDisclosureChecks < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :disclosure_checks, :motoring_lifetime_ban, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_29_155945) do
+ActiveRecord::Schema.define(version: 2020_07_16_114413) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 2020_03_29_155945) do
     t.date "compensation_payment_date"
     t.string "motoring_endorsement"
     t.date "motoring_disqualification_end_date"
-    t.string "motoring_lifetime_ban"
     t.uuid "check_group_id"
     t.string "conviction_bail"
     t.integer "conviction_bail_days"


### PR DESCRIPTION
We have remove the functionality around motoring lifetime ban, this is just to tidy up and remove the database column which is no longer in use.

Follow up on https://github.com/ministryofjustice/disclosure-checker/pull/361/files


Story: https://mojdigital.teamwork.com/#/tasks/20951241