### PR TITLE
Use the caption field provided by the Design System gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ tags
 
 public/assets/
 .DS_Store
+
+rerun.txt

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,14 +23,6 @@ module ApplicationHelper
     }
   end
 
-  def step_subsection(form_object = @form_object)
-    capture do
-      render partial: 'step_subsection', locals: {
-        subsection: form_object.conviction_subtype
-      }
-    end
-  end
-
   def error_summary(form_object = @form_object)
     return unless GovukElementsErrorsHelper.errors_exist?(form_object)
 

--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -3,6 +3,13 @@ module CustomFormHelpers
     submit_button(continue)
   end
 
+  # Used to customise captions above the page heading
+  def i18n_caption
+    I18n.t(
+      object.conviction_subtype, scope: scope_for_locale(:caption)
+    )
+  end
+
   # Used to customise legends when reusing the same view
   def i18n_legend
     I18n.t(

--- a/app/views/application/_step_subsection.html.erb
+++ b/app/views/application/_step_subsection.html.erb
@@ -1,3 +1,0 @@
-<span class="govuk-caption-l">
-  <%=t subsection, scope: [:shared, :subsection], default: '' %>
-</span>

--- a/app/views/steps/conviction/compensation_paid/edit.html.erb
+++ b/app/views/steps/conviction/compensation_paid/edit.html.erb
@@ -4,10 +4,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
-    <%= step_subsection %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_collection_radio_buttons :compensation_paid, GenericYesNo.values, :value, nil %>
+      <%= f.govuk_collection_radio_buttons :compensation_paid,
+            GenericYesNo.values, :value, nil,
+            caption: { text: f.i18n_caption } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/conviction/compensation_paid_amount/edit.html.erb
+++ b/app/views/steps/conviction/compensation_paid_amount/edit.html.erb
@@ -4,10 +4,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
-    <%= step_subsection %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_collection_radio_buttons :compensation_payment_over_100, GenericYesNo.values, :value, nil, inline: true %>
+      <%= f.govuk_collection_radio_buttons :compensation_payment_over_100,
+            GenericYesNo.values, :value, nil, inline: true,
+            caption: { text: f.i18n_caption } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/conviction/compensation_payment_date/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_date/edit.html.erb
@@ -4,10 +4,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
-    <%= step_subsection %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_date_field :compensation_payment_date, form_group_classes: 'app-util--compact-form-group' %>
+      <%= f.govuk_date_field :compensation_payment_date,
+          form_group_classes: 'app-util--compact-form-group',
+          caption: { text: f.i18n_caption } %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_compensation_payment_date

--- a/app/views/steps/conviction/compensation_payment_receipt/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_receipt/edit.html.erb
@@ -4,10 +4,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= error_summary %>
-    <%= step_subsection %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_collection_radio_buttons :compensation_receipt_sent, GenericYesNo.values, :value, nil, inline: true %>
+      <%= f.govuk_collection_radio_buttons :compensation_receipt_sent,
+            GenericYesNo.values, :value, nil, inline: true,
+            caption: { text: f.i18n_caption } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/conviction/conviction_bail/edit.html.erb
+++ b/app/views/steps/conviction/conviction_bail/edit.html.erb
@@ -4,10 +4,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
-    <%= step_subsection %>
 
     <%= step_form @form_object do |f| %>
-        <%= f.govuk_collection_radio_buttons :conviction_bail, GenericYesNo.values, :value, nil, inline: true %>
+        <%= f.govuk_collection_radio_buttons :conviction_bail,
+              GenericYesNo.values, :value, nil, inline: true,
+              caption: { text: f.i18n_caption } %>
+
         <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/conviction/conviction_bail_days/edit.html.erb
+++ b/app/views/steps/conviction/conviction_bail_days/edit.html.erb
@@ -4,14 +4,17 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
-    <%= step_subsection %>
 
     <h1 class="govuk-heading-xl">
       <%=t '.heading' %>
     </h1>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_field :conviction_bail_days, width: 3, pattern: "[0-9]*", inputmode: "numeric" %>
+      <%= f.govuk_text_field :conviction_bail_days,
+            width: 3,
+            pattern: "[0-9]*",
+            inputmode: "numeric",
+            caption: { text: f.i18n_caption } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/conviction/conviction_bail_days/edit.html.erb
+++ b/app/views/steps/conviction/conviction_bail_days/edit.html.erb
@@ -5,16 +5,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <h1 class="govuk-heading-xl">
-      <%=t '.heading' %>
-    </h1>
-
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_text_field :conviction_bail_days,
-            width: 3,
-            pattern: "[0-9]*",
-            inputmode: "numeric",
-            caption: { text: f.i18n_caption } %>
+      <%= f.govuk_fieldset legend: { text: t('.heading') }, caption: { text: f.i18n_caption } do %>
+        <%= f.govuk_text_field :conviction_bail_days, width: 3, pattern: "[0-9]*", inputmode: "numeric" %>
+      <% end %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/conviction/conviction_length/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length/edit.html.erb
@@ -4,7 +4,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
-    <%= step_subsection %>
 
     <h1 class="govuk-heading-xl">
       <%=t ".heading.#{@form_object.conviction_subtype}", default: t('.heading.default') %>
@@ -15,6 +14,7 @@
     <%= step_form @form_object do |f| %>
         <%= f.govuk_text_field :conviction_length,
                        label: { text: f.i18n_legend },
+                       caption: { text: f.i18n_caption },
                        width: 3, pattern: "[0-9]*", inputmode: "numeric" %>
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/conviction/conviction_length/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length/edit.html.erb
@@ -1,21 +1,20 @@
 <% title t('.page_title') %>
-<%= step_header %>
+<% step_header %>
+
+<%
+  heading = t(".heading.#{@form_object.conviction_subtype}", default: t('.heading.default'))
+  explanation = t(".explanation.#{@form_object.conviction_subtype}_html", default: '')
+%>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
-    <h1 class="govuk-heading-xl">
-      <%=t ".heading.#{@form_object.conviction_subtype}", default: t('.heading.default') %>
-    </h1>
-
-    <%=t ".explanation.#{@form_object.conviction_subtype}_html", default: '' %>
-
     <%= step_form @form_object do |f| %>
-        <%= f.govuk_text_field :conviction_length,
-                       label: { text: f.i18n_legend },
-                       caption: { text: f.i18n_caption },
-                       width: 3, pattern: "[0-9]*", inputmode: "numeric" %>
+      <%= f.govuk_fieldset legend: { text: heading }, caption: { text: f.i18n_caption } do %>
+        <%= f.govuk_text_field :conviction_length, label: { text: f.i18n_legend }, width: 3, pattern: "[0-9]*", inputmode: "numeric" %>
+      <% end %>
+
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/app/views/steps/conviction/conviction_length_type/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length_type/edit.html.erb
@@ -4,11 +4,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
-    <%= step_subsection %>
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :conviction_length_type, @form_object.values, :value, nil,
-            legend: { text: f.i18n_legend } %>
+            legend: { text: f.i18n_legend },
+            caption: { text: f.i18n_caption } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/app/views/steps/conviction/known_date/edit.html.erb
+++ b/app/views/steps/conviction/known_date/edit.html.erb
@@ -4,11 +4,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
-    <%= step_subsection %>
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_date_field :known_date, form_group_classes: 'app-util--compact-form-group',
-                             legend: { text: f.i18n_legend }, hint_text: f.i18n_hint %>
+            legend: { text: f.i18n_legend },
+            hint_text: f.i18n_hint,
+            caption: { text: f.i18n_caption } %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_known_date

--- a/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
+++ b/app/views/steps/conviction/motoring_disqualification_end_date/edit.html.erb
@@ -4,10 +4,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
-    <%= step_subsection %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_date_field :motoring_disqualification_end_date, form_group_classes: 'app-util--compact-form-group' %>
+      <%= f.govuk_date_field :motoring_disqualification_end_date,
+            form_group_classes: 'app-util--compact-form-group',
+            caption: { text: f.i18n_caption } %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_motoring_disqualification_end_date

--- a/app/views/steps/conviction/motoring_endorsement/edit.html.erb
+++ b/app/views/steps/conviction/motoring_endorsement/edit.html.erb
@@ -4,10 +4,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
-    <%= step_subsection %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_collection_radio_buttons :motoring_endorsement, GenericYesNo.values, :value, nil %>
+      <%= f.govuk_collection_radio_buttons :motoring_endorsement,
+            GenericYesNo.values, :value, nil,
+            caption: { text: f.i18n_caption } %>
+
       <%= f.continue_button %>
     <% end %>
   </div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -116,8 +116,6 @@ en:
 
   shared:
     back_link: Back
-    subsection:
-      <<: *CONVICTION_SUBTYPES
 
   helpers:
     buttons:
@@ -127,6 +125,28 @@ en:
       restart_check: Start a new check
       cancel_check: Go back to check your answers
       results_page: Go to results page
+
+    caption:
+      steps_conviction_known_date_form:
+        <<: *CONVICTION_SUBTYPES
+      steps_conviction_compensation_paid_form:
+        <<: *CONVICTION_SUBTYPES
+      steps_conviction_compensation_payment_date_form:
+        <<: *CONVICTION_SUBTYPES
+      steps_conviction_compensation_payment_receipt_form:
+        <<: *CONVICTION_SUBTYPES
+      steps_conviction_conviction_bail_days_form:
+        <<: *CONVICTION_SUBTYPES
+      steps_conviction_conviction_bail_form:
+        <<: *CONVICTION_SUBTYPES
+      steps_conviction_conviction_length_type_form:
+        <<: *CONVICTION_SUBTYPES
+      steps_conviction_conviction_length_form:
+        <<: *CONVICTION_SUBTYPES
+      steps_conviction_motoring_disqualification_end_date_form:
+        <<: *CONVICTION_SUBTYPES
+      steps_conviction_motoring_endorsement_form:
+        <<: *CONVICTION_SUBTYPES
 
     hint:
       steps_conviction_conviction_type_form:

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -15,7 +15,7 @@ Then(/^I should not see "([^"]*)"$/) do |text|
 end
 
 And(/^I should see subsection "([^"]*)"$/) do |text|
