### PR TITLE
Remove old `gov_uk_date_fields` gem and cleanup old code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'govuk_design_system_formbuilder'
 #       migrated all the forms to the govuk_design_system_formbuilder
 gem 'govuk_elements_form_builder', '~> 1.3.1'
 
-gem 'gov_uk_date_fields', '~> 4.1.0'
 gem 'jquery-rails'
 gem 'pg', '~> 1.1'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,8 +135,6 @@ GEM
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    gov_uk_date_fields (4.1.0)
-      rails (>= 5.0.7.2)
     govuk_design_system_formbuilder (1.2.7)
       actionview (>= 5.2)
       activemodel (>= 5.2)
@@ -373,7 +371,6 @@ DEPENDENCIES
   cucumber-rails
   dotenv-rails
   factory_bot_rails
-  gov_uk_date_fields (~> 4.1.0)
   govuk_design_system_formbuilder
   govuk_elements_form_builder (~> 1.3.1)
   i18n-debug

--- a/app/views/steps/caution/conditional_end_date/edit.html.erb
+++ b/app/views/steps/caution/conditional_end_date/edit.html.erb
@@ -8,7 +8,7 @@
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_date_field :conditional_end_date, form_group_classes: 'app-util--compact-form-group' %>
 
-      <%= render partial: 'steps/shared/new_approx_date_checkbox', locals: {
+      <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_conditional_end_date
       } %>
 

--- a/app/views/steps/caution/known_date/edit.html.erb
+++ b/app/views/steps/caution/known_date/edit.html.erb
@@ -8,7 +8,7 @@
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_date_field :known_date, form_group_classes: 'app-util--compact-form-group' %>
 
-      <%= render partial: 'steps/shared/new_approx_date_checkbox', locals: {
+      <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_known_date
       } %>
 

--- a/app/views/steps/conviction/compensation_payment_date/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_date/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_date_field :compensation_payment_date, form_group_classes: 'app-util--compact-form-group' %>
 
-      <%= render partial: 'steps/shared/new_approx_date_checkbox', locals: {
+      <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_compensation_payment_date
       } %>
 

--- a/app/views/steps/conviction/known_date/edit.html.erb
+++ b/app/views/steps/conviction/known_date/edit.html.erb
@@ -10,7 +10,7 @@
       <%= f.govuk_date_field :known_date, form_group_classes: 'app-util--compact-form-group',
                              legend: { text: f.i18n_legend }, hint_text: f.i18n_hint %>
 
-      <%= render partial: 'steps/shared/new_approx_date_checkbox', locals: {
+      <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_known_date
       } %>
 

--- a/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
+++ b/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
@@ -9,7 +9,7 @@
     <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_date_field :motoring_disqualification_end_date, form_group_classes: 'app-util--compact-form-group' %>
 
-      <%= render partial: 'steps/shared/new_approx_date_checkbox', locals: {
+      <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_motoring_disqualification_end_date
       } %>
 

--- a/app/views/steps/shared/_approx_date_checkbox.html.erb
+++ b/app/views/steps/shared/_approx_date_checkbox.html.erb
@@ -1,3 +1,3 @@
-<%# Use this partial with the old gem, and remove once all is migrated %>
-
-<%= form.check_box_fieldset attribute, [attribute], { small: true, no_legend: true } %>
+<%= form.govuk_check_boxes_fieldset attribute, small: true, legend: { tag: 'span', size: 's', hidden: true } do %>
+  <%= form.govuk_check_box attribute, true, multiple: false, link_errors: true %>
+<% end %>

--- a/app/views/steps/shared/_new_approx_date_checkbox.html.erb
+++ b/app/views/steps/shared/_new_approx_date_checkbox.html.erb
@@ -1,5 +1,0 @@
-<%# Use this partial with the new gem, and rename once all is migrated %>
-
-<%= form.govuk_check_boxes_fieldset attribute, small: true, legend: { tag: 'span', size: 's', hidden: true } do %>
-  <%= form.govuk_check_box attribute, true, multiple: false, link_errors: true %>
-<% end %>

--- a/lib/generators/step/templates/date/edit.html.erb
+++ b/lib/generators/step/templates/date/edit.html.erb
@@ -5,14 +5,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%%= error_summary %>
 
-    <h1 class="govuk-heading-xl"><%%=t '.heading' %></h1>
-
-    <p class="govuk-body-l"><%%=t '.lead_text' %></p>
+    <!-- The header is part of the date legend by default, but can be configured -->
 
     <%%= step_form @form_object do |f| %>
-      <%%= f.gov_uk_date_field :caution_date,
-                              legend_options: { page_heading: false, visually_hidden: true } %>
-
+      <%%= f.govuk_date_field :caution_date %>
       <%%= f.continue_button %>
     <%% end %>
   </div>

--- a/spec/forms/steps/caution/conditional_end_date_form_spec.rb
+++ b/spec/forms/steps/caution/conditional_end_date_form_spec.rb
@@ -5,24 +5,6 @@ RSpec.describe Steps::Caution::ConditionalEndDateForm do
     before do
       allow(subject).to receive(:after_caution_date?).and_return(true)
     end
-
-    # TODO: move this context to the shared examples once all dates are migrated
-    context 'casting the date from multi parameters' do
-      context 'when date is valid' do
-        let(:date_value) { [nil, 2008, 11, 22] }
-        it { expect(subject).to be_valid }
-      end
-
-      context 'when date is not valid' do
-        let(:date_value) { [nil, 18, 11, 22] } # 2-digits year (18)
-        it { expect(subject).not_to be_valid }
-      end
-
-      context 'when a part is missing (nil or zero)' do
-        let(:date_value) { [nil, 2008, 0, 22] }
-        it { expect(subject).not_to be_valid }
-      end
-    end
   end
 
   context '#after_caution_date? validation' do

