### PR TITLE
Migrate `motoring_disqualification_end_date` to use new gem

### DIFF
--- a/app/forms/steps/conviction/motoring_disqualification_end_date_form.rb
+++ b/app/forms/steps/conviction/motoring_disqualification_end_date_form.rb
@@ -1,12 +1,8 @@
 module Steps
   module Conviction
     class MotoringDisqualificationEndDateForm < BaseForm
-      include GovUkDateFields::ActsAsGovUkDate
-
-      attribute :motoring_disqualification_end_date, Date
+      attribute :motoring_disqualification_end_date, MultiParamDate
       attribute :approximate_motoring_disqualification_end_date, Boolean
-
-      acts_as_gov_uk_date :motoring_disqualification_end_date, error_clash_behaviour: :omit_gov_uk_date_field_error
 
       validates :motoring_disqualification_end_date, sensible_date: { allow_future: true }
 

--- a/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
+++ b/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
@@ -1,26 +1,19 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="govuk-width-container">
-  <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+    <%= step_subsection %>
 
-  <main id="main-content" class="govuk-main-wrapper">
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_date_field :motoring_disqualification_end_date, form_group_classes: 'app-util--compact-form-group' %>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= error_summary %>
-        <%= step_subsection %>
+      <%= render partial: 'steps/shared/new_approx_date_checkbox', locals: {
+        form: f, attribute: :approximate_motoring_disqualification_end_date
+      } %>
 
-        <%= step_form @form_object do |f| %>
-          <%= f.gov_uk_date_field :motoring_disqualification_end_date %>
-
-          <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
-            form: f, attribute: :approximate_motoring_disqualification_end_date
-          } %>
-
-          <%= f.continue_button %>
-        <% end %>
-      </div>
-    </div>
-
-  </main>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
 </div>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -52,9 +52,9 @@ en:
               future: The date of the compensation payment date can’t be in the future
         steps/conviction/motoring_disqualification_end_date_form:
           attributes:
+            # Note: this date can be blank or in the future, but not too far in the past
             motoring_disqualification_end_date:
-              blank: Enter the end date of the motoring disqualification in the format dd/mm/yyyy
-              invalid: The end date of the motoring disqualification is not valid
+              invalid: The date is too far in the past. Enter a date after 01/01/1940
         steps/conviction/conviction_bail_form:
           attributes:
             conviction_bail:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -131,8 +131,6 @@ en:
       steps_check_under_age_form:
         caution: How old were you when you got cautioned?
         conviction: How old were you when you got convicted?
-      steps_conviction_conviction_type_form:
-        conviction_type: What type of conviction did you get?
       steps_conviction_conviction_subtype_form:
         # default key
         conviction_subtype: What type of order were you given?
@@ -161,8 +159,6 @@ en:
         adult_disqualification: Was the length of the disqualification given in weeks, months or years?
       steps_conviction_motoring_endorsement_form:
         motoring_endorsement: Did you get an endorsement?
-      steps_conviction_motoring_disqualification_end_date_form:
-        motoring_disqualification_end_date: When did your disqualification end?
       steps_conviction_conviction_bail_form:
         conviction_bail: Did you spend any time on bail with an electronic tag?
 
@@ -225,7 +221,7 @@ en:
       steps_conviction_motoring_endorsement_form:
         motoring_endorsement: An endorsement means that your conviction is recorded on your driving licence. Endorsements are usually given by courts.
       steps_conviction_motoring_disqualification_end_date_form:
-        motoring_disqualification_end_date_html: If you do not know the exact date, you can enter an approximate one. Leave this blank if your ban had no end date. <span class='nowrap'>For example, 23 9 2018</span>
+        motoring_disqualification_end_date_html: If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span> <p>Leave this blank if your ban had no end date.</p>
       steps_conviction_conviction_bail_form:
         conviction_bail: Time spent on bail with an electronic tag affects the spent date of your conviction. Time spent on bail without a tag does not.
       steps_conviction_conviction_bail_days_form:
@@ -335,8 +331,8 @@ en:
       steps_conviction_compensation_paid_amount_form:
         compensation_payment_over_100_options: *YESNO
       steps_conviction_motoring_disqualification_end_date_form:
-        <<: *DATE_PARTS
-        approximate_motoring_disqualification_end_date: *approximate_date_checkbox
+        approximate_motoring_disqualification_end_date_options:
+          'true': *approximate_date_checkbox
       steps_conviction_conviction_bail_days_form:
         conviction_bail_days: Number of days
       steps_conviction_compensation_paid_form:
@@ -383,6 +379,9 @@ en:
         youth_penalty_points: When were you given the penalty points?
       steps_conviction_conviction_type_form:
         conviction_type: What type of conviction did you get?
+      steps_conviction_motoring_disqualification_end_date_form:
+        motoring_disqualification_end_date: When did your disqualification end?
+        approximate_motoring_disqualification_end_date: *approximate_date_legend
       steps_conviction_compensation_payment_date_form:
         compensation_payment_date: When did you pay the compensation in full?
         approximate_compensation_payment_date: *approximate_date_legend
@@ -391,4 +390,4 @@ en:
       steps_conviction_compensation_paid_form:
         compensation_paid: Have you paid the compensation in full?
       steps_conviction_compensation_payment_receipt_form:
-          compensation_receipt_sent: Did you send the payment receipt to the Disclosure and Barring (DBS) service?
+        compensation_receipt_sent: Did you send the payment receipt to the Disclosure and Barring (DBS) service?

--- a/spec/forms/steps/conviction/motoring_disqualification_end_date_form_spec.rb
+++ b/spec/forms/steps/conviction/motoring_disqualification_end_date_form_spec.rb
@@ -1,5 +1,18 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Conviction::MotoringDisqualificationEndDateForm do
-  it_behaves_like 'a date question form', attribute_name: :motoring_disqualification_end_date, allow_empty_date: true, allow_future: true
+  it_behaves_like 'a date question form', attribute_name: :motoring_disqualification_end_date, allow_empty_date: true, allow_future: true do
+    # TODO: move this context to the shared examples once all dates are migrated
+    context 'casting the date from multi parameters' do
+      context 'when date is valid' do
+        let(:date_value) { [nil, 2008, 11, 22] }
+        it { expect(subject).to be_valid }
+      end
+
+      context 'when date is not valid' do
+        let(:date_value) { [nil, 18, 11, 22] } # 2-digits year (18)
+        it { expect(subject).not_to be_valid }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://mojdigital.teamwork.com/#/tasks/21737618

Same as with previous dates.
This one however allows to be in the future, and also to be left blank.

In a follow-up PR, I will remove all the code related to the old dates gem and refactor the duplication in the tests now that we've migrated all the dates.

<img width="622" alt="Screen Shot 2020-09-03 at 11 35 31" src="https://user-images.githubusercontent.com/687910/92105471-cca15500-edda-11ea-8bb2-d3710af2cfec.png">

<img width="691" alt="Screen Shot 2020-09-03 at 11 38 36" src="https://user-images.githubusercontent.com/687910/92105478-cf9c4580-edda-11ea-8344-7059913bc241.png">
