### PR TITLE
Fix typo in DB migration

### DIFF
--- a/db/migrate/20190926082054_add_motoring_endorsement_to_disclosure_check.rb
+++ b/db/migrate/20190926082054_add_motoring_endorsement_to_disclosure_check.rb
@@ -1,5 +1,5 @@
 class AddMotoringEndorsementToDisclosureCheck < ActiveRecord::Migration[5.2]
   def change
-    add_column :disclosure_checks, :motoring_lifetime_ban_to_disclosure_check, :string
+    add_column :disclosure_checks, :motoring_endorsement, :string
   end
 end


### PR DESCRIPTION
I had to drop and recreate my local DB and I found this issue.

This does not affect already created databases.