### PR TITLE
add missing translation key for compensation paid page

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -147,6 +147,8 @@ en:
         <<: *CONVICTION_SUBTYPES
       steps_conviction_motoring_endorsement_form:
         <<: *CONVICTION_SUBTYPES
+      steps_conviction_compensation_paid_amount_form:
+        <<: *CONVICTION_SUBTYPES
 
     hint:
       steps_conviction_conviction_type_form:


### PR DESCRIPTION
Missed the compensation paid page caption translation key.
This did not affect production (just staging)

