### PR TITLE
Migrate `compensation_payment_date` to use new gem

### DIFF
--- a/app/forms/steps/conviction/compensation_payment_date_form.rb
+++ b/app/forms/steps/conviction/compensation_payment_date_form.rb
@@ -1,12 +1,8 @@
 module Steps
   module Conviction
     class CompensationPaymentDateForm < BaseForm
-      include GovUkDateFields::ActsAsGovUkDate
-
-      attribute :compensation_payment_date, Date
+      attribute :compensation_payment_date, MultiParamDate
       attribute :approximate_compensation_payment_date, Boolean
-
-      acts_as_gov_uk_date :compensation_payment_date, error_clash_behaviour: :omit_gov_uk_date_field_error
 
       validates_presence_of :compensation_payment_date
       validates :compensation_payment_date, sensible_date: true

--- a/app/views/steps/conviction/compensation_payment_date/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_date/edit.html.erb
@@ -1,26 +1,19 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="govuk-width-container">
-  <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+    <%= step_subsection %>
 
-  <main id="main-content" class="govuk-main-wrapper">
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_date_field :compensation_payment_date, form_group_classes: 'app-util--compact-form-group' %>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= error_summary %>
-        <%= step_subsection %>
+      <%= render partial: 'steps/shared/new_approx_date_checkbox', locals: {
+        form: f, attribute: :approximate_compensation_payment_date
+      } %>
 
-        <%= step_form @form_object do |f| %>
-          <%= f.gov_uk_date_field :compensation_payment_date %>
-
-          <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
-            form: f, attribute: :approximate_compensation_payment_date
-          } %>
-
-          <%= f.continue_button %>
-        <% end %>
-      </div>
-    </div>
-
-  </main>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
 </div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -362,8 +362,8 @@ en:
         months: Number of months
         years: Number of years
       steps_conviction_compensation_payment_date_form:
-        <<: *DATE_PARTS
-        approximate_compensation_payment_date: *approximate_date_checkbox
+        approximate_compensation_payment_date_options:
+          'true': *approximate_date_checkbox
       steps_conviction_compensation_paid_amount_form:
         compensation_payment_over_100_options: *YESNO
       steps_conviction_motoring_disqualification_end_date_form:
@@ -385,6 +385,9 @@ en:
       steps_caution_conditional_end_date_form:
         conditional_end_date: When did the conditions end?
         approximate_conditional_end_date: *approximate_date_legend
+      steps_conviction_compensation_payment_date_form:
+        compensation_payment_date: When did you pay the compensation in full?
+        approximate_compensation_payment_date: *approximate_date_legend
       steps_conviction_compensation_paid_amount_form:
         compensation_payment_over_100: Was the compensation order amount over £100?
       steps_conviction_compensation_paid_form:

--- a/spec/forms/steps/conviction/compensation_payment_date_form_spec.rb
+++ b/spec/forms/steps/conviction/compensation_payment_date_form_spec.rb
@@ -1,5 +1,23 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Conviction::CompensationPaymentDateForm do
-  it_behaves_like 'a date question form', attribute_name: :compensation_payment_date
+  it_behaves_like 'a date question form', attribute_name: :compensation_payment_date do
+    # TODO: move this context to the shared examples once all dates are migrated
+    context 'casting the date from multi parameters' do
+      context 'when date is valid' do
+        let(:date_value) { [nil, 2008, 11, 22] }
+        it { expect(subject).to be_valid }
+      end
+
+      context 'when date is not valid' do
+        let(:date_value) { [nil, 18, 11, 22] } # 2-digits year (18)
+        it { expect(subject).not_to be_valid }
+      end
+
+      context 'when a part is missing (nil or zero)' do
+        let(:date_value) { [nil, 2008, 0, 22] }
+        it { expect(subject).not_to be_valid }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21707830

Continuation of PR #375, migrating all the dates in the service to use the new gem.

<img width="640" alt="Screen Shot 2020-09-02 at 11 03 15" src="https://user-images.githubusercontent.com/687910/91970102-13c21400-ed0f-11ea-9058-b59f590d363b.png">
<img width="695" alt="Screen Shot 2020-09-02 at 11 02 57" src="https://user-images.githubusercontent.com/687910/91970105-145aaa80-ed0f-11ea-94df-1dea432dc39c.png">
