### PR TITLE
Remove endorsement question from motoring penalty points

### DIFF
--- a/app/decorators/conviction_decorator.rb
+++ b/app/decorators/conviction_decorator.rb
@@ -28,6 +28,11 @@ module ConvictionDecorator
       ConvictionType::ADULT_PENALTY_NOTICE.eql?(self)
   end
 
+  def motoring_penalty_points?
+    ConvictionType::YOUTH_PENALTY_POINTS.eql?(self) ||
+      ConvictionType::ADULT_PENALTY_POINTS.eql?(self)
+  end
+
   def bailable_offense?
     [
       ConvictionType::DETENTION,

--- a/app/forms/steps/conviction/conviction_subtype_form.rb
+++ b/app/forms/steps/conviction/conviction_subtype_form.rb
@@ -32,7 +32,8 @@ module Steps
           conviction_length: nil,
           conviction_length_type: nil,
           compensation_paid: nil,
-          compensation_payment_date: nil
+          compensation_payment_date: nil,
+          motoring_endorsement: nil
         )
       end
     end

--- a/app/services/calculators/motoring/adult/penalty_points.rb
+++ b/app/services/calculators/motoring/adult/penalty_points.rb
@@ -1,18 +1,13 @@
 module Calculators
   module Motoring
     module Adult
-      # If an endorsement was received:
+      # An endorsement is always received when Penalty Points
       # start_date + 5 years
-      # If an endorsement was not received:
-      # start_date + 3 years
       class PenaltyPoints < MotoringCalculator
         REHABILITATION_1 = { months: 60 }.freeze
-        REHABILITATION_2 = { months: 36 }.freeze
 
         def expiry_date
-          return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
-
-          conviction_start_date.advance(REHABILITATION_2)
+          conviction_start_date.advance(REHABILITATION_1)
         end
       end
     end

--- a/app/services/calculators/motoring/youth/penalty_points.rb
+++ b/app/services/calculators/motoring/youth/penalty_points.rb
@@ -1,9 +1,7 @@
 module Calculators
   module Motoring
     module Youth
-      # If an endorsement was received:
-      # start_date + 3 years
-      # If an endorsement was not received:
+      # An endorsement is always received when Penalty Points
       # start_date + 3 years
       # Because the Youth endorsement is 2.5 years and penalty points are 3 years,
       # even if there is an endorsement, the penalty points have a longer duration

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -51,7 +51,9 @@ class ConvictionDecisionTree < BaseDecisionTree
   end
 
   def after_motoring_conviction
-    edit(:motoring_endorsement)
+    return edit(:motoring_endorsement) unless conviction_subtype.motoring_penalty_points?
+
+    known_date_question
   end
 
   def after_known_date

--- a/features/adults/conviction_motoring.feature
+++ b/features/adults/conviction_motoring.feature
@@ -40,8 +40,19 @@ Feature: Adult Conviction
       | Fine                       | 01-01-2020 | Yes         | When were you given the fine?            | will be spent on 1 January 2025 |
       | Fine                       | 01-01-2020 | No          | When were you given the fine?            | will be spent on 1 January 2021 |
       | Fixed Penalty notice (FPN) | 01-01-2020 | Yes         | When was the endorsement given?          | will be spent on 1 January 2025 |
-      | Penalty points             | 01-01-2020 | Yes         | When were you given the penalty points?  | will be spent on 1 January 2025 |
-      | Penalty points             | 01-01-2020 | No          | When were you given the penalty points?  | will be spent on 1 January 2023 |
+
+  @happy_path
+  Scenario Outline: Motoring convictions without length (penalty points)
+    When I choose "<subtype>"
+    Then I should see "<known_date_header>"
+
+    And I enter the following date <ban_date>
+    Then I should be on "/steps/check/results"
+    And I should see "This conviction <spent_date>"
+
+    Examples:
+      | subtype                    | ban_date   | known_date_header                        | spent_date     |
+      | Penalty points             | 01-01-2020 | When were you given the penalty points?  | will be spent on 1 January 2025 |
 
   @happy_path
   Scenario: Fixed Penalty notice (FPN) convictions without endorsement

--- a/features/youth/conviction_motoring.feature
+++ b/features/youth/conviction_motoring.feature
@@ -44,8 +44,21 @@ Feature: Youth Conviction
       | Fine                       | Yes         | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 July 2022    |
       | Fine                       | No          | When were you given the fine?            | /steps/check/results | This conviction was spent on 1 July 2020        |
       | Fixed Penalty notice (FPN) | Yes         | When was the endorsement given?          | /steps/check/results | This conviction will be spent on 1 July 2022    |
