### PR TITLE
Migrate `conviction_known_date` to use new gem

### DIFF
--- a/app/forms/steps/conviction/known_date_form.rb
+++ b/app/forms/steps/conviction/known_date_form.rb
@@ -1,15 +1,17 @@
 module Steps
   module Conviction
     class KnownDateForm < BaseForm
-      include GovUkDateFields::ActsAsGovUkDate
-
-      attribute :known_date, Date
+      attribute :known_date, MultiParamDate
       attribute :approximate_known_date, Boolean
-
-      acts_as_gov_uk_date :known_date, error_clash_behaviour: :omit_gov_uk_date_field_error
 
       validates_presence_of :known_date
       validates :known_date, sensible_date: true
+
+      # As we reuse this form object in multiple views, this is the attribute
+      # that will be used to choose the locales for legends and hints.
+      def i18n_attribute
+        conviction_subtype
+      end
 
       private
 

--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -3,9 +3,28 @@ module CustomFormHelpers
     submit_button(continue)
   end
 
+  # Used to customise legends when reusing the same view
+  def i18n_legend
+    I18n.t(
+      object.i18n_attribute, scope: scope_for_locale(:legend), default: :default
+    )
+  end
+
+  # Used to customise hints when reusing the same view
+  # Hints support markup so ensure locale keys ends with `_html`
+  def i18n_hint
+    I18n.t(
+      "#{object.i18n_attribute}_html", scope: scope_for_locale(:hint), default: :default_html
+    ).html_safe
+  end
+
   private
 
   def submit_button(i18n_key, opts = {}, &block)
     govuk_submit I18n.t("helpers.buttons.#{i18n_key}"), opts, &block
+  end
+
+  def scope_for_locale(context)
+    [:helpers, context, object_name]
   end
 end

--- a/app/views/steps/conviction/known_date/edit.html.erb
+++ b/app/views/steps/conviction/known_date/edit.html.erb
@@ -1,26 +1,20 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="govuk-width-container">
-  <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+    <%= step_subsection %>
 
-  <main id="main-content" class="govuk-main-wrapper">
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_date_field :known_date, form_group_classes: 'app-util--compact-form-group',
+                             legend: { text: f.i18n_legend }, hint_text: f.i18n_hint %>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= error_summary %>
-        <%= step_subsection %>
+      <%= render partial: 'steps/shared/new_approx_date_checkbox', locals: {
+        form: f, attribute: :approximate_known_date
+      } %>
 
-        <%= step_form @form_object do |f| %>
-          <%= f.gov_uk_date_field :known_date, i18n_attribute: @form_object.conviction_subtype %>
-
-          <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
-            form: f, attribute: :approximate_known_date
-          } %>
-
-          <%= f.continue_button %>
-        <% end %>
-      </div>
-    </div>
-
-  </main>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
 </div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -131,31 +131,6 @@ en:
       steps_check_under_age_form:
         caution: How old were you when you got cautioned?
         conviction: How old were you when you got convicted?
-      steps_conviction_known_date_form:
-        # default key
-        known_date: When were you given the order?
-        # alternative keys defined with `i18_attribute`
-        referral_order: What was the date of your first panel meeting?
-        dismissal: When were you given the dismissal?
-        service_detention: When were you given the detention?
-        detention_training_order: When did the DTO start?
-        detention: When did the detention start?
-        absolute_discharge: When were you given the discharge?
-        conditional_discharge: When were you given the discharge?
-        adult_absolute_discharge: When were you given the discharge?
-        adult_conditional_discharge: When were you given the discharge?
-        adult_suspended_prison_sentence: When did the sentence start?
-        adult_prison_sentence: When did the sentence start?
-        adult_dismissal: When were you given the dismissal?
-        adult_service_detention: When were you given the detention?
-        adult_disqualification: When did the ban start?
-        adult_motoring_fine: When were you given the fine?
-        adult_penalty_notice: When was the endorsement given?
-        adult_penalty_points: When were you given the penalty points?
-        youth_disqualification: When did the ban start?
-        youth_motoring_fine: When were you given the fine?
-        youth_penalty_notice: When was the endorsement given?
-        youth_penalty_points: When were you given the penalty points?
       steps_conviction_conviction_type_form:
         conviction_type: What type of conviction did you get?
       steps_conviction_conviction_subtype_form:
@@ -184,14 +159,8 @@ en:
         adult_suspended_prison_sentence: Was the length of the sentence given in weeks, months or years?
         adult_prison_sentence: Was the length of the sentence given in weeks, months or years?
         adult_disqualification: Was the length of the disqualification given in weeks, months or years?
-      steps_conviction_compensation_paid_form:
-        compensation_paid: Have you paid the compensation in full?
-      steps_conviction_compensation_paid_amount_form:
-        compensation_payment_over_100: Was the compensation order amount over £100?
-      steps_conviction_compensation_payment_date_form:
-        compensation_payment_date: When did you pay the compensation in full?
       steps_conviction_compensation_payment_receipt_form:
-          compensation_receipt_sent: Did you send the payment receipt to the Disclosure and Barring (DBS) service?
+        compensation_receipt_sent: Did you send the payment receipt to the Disclosure and Barring (DBS) service?
       steps_conviction_motoring_endorsement_form:
         motoring_endorsement: Did you get an endorsement?
       steps_conviction_motoring_disqualification_end_date_form:
@@ -219,7 +188,7 @@ en:
         conditional_end_date_html: "Enter the date you agreed the conditions would end. This might have included paying a fine or compensation. If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>"
       steps_conviction_known_date_form:
         # default key
-        known_date_html: *court_sentence_hint_text
+        default_html: *court_sentence_hint_text
         # alternative keys defined with `i18_attribute`
         referral_order_html: Enter the date of your first youth offender panel meeting. If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>
         bind_over_html: *court_conviction_hint_text