-  expect(page).to have_css('span.govuk-caption-l', exact_text: text)
+  expect(page).to have_css('span.govuk-caption-xl', exact_text: text)
 end
 
 Then(/^I should see a "([^"]*)" link to "([^"]*)"$/) do |text, href|

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -61,15 +61,6 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#step_subsection' do
-    let(:form_object) { double('form object', conviction_subtype: 'conviction_subtype') }
-
-    it 'renders the expected content' do
-      expect(helper).to receive(:render).with(partial: 'step_subsection', locals: {subsection: 'conviction_subtype'}).and_return('foobar')
-      expect(helper.step_subsection(form_object)).to eq('foobar')
-    end
-  end
-
   describe '#error_summary' do
     context 'when no form object is given' do
       let(:form_object) { nil }

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe CustomFormHelpers, type: :helper do
     end
   end
 
+  describe '#i18n_caption' do
+    before do
+      allow(form_object).to receive(:conviction_subtype).and_return(:foobar)
+    end
+
+    it 'seeks the expected locale key' do
+      expect(I18n).to receive(:t).with(
+        :foobar, scope: [:helpers, :caption, :disclosure_check]
+      )
+
+      builder.i18n_caption
+    end
+  end
+
   describe '#i18n_legend' do
     before do
       allow(form_object).to receive(:i18n_attribute).and_return(:foobar)


### PR DESCRIPTION
The caption is now part of the form, that means that if there's an error message the whole vertical red line also covers the caption above the page header (h1)

Example:

<img width="1440" alt="Screenshot 2020-09-08 at 10 51 15" src="https://user-images.githubusercontent.com/136777/92474404-ab25dc00-f1d3-11ea-8bad-cca9888d0d9f.png">

Story: https://mojdigital.teamwork.com/#/tasks/21724564