### PR TITLE
Update Design System for steps/conviction/conviction_bail_days/

### DIFF
--- a/app/views/steps/conviction/conviction_bail_days/edit.html.erb
+++ b/app/views/steps/conviction/conviction_bail_days/edit.html.erb
@@ -1,28 +1,19 @@
 <% title t('.page_title') %>
+<% step_header %>
 
-<div class="govuk-width-container">
-  <%= step_header %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+    <%= step_subsection %>
 
-  <main id="main-content" class="govuk-main-wrapper">
+    <h1 class="govuk-heading-xl">
+      <%=t '.heading' %>
+    </h1>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= error_summary %>
-        <%= step_subsection %>
+    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_text_field :conviction_bail_days, width: 3, pattern: "[0-9]*", inputmode: "numeric" %>
 
-        <h1 class="govuk-heading-xl">
-          <%=t '.heading' %>
-        </h1>
-
-        <%= step_form @form_object do |f| %>
-          <%= f.text_field :conviction_bail_days,
-                           input_options: { class: 'govuk-input--width-3', inputmode: :numeric, pattern: '[0-9]*' },
-                           label_options: { page_heading: false, size: 's' } %>
-
-          <%= f.continue_button %>
-        <% end %>
-      </div>
-    </div>
-
-  </main>
+      <%= f.continue_button %>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
Story: https://mojdigital.teamwork.com/#/tasks/21725162

There's a bit of a discrepancy between before and now:
- 'number of days' is not bold (I've tried to play with the size option but nothing changed, ideas?)
- title of the page used to be larger
- On C100 we normally used `one-half` or similar, but any of those sizes made the text field look really wide, so I used `width: 3` instead


Left is new design, right is old design

<img width="1350" alt="Screenshot 2020-09-04 at 15 21 29" src="https://user-images.githubusercontent.com/136777/92249805-86bfbc00-eec2-11ea-99f4-e7469f0d7f95.png">