-      | Penalty points             | Yes         | When were you given the penalty points?  | /steps/check/results | This conviction will be spent on 1 January 2023 |
-      | Penalty points             | No          | When were you given the penalty points?  | /steps/check/results | This conviction will be spent on 1 January 2023 |
+
+  @happy_path @date_travel
+  Scenario Outline: Motoring convictions without length (penalty points)
+    Given The current date is 03-07-2020
+    When I choose "<subtype>"
+
+    Then I should see "<known_date_header>"
+    And I enter the following date 01-01-2020
+
+    Then I should be on "<result>"
+    And I should see "<spent_date>"
+
+    Examples:
+      | subtype        | known_date_header                        | result               | spent_date                                      |
+      | Penalty points | When were you given the penalty points?  | /steps/check/results | This conviction will be spent on 1 January 2023 |
 
   @happy_path
   Scenario: Fixed Penalty notice (FPN) convictions without endorsement

--- a/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe Steps::Conviction::ConvictionSubtypeForm do
           conviction_length: nil,
           conviction_length_type: nil,
           compensation_paid: nil,
-          compensation_payment_date: nil
+          compensation_payment_date: nil,
+          motoring_endorsement: nil,
         ).and_return(true)
 
         expect(subject.save).to be(true)

--- a/spec/services/calculators/motoring/adult/penalty_points_spec.rb
+++ b/spec/services/calculators/motoring/adult/penalty_points_spec.rb
@@ -5,21 +5,14 @@ RSpec.describe Calculators::Motoring::Adult::PenaltyPoints do
 
   let(:disclosure_check) { build(:disclosure_check,
                                  under_age: under_age,
-                                 known_date: known_date,
-                                 motoring_endorsement: motoring_endorsement) }
+                                 known_date: known_date) }
 
   let(:under_age) { GenericYesNo::NO }
   let(:known_date) { Date.new(2018, 10, 31) }
-  let(:motoring_endorsement) { GenericYesNo::NO }
 
   describe '#expiry_date' do
     context 'with a motoring endorsement ' do
-      let(:motoring_endorsement) { GenericYesNo::YES }
       it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
-    end
-
-    context 'without a motoring endorsement ' do
-      it { expect(subject.expiry_date.to_s).to eq('2021-10-31') }
     end
   end
 end

--- a/spec/services/calculators/motoring/youth/penalty_points_spec.rb
+++ b/spec/services/calculators/motoring/youth/penalty_points_spec.rb
@@ -5,21 +5,14 @@ RSpec.describe Calculators::Motoring::Youth::PenaltyPoints do
 
   let(:disclosure_check) { build(:disclosure_check,
                                  under_age: under_age,
-                                 known_date: known_date,
-                                 motoring_endorsement: motoring_endorsement) }
+                                 known_date: known_date) }
 
   let(:under_age) { GenericYesNo::YES }
   let(:known_date) { Date.new(2018, 10, 31) }
-  let(:motoring_endorsement) { GenericYesNo::NO }
 
   describe '#expiry_date' do
     context 'with a motoring endorsement' do
-      let(:motoring_endorsement) { GenericYesNo::YES }
 
-      it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
-    end
-
-    context 'without a motoring endorsement' do
       it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
     end
   end

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe ConvictionDecisionTree do
 
       context 'when subtype equal youth_penalty_points' do
         let(:conviction_subtype) { :youth_penalty_points }
-        it { is_expected.to have_destination(:motoring_endorsement, :edit) }
+        it { is_expected.to have_destination(:known_date, :edit) }
       end
     end
 
@@ -97,7 +97,7 @@ RSpec.describe ConvictionDecisionTree do
 
       context 'when subtype equal adult_penalty_points' do
         let(:conviction_subtype) { :adult_penalty_points }
-        it { is_expected.to have_destination(:motoring_endorsement, :edit) }
+        it { is_expected.to have_destination(:known_date, :edit) }
       end
     end
 


### PR DESCRIPTION
Penalty points can only be accrued if the offence has been endorsed. So  you won’t see penalty points without endorsement.

Co-Authored-by: @njseeto 

Story: https://mojdigital.teamwork.com/#/tasks/21245933