### PR TITLE
Update Design System for steps/conviction/compensation_paid

### DIFF
--- a/app/views/steps/conviction/compensation_paid/edit.html.erb
+++ b/app/views/steps/conviction/compensation_paid/edit.html.erb
@@ -1,23 +1,15 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="govuk-width-container">
-  <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+    <%= step_subsection %>
 
-  <main id="main-content" class="govuk-main-wrapper">
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_collection_radio_buttons :compensation_paid, GenericYesNo.values, :value, nil %>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= error_summary %>
-        <%= step_subsection %>
-
-        <!-- The header is part of the radios legend by default, but can be configured -->
-
-        <%= step_form @form_object do |f| %>
-          <%= f.radio_button_fieldset :compensation_paid, inline: true, choices: GenericYesNo.values %>
-          <%= f.continue_button %>
-        <% end %>
-      </div>
-    </div>
-
-  </main>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
 </div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -186,6 +186,8 @@ en:
         adult_disqualification: Was the length of the disqualification given in weeks, months or years?
       steps_conviction_compensation_paid_form:
         compensation_paid: Have you paid the compensation in full?
+      steps_conviction_compensation_paid_amount_form:
+        compensation_payment_over_100: Was the compensation order amount over £100?
       steps_conviction_compensation_payment_date_form:
         compensation_payment_date: When did you pay the compensation in full?
       steps_conviction_compensation_payment_receipt_form:
@@ -369,6 +371,8 @@ en:
         approximate_motoring_disqualification_end_date: *approximate_date_checkbox
       steps_conviction_conviction_bail_days_form:
         conviction_bail_days: Number of days
+      steps_conviction_compensation_paid_form:
+        compensation_paid_options: *YESNO
 
     legend:
       steps_check_kind_form:
@@ -383,3 +387,5 @@ en:
         approximate_conditional_end_date: *approximate_date_legend
       steps_conviction_compensation_paid_amount_form:
         compensation_payment_over_100: Was the compensation order amount over £100?
+      steps_conviction_compensation_paid_form:
+        compensation_paid: Have you paid the compensation in full?


### PR DESCRIPTION
Needs to be rebased after https://github.com/ministryofjustice/disclosure-checker/pull/377 is merged to use the YAML constant YESNO.

Story: https://mojdigital.teamwork.com/#/tasks/21707828


### Before
<img width="1207" alt="Screenshot 2020-09-02 at 09 07 46" src="https://user-images.githubusercontent.com/136777/91956291-60e8ba80-ecfc-11ea-90f4-ef4f3cf7bd99.png">

### After

<img width="1207" alt="Screenshot 2020-09-02 at 09 07 22" src="https://user-images.githubusercontent.com/136777/91956303-6514d800-ecfc-11ea-917c-5bee4f50d96e.png">
