### PR TITLE
Define GOVUKDesignSystemFormBuilder::FormBuilder as the default

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,17 +47,12 @@ module ApplicationHelper
   def govuk_error_summary(form_object = @form_object)
     return unless form_object.try(:errors).present?
 
-    # TODO: can be removed once we use this builder globally
-    options = {
-      builder: GOVUKDesignSystemFormBuilder::FormBuilder
-    }
-
     # Prepend page title so screen readers read it out as soon as possible
     content_for(:page_title, flush: true) do
       content_for(:page_title).insert(0, t('errors.page_title_prefix'))
     end
 
-    fields_for(form_object, form_object, options) do |f|
+    fields_for(form_object, form_object) do |f|
       f.govuk_error_summary t('errors.error_summary.heading')
     end
   end

--- a/app/views/steps/caution/caution_type/edit.html.erb
+++ b/app/views/steps/caution/caution_type/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :caution_type, @form_object.values, :value, nil %>
 
       <%= f.continue_button %>

--- a/app/views/steps/caution/conditional_end_date/edit.html.erb
+++ b/app/views/steps/caution/conditional_end_date/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_date_field :conditional_end_date, form_group_classes: 'app-util--compact-form-group' %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {

--- a/app/views/steps/caution/known_date/edit.html.erb
+++ b/app/views/steps/caution/known_date/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_date_field :known_date, form_group_classes: 'app-util--compact-form-group' %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {

--- a/app/views/steps/check/kind/edit.html.erb
+++ b/app/views/steps/check/kind/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :kind, CheckKind.values, :value, nil %>
 
       <%= f.continue_button %>

--- a/app/views/steps/check/under_age/edit.html.erb
+++ b/app/views/steps/check/under_age/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= error_summary %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
         <%= f.govuk_collection_radio_buttons :under_age, GenericYesNo.values, :value, nil,
               legend: { text: f.i18n_legend }, hint_text: f.i18n_hint %>
 

--- a/app/views/steps/conviction/compensation_paid/edit.html.erb
+++ b/app/views/steps/conviction/compensation_paid/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
     <%= step_subsection %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :compensation_paid, GenericYesNo.values, :value, nil %>
 
       <%= f.continue_button %>

--- a/app/views/steps/conviction/compensation_paid_amount/edit.html.erb
+++ b/app/views/steps/conviction/compensation_paid_amount/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
     <%= step_subsection %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :compensation_payment_over_100, GenericYesNo.values, :value, nil, inline: true %>
 
       <%= f.continue_button %>

--- a/app/views/steps/conviction/compensation_payment_date/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_date/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
     <%= step_subsection %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_date_field :compensation_payment_date, form_group_classes: 'app-util--compact-form-group' %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {

--- a/app/views/steps/conviction/compensation_payment_receipt/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_receipt/edit.html.erb
@@ -6,7 +6,7 @@
     <%= error_summary %>
     <%= step_subsection %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :compensation_receipt_sent, GenericYesNo.values, :value, nil, inline: true %>
 
       <%= f.continue_button %>

--- a/app/views/steps/conviction/conviction_bail/edit.html.erb
+++ b/app/views/steps/conviction/conviction_bail/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
     <%= step_subsection %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
         <%= f.govuk_collection_radio_buttons :conviction_bail, GenericYesNo.values, :value, nil, inline: true %>
         <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/conviction/conviction_bail_days/edit.html.erb
+++ b/app/views/steps/conviction/conviction_bail_days/edit.html.erb
@@ -10,7 +10,7 @@
       <%=t '.heading' %>
     </h1>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_text_field :conviction_bail_days, width: 3, pattern: "[0-9]*", inputmode: "numeric" %>
 
       <%= f.continue_button %>

--- a/app/views/steps/conviction/conviction_length/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length/edit.html.erb
@@ -12,7 +12,7 @@
 
     <%=t ".explanation.#{@form_object.conviction_subtype}_html", default: '' %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
         <%= f.govuk_text_field :conviction_length,
                        label: { text: f.i18n_legend },
                        width: 3, pattern: "[0-9]*", inputmode: "numeric" %>

--- a/app/views/steps/conviction/conviction_length_type/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length_type/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
     <%= step_subsection %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :conviction_length_type, @form_object.values, :value, nil,
             legend: { text: f.i18n_legend } %>
 

--- a/app/views/steps/conviction/conviction_subtype/edit.html.erb
+++ b/app/views/steps/conviction/conviction_subtype/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :conviction_subtype, @form_object.values, :value, nil,
             legend: { text: f.i18n_legend } %>
 

--- a/app/views/steps/conviction/conviction_type/edit.html.erb
+++ b/app/views/steps/conviction/conviction_type/edit.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :conviction_type, @form_object.values, :value, nil %>
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/conviction/known_date/edit.html.erb
+++ b/app/views/steps/conviction/known_date/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
     <%= step_subsection %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_date_field :known_date, form_group_classes: 'app-util--compact-form-group',
                              legend: { text: f.i18n_legend }, hint_text: f.i18n_hint %>
 

--- a/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
+++ b/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
     <%= step_subsection %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_date_field :motoring_disqualification_end_date, form_group_classes: 'app-util--compact-form-group' %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {

--- a/app/views/steps/conviction/motoring_endorsement/edit.html.erb
+++ b/app/views/steps/conviction/motoring_endorsement/edit.html.erb
@@ -6,7 +6,7 @@
     <%= govuk_error_summary %>
     <%= step_subsection %>
 
-    <%= step_form @form_object, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :motoring_endorsement, GenericYesNo.values, :value, nil %>
       <%= f.continue_button %>
     <% end %>

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -20,7 +20,7 @@
 require_relative '../../lib/govuk_components/form_builder'
 require_relative '../../lib/govuk_components/error_helpers'
 
-ActionView::Base.default_form_builder = GovukComponents::FormBuilder
+ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
 
 GOVUKDesignSystemFormBuilder.configure do |config|
   config.default_legend_tag   = 'h1'


### PR DESCRIPTION
This commit removes all the explicit places where we had previously defined which form builder to be used and make it the default form builder in this project.