### PR TITLE
Reset motoring attributes to nil

### DIFF
--- a/app/forms/steps/conviction/conviction_subtype_form.rb
+++ b/app/forms/steps/conviction/conviction_subtype_form.rb
@@ -33,7 +33,9 @@ module Steps
           conviction_length_type: nil,
           compensation_paid: nil,
           compensation_payment_date: nil,
-          motoring_endorsement: nil
+          motoring_endorsement: nil,
+          motoring_disqualification_end_date: nil,
+          approximate_motoring_disqualification_end_date: nil
         )
       end
     end

--- a/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe Steps::Conviction::ConvictionSubtypeForm do
           compensation_paid: nil,
           compensation_payment_date: nil,
           motoring_endorsement: nil,
+          motoring_disqualification_end_date: nil,
+          approximate_motoring_disqualification_end_date: nil
         ).and_return(true)
 
         expect(subject.save).to be(true)


### PR DESCRIPTION
Task: https://mojdigital.teamwork.com/#/tasks/21392749

Reseting the motoring attributes allows us to minimise the affect on calculations if a user to goes back and changes their journey.

I think there's only the motor attributes that need to be reset, please do let me know if there are any others.

List of attributes:
<img width="1113" alt="Screenshot 2020-08-03 at 11 51 29" src="https://user-images.githubusercontent.com/29227502/89175436-af7d2a80-d57f-11ea-8767-efb5fbff2e6d.png">