@@ -343,8 +312,8 @@ en:
         caution_type_options:
           <<: *CAUTION_TYPES
       steps_conviction_known_date_form:
-        <<: *DATE_PARTS
-        approximate_known_date: *approximate_date_checkbox
+        approximate_known_date_options:
+          'true': *approximate_date_checkbox
       steps_conviction_conviction_type_form:
         conviction_type:
           <<: *CONVICTION_TYPES
@@ -385,6 +354,32 @@ en:
       steps_caution_conditional_end_date_form:
         conditional_end_date: When did the conditions end?
         approximate_conditional_end_date: *approximate_date_legend
+      steps_conviction_known_date_form:
+        approximate_known_date: *approximate_date_legend
+        # default key
+        default: When were you given the order?
+        # alternative keys defined with `i18_attribute`
+        referral_order: What was the date of your first panel meeting?
+        dismissal: When were you given the dismissal?
+        service_detention: When were you given the detention?
+        detention_training_order: When did the DTO start?
+        detention: When did the detention start?
+        absolute_discharge: When were you given the discharge?
+        conditional_discharge: When were you given the discharge?
+        adult_absolute_discharge: When were you given the discharge?
+        adult_conditional_discharge: When were you given the discharge?
+        adult_suspended_prison_sentence: When did the sentence start?
+        adult_prison_sentence: When did the sentence start?
+        adult_dismissal: When were you given the dismissal?
+        adult_service_detention: When were you given the detention?
+        adult_disqualification: When did the ban start?
+        adult_motoring_fine: When were you given the fine?
+        adult_penalty_notice: When was the endorsement given?
+        adult_penalty_points: When were you given the penalty points?
+        youth_disqualification: When did the ban start?
+        youth_motoring_fine: When were you given the fine?
+        youth_penalty_notice: When was the endorsement given?
+        youth_penalty_points: When were you given the penalty points?
       steps_conviction_compensation_payment_date_form:
         compensation_payment_date: When did you pay the compensation in full?
         approximate_compensation_payment_date: *approximate_date_legend

--- a/spec/forms/steps/conviction/known_date_form_spec.rb
+++ b/spec/forms/steps/conviction/known_date_form_spec.rb
@@ -1,5 +1,33 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Conviction::KnownDateForm do
-  it_behaves_like 'a date question form', attribute_name: :known_date
+  it_behaves_like 'a date question form', attribute_name: :known_date do
+    # TODO: move this context to the shared examples once all dates are migrated
+    context 'casting the date from multi parameters' do
+      context 'when date is valid' do
+        let(:date_value) { [nil, 2008, 11, 22] }
+        it { expect(subject).to be_valid }
+      end
+
+      context 'when date is not valid' do
+        let(:date_value) { [nil, 18, 11, 22] } # 2-digits year (18)
+        it { expect(subject).not_to be_valid }
+      end
+
+      context 'when a part is missing (nil or zero)' do
+        let(:date_value) { [nil, 2008, 0, 22] }
+        it { expect(subject).not_to be_valid }
+      end
+    end
+  end
+
+  describe '#i18n_attribute' do
+    before do
+      allow(subject).to receive(:conviction_subtype).and_return(:foobar)
+    end
+
+    it 'returns the key that will be used to translate legends and hints' do
+      expect(subject.i18n_attribute).to eq(:foobar)
+    end
+  end
 end

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -4,10 +4,12 @@ class TestHelper < ActionView::Base ; end
 
 RSpec.describe CustomFormHelpers, type: :helper do
   let(:helper) { TestHelper.new }
+  let(:form_object) { double('FormObject') }
+
   let(:builder) do
     GOVUKDesignSystemFormBuilder::FormBuilder.new(
       :disclosure_check,
-      DisclosureCheck.new,
+      form_object,
       helper,
       {}
     )
@@ -18,6 +20,38 @@ RSpec.describe CustomFormHelpers, type: :helper do
       expect(
         builder.continue_button
       ).to eq('<input type="submit" name="commit" value="Continue" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" />')
+    end
+  end
+
+  describe '#i18n_legend' do
+    before do
+      allow(form_object).to receive(:i18n_attribute).and_return(:foobar)
+    end
+
+    it 'seeks the expected locale key' do
+      expect(I18n).to receive(:t).with(
+        :foobar, scope: [:helpers, :legend, :disclosure_check], default: :default
+      )
+
+      builder.i18n_legend
+    end
+  end
+
+  describe '#i18n_hint' do
+    let(:found_locale) { double('locale') }
+
+    before do
+      allow(form_object).to receive(:i18n_attribute).and_return(:foobar)
+    end
+
+    it 'seeks the expected locale key' do
+      expect(I18n).to receive(:t).with(
+        'foobar_html', scope: [:helpers, :hint, :disclosure_check], default: :default_html
+      ).and_return(found_locale)
+
+      expect(found_locale).to receive(:html_safe)
+
+      builder.i18n_hint
     end
   end
 end


### PR DESCRIPTION
Similar to previous PR to migrate gems, but this one is a bit special as this is the first form to be migrated with our custom `i18n_attribute` that we created to allow a same form to be reused in multiple views with different legends and hint texts.

This is a preliminary version of a potential solution that more or less maintain the same interface and same locales and should be easy to migrate the rest of the forms.

<img width="692" alt="Screen Shot 2020-09-02 at 16 10 34" src="https://user-images.githubusercontent.com/687910/92001715-edb06a00-ed36-11ea-98ac-f6cbdb4898c8.png">

<img width="683" alt="Screen Shot 2020-09-02 at 16 10 45" src="https://user-images.githubusercontent.com/687910/92001712-ed17d380-ed36-11ea-82e8-c7e88952d3ba.png">