--- a/spec/forms/steps/caution/known_date_form_spec.rb
+++ b/spec/forms/steps/caution/known_date_form_spec.rb
@@ -1,23 +1,5 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Caution::KnownDateForm do
-  it_behaves_like 'a date question form', attribute_name: :known_date do
-    # TODO: move this context to the shared examples once all dates are migrated
-    context 'casting the date from multi parameters' do
-      context 'when date is valid' do
-        let(:date_value) { [nil, 2008, 11, 22] }
-        it { expect(subject).to be_valid }
-      end
-
-      context 'when date is not valid' do
-        let(:date_value) { [nil, 18, 11, 22] } # 2-digits year (18)
-        it { expect(subject).not_to be_valid }
-      end
-
-      context 'when a part is missing (nil or zero)' do
-        let(:date_value) { [nil, 2008, 0, 22] }
-        it { expect(subject).not_to be_valid }
-      end
-    end
-  end
+  it_behaves_like 'a date question form', attribute_name: :known_date
 end

--- a/spec/forms/steps/conviction/compensation_payment_date_form_spec.rb
+++ b/spec/forms/steps/conviction/compensation_payment_date_form_spec.rb
@@ -1,23 +1,5 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Conviction::CompensationPaymentDateForm do
-  it_behaves_like 'a date question form', attribute_name: :compensation_payment_date do
-    # TODO: move this context to the shared examples once all dates are migrated
-    context 'casting the date from multi parameters' do
-      context 'when date is valid' do
-        let(:date_value) { [nil, 2008, 11, 22] }
-        it { expect(subject).to be_valid }
-      end
-
-      context 'when date is not valid' do
-        let(:date_value) { [nil, 18, 11, 22] } # 2-digits year (18)
-        it { expect(subject).not_to be_valid }
-      end
-
-      context 'when a part is missing (nil or zero)' do
-        let(:date_value) { [nil, 2008, 0, 22] }
-        it { expect(subject).not_to be_valid }
-      end
-    end
-  end
+  it_behaves_like 'a date question form', attribute_name: :compensation_payment_date
 end

--- a/spec/forms/steps/conviction/known_date_form_spec.rb
+++ b/spec/forms/steps/conviction/known_date_form_spec.rb
@@ -1,25 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Conviction::KnownDateForm do
-  it_behaves_like 'a date question form', attribute_name: :known_date do
-    # TODO: move this context to the shared examples once all dates are migrated
-    context 'casting the date from multi parameters' do
-      context 'when date is valid' do
-        let(:date_value) { [nil, 2008, 11, 22] }
-        it { expect(subject).to be_valid }
-      end
-
-      context 'when date is not valid' do
-        let(:date_value) { [nil, 18, 11, 22] } # 2-digits year (18)
-        it { expect(subject).not_to be_valid }
-      end
-
-      context 'when a part is missing (nil or zero)' do
-        let(:date_value) { [nil, 2008, 0, 22] }
-        it { expect(subject).not_to be_valid }
-      end
-    end
-  end
+  it_behaves_like 'a date question form', attribute_name: :known_date
 
   describe '#i18n_attribute' do
     before do

--- a/spec/forms/steps/conviction/motoring_disqualification_end_date_form_spec.rb
+++ b/spec/forms/steps/conviction/motoring_disqualification_end_date_form_spec.rb
@@ -1,18 +1,5 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Conviction::MotoringDisqualificationEndDateForm do
-  it_behaves_like 'a date question form', attribute_name: :motoring_disqualification_end_date, allow_empty_date: true, allow_future: true do
-    # TODO: move this context to the shared examples once all dates are migrated
-    context 'casting the date from multi parameters' do
-      context 'when date is valid' do
-        let(:date_value) { [nil, 2008, 11, 22] }
-        it { expect(subject).to be_valid }
-      end
-
-      context 'when date is not valid' do
-        let(:date_value) { [nil, 18, 11, 22] } # 2-digits year (18)
-        it { expect(subject).not_to be_valid }
-      end
-    end
-  end
+  it_behaves_like 'a date question form', attribute_name: :motoring_disqualification_end_date, allow_empty_date: true, allow_future: true
 end

--- a/spec/support/form_validation_shared_examples.rb
+++ b/spec/support/form_validation_shared_examples.rb
@@ -207,6 +207,25 @@ RSpec.shared_examples 'a date question form' do |options|
       end
     end
 
+    context 'casting the date from multi parameters' do
+      context 'when date is valid' do
+        let(:date_value) { [nil, 2008, 11, 22] }
+        it { expect(subject).to be_valid }
+      end
+
+      context 'when date is not valid' do
+        let(:date_value) { [nil, 18, 11, 22] } # 2-digits year (18)
+        it { expect(subject).not_to be_valid }
+      end
+
+      if options[:allow_future].nil?
+        context 'when a part is missing (nil or zero)' do
+          let(:date_value) { [nil, 2008, 0, 22] }
+          it { expect(subject).not_to be_valid }
+        end
+      end
+    end
+
     context 'when form is valid' do
       it 'saves the record' do
         expect(disclosure_check).to receive(:update).with(


### PR DESCRIPTION
This is the final PR to the work done to migrate the dates to use the new gem.

In this PR we remove the gem, and cleanup/refactor the old code or the code introduced while we were migrating.

Individual commits for more context.