### PR TITLE
Add .ruby-version file in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN addgroup -g 1000 -S appgroup && \
 RUN mkdir -p /usr/src/app && mkdir -p /usr/src/app/tmp
 WORKDIR /usr/src/app
 
+COPY Gemfile* .ruby-version ./
 COPY Gemfile* ./
 
 RUN gem install bundler -v 2.1.4 && \


### PR DESCRIPTION
Running the docker image won't know about the `.ruby-version` file without copying it into the image.
This happened on #402 when I changed the Gemfile to read the ruby version from that file.

I should have run `docker-compose up` to see the problem.

