### PR TITLE
Fix warnings on ruby 2.7.2

### DIFF
--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -28,7 +28,7 @@ module CustomFormHelpers
   private
 
   def submit_button(i18n_key, opts = {}, &block)
-    govuk_submit I18n.t("helpers.buttons.#{i18n_key}"), opts, &block
+    govuk_submit I18n.t("helpers.buttons.#{i18n_key}"), **opts, &block
   end
 
   def scope_for_locale(context)


### PR DESCRIPTION
No breaking changes but there are some new features in ruby 2.7.x as well as some deprecations in preparation for the next major version.

General changes in 2.7.x:
https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/

Deprecations turned off in 2.7.2:
https://www.ruby-lang.org/en/news/2020/10/02/ruby-2-7-2-released/

As these deprecations are turned off by default on 2.7.2, to see them I did the following,
running all the tests to see only the deprecations in our code, NOT in the gems as we don't have control over those ones:

```bash
RUBYOPT='-W:deprecated' RAILS_ENV=test bundle exec rake test:all_the_things 2>&1 | grep -v gems | grep deprecated
```

More info about these deprecations and the next ruby version 3.0 here:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/



![Screenshot 2020-11-05 at 11 21 20](https://user-images.githubusercontent.com/136777/98234908-09afd200-1f59-11eb-9f7f-f0d5bf45dc2d.png)
