### PR TITLE
Design System smoke tests

### DIFF
--- a/app/lib/markup_normaliser.rb
+++ b/app/lib/markup_normaliser.rb
@@ -1,0 +1,35 @@
+class MarkupNormaliser
+  attr_reader :markup1, :markup2
+
+  def initialize(markup1, markup2)
+    @markup1 = markup1
+    @markup2 = markup2
+
+    normalise!
+  end
+
+  private
+
+  def normalise!
+    @markup1 = remove_blank_children(
+      Nokogiri::HTML.fragment(markup1)
+    ).to_html
+
+    @markup2 = remove_blank_children(
+      Nokogiri::HTML.fragment(markup2)
+    ).to_html
+  end
+
+  def remove_blank_children(element)
+    element.children.each do |child|
+      if child.children.any?
+        remove_blank_children(child)
+      elsif child.blank?
+        # Remove empty elements, like `#(Text "\n  ")`
+        child.remove
+      end
+    end
+
+    element
+  end
+end

--- a/features/fixtures/README.md
+++ b/features/fixtures/README.md
@@ -1,0 +1,21 @@
+# Markup fixtures
+
+This directory contains HTML fixtures to be used in [markup_smoke_tests.feature](/features/markup_smoke_tests.feature)
+
+The idea is to have a sample of a few representative pages in the service containing form elements that are built using
+the gem [govuk_design_system_formbuilder](https://github.com/DFE-Digital/govuk_design_system_formbuilder) so we are more
+confident when upgrading to new versions of the gem and we can detect regressions and bugs in the markup, that otherwise
+would be difficult to catch.
+
+These pages should be a mixture of simple text inputs, radios, checkboxes and some more elaborated form elements.
+
+To add more fixtures, first render the page in a browser, as a user would see it.  
+Then, inspect the HTML markup of the page and look inside the `<form>` tag for one or more `<div class="govuk-form-group">...</div>`
+and paste that exact markup (including the div containers) into a new fixture file.  
+If there are more than one `<div>` copy all of them one after another as they appear in the page.
+
+Then edit the cucumber scenario to add a new path and corresponding fixture. Make sure the test passes, and if not, check
+the fixture for any **unnecessary break lines**, in particular in the **localised copy**.
+
+Repeat these steps, but generating a validation error on the page, so you can create a fixture of the markup containing errors.
+Not all pages produce errors so choose the ones that do.

--- a/features/fixtures/files/steps_check_kind.html
+++ b/features/fixtures/files/steps_check_kind.html
@@ -1,0 +1,19 @@
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading">Were you cautioned or convicted?</h1>
+    </legend>
+    <div class="govuk-radios" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input id="steps-check-kind-form-kind-caution-field" aria-describedby="steps-check-kind-form-kind-caution-hint" class="govuk-radios__input" type="radio" value="caution" name="steps_check_kind_form[kind]">
+        <label for="steps-check-kind-form-kind-caution-field" class="govuk-label govuk-radios__label">Cautioned</label>
+        <span class="govuk-hint govuk-radios__hint" id="steps-check-kind-form-kind-caution-hint">You were given an official warning by the police</span>
+      </div>
+      <div class="govuk-radios__item">
+        <input id="steps-check-kind-form-kind-conviction-field" aria-describedby="steps-check-kind-form-kind-conviction-hint" class="govuk-radios__input" type="radio" value="conviction" name="steps_check_kind_form[kind]">
+        <label for="steps-check-kind-form-kind-conviction-field" class="govuk-label govuk-radios__label">Convicted</label>
+        <span class="govuk-hint govuk-radios__hint" id="steps-check-kind-form-kind-conviction-hint">You were found guilty of a crime in court</span>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/steps_check_kind_with_errors.html
+++ b/features/fixtures/files/steps_check_kind_with_errors.html
@@ -1,0 +1,21 @@
+<div class="govuk-form-group govuk-form-group--error">
+  <fieldset class="govuk-fieldset" aria-describedby="steps-check-kind-form-kind-error">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading">Were you cautioned or convicted?</h1>
+    </legend>
+    <span class="govuk-error-message" id="steps-check-kind-form-kind-error">
+      <span class="govuk-visually-hidden">Error: </span>Select caution or conviction</span>
+      <div class="govuk-radios" data-module="govuk-radios">
+        <div class="govuk-radios__item">
+          <input id="steps-check-kind-form-kind-field-error" aria-describedby="steps-check-kind-form-kind-caution-hint" class="govuk-radios__input" type="radio" value="caution" name="steps_check_kind_form[kind]">
+          <label for="steps-check-kind-form-kind-field-error" class="govuk-label govuk-radios__label">Cautioned</label>
+          <span class="govuk-hint govuk-radios__hint" id="steps-check-kind-form-kind-caution-hint">You were given an official warning by the police</span>
+        </div>
+      <div class="govuk-radios__item">
+        <input id="steps-check-kind-form-kind-conviction-field" aria-describedby="steps-check-kind-form-kind-conviction-hint" class="govuk-radios__input" type="radio" value="conviction" name="steps_check_kind_form[kind]">
+        <label for="steps-check-kind-form-kind-conviction-field" class="govuk-label govuk-radios__label">Convicted</label>
+        <span class="govuk-hint govuk-radios__hint" id="steps-check-kind-form-kind-conviction-hint">You were found guilty of a crime in court</span>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/steps_conviction_known_date.html
+++ b/features/fixtures/files/steps_conviction_known_date.html
@@ -1,0 +1,45 @@
+<div class="govuk-form-group app-util--compact-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
+    </legend>
+
+    <span class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">This is usually the day you were convicted in court. If you do not know the exact date, you can enter an approximate one.
+<span class="nowrap">For example, 23 9 2018</span></span>
+
+    <div class="govuk-date-input">
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_3i">Day</label>
+          <input id="steps_conviction_known_date_form_known_date_3i" class="govuk-input govuk-date-input__input govuk-input--width-2" name="steps_conviction_known_date_form[known_date(3i)]" type="text" pattern="[0-9]*" inputmode="numeric">
+        </div>
+      </div>
+
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_2i">Month</label>
+          <input id="steps_conviction_known_date_form_known_date_2i" class="govuk-input govuk-date-input__input govuk-input--width-2" name="steps_conviction_known_date_form[known_date(2i)]" type="text" pattern="[0-9]*" inputmode="numeric">
+        </div>
+      </div>
+
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_1i">Year</label>
+          <input id="steps_conviction_known_date_form_known_date_1i" class="govuk-input govuk-date-input__input govuk-input--width-4" name="steps_conviction_known_date_form[known_date(1i)]" type="text" pattern="[0-9]*" inputmode="numeric">
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>
+
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-visually-hidden">Approximate date</legend>
+    <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+      <div class="govuk-checkboxes__item">
+        <input id="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-checkboxes__input" type="checkbox" value="true" name="steps_conviction_known_date_form[approximate_known_date]">
+        <label for="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-label govuk-checkboxes__label">This is not the exact date</label>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/features/fixtures/files/steps_conviction_known_date_with_errors.html
+++ b/features/fixtures/files/steps_conviction_known_date_with_errors.html
@@ -1,0 +1,38 @@
+<div class="govuk-form-group govuk-form-group--error app-util--compact-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-error steps-conviction-known-date-form-known-date-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
+    </legend>
+    <span class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">This is usually the day you were convicted in court. If you do not know the exact date, you can enter an approximate one.
+<span class="nowrap">For example, 23 9 2018</span></span>
+
+<span class="govuk-error-message" id="steps-conviction-known-date-form-known-date-error">
+  <span class="govuk-visually-hidden">Error: </span>Enter the date of the conviction in the format dd/mm/yyyy</span>
+  <div class="govuk-date-input">
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="steps-conviction-known-date-form-known-date-field-error">Day</label>
+        <input id="steps-conviction-known-date-form-known-date-field-error" class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" name="steps_conviction_known_date_form[known_date(3i)]" type="text" pattern="[0-9]*" inputmode="numeric">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_2i">Month</label>
+        <input id="steps_conviction_known_date_form_known_date_2i" class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" name="steps_conviction_known_date_form[known_date(2i)]" type="text" pattern="[0-9]*" inputmode="numeric">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_1i">Year</label>
+        <input id="steps_conviction_known_date_form_known_date_1i" class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--error" name="steps_conviction_known_date_form[known_date(1i)]" type="text" pattern="[0-9]*" inputmode="numeric">
+      </div>
+    </div>
+  </div>
+</fieldset>
+</div>
+
+<div class="govuk-form-group"><fieldset class="govuk-fieldset"><legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-visually-hidden">Approximate date</legend><div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+  <div class="govuk-checkboxes__item"><input id="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-checkboxes__input" type="checkbox" value="true" name="steps_conviction_known_date_form[approximate_known_date]"><label for="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-label govuk-checkboxes__label">This is not the exact date</label></div>
+</div></fieldset></div>

--- a/features/markup_smoke_tests.feature
+++ b/features/markup_smoke_tests.feature
@@ -1,15 +1,13 @@
 Feature: High level form markup smoke tests
-  Background:
+  Scenario: Radio button form markup should be correct
     Given I have started an application
+    When I visit "steps/check/kind"
 
-  Scenario Outline: Form markup should be correct
-    When I visit "<step_path>"
+    Then The form markup should match "steps_check_kind"
+    Then The form markup with errors should match "steps_check_kind_with_errors"
 
-    Then The form markup should match "<fixture_file>"
-    Then The form markup with errors should match "<error_fixture_file>"
+  Scenario: Date form markup should be correct
+    When I am in the conviction known date step
 
-    Examples:
-      | step_path        | fixture_file     | error_fixture_file           |
-      | steps/check/kind | steps_check_kind | steps_check_kind_with_errors |
-
-  # cover date , checkbox and radio button forms
+    Then The form markup should match "steps_conviction_known_date"
+    Then The form markup with errors should match "steps_conviction_known_date_with_errors"

--- a/features/markup_smoke_tests.feature
+++ b/features/markup_smoke_tests.feature
@@ -1,0 +1,15 @@
+Feature: High level form markup smoke tests
+  Background:
+    Given I have started an application
+
+  Scenario Outline: Form markup should be correct
+    When I visit "<step_path>"
+
+    Then The form markup should match "<fixture_file>"
+    Then The form markup with errors should match "<error_fixture_file>"
+
+    Examples:
+      | step_path        | fixture_file     | error_fixture_file           |
+      | steps/check/kind | steps_check_kind | steps_check_kind_with_errors |
+
+  # cover date , checkbox and radio button forms

--- a/features/markup_smoke_tests.feature
+++ b/features/markup_smoke_tests.feature
@@ -1,6 +1,6 @@
 Feature: High level form markup smoke tests
   Scenario: Radio button form markup should be correct
-    Given I have started an application
+    Given I have started a check
     When I visit "steps/check/kind"
 
     Then The form markup should match "steps_check_kind"

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -50,8 +50,7 @@ And(/^I choose "([^"]*)" and fill in "([^"]*)" with "([^"]*)"$/) do |text, field
 end
 
 When(/^I am completing a basic under 18 "([^"]*)" conviction$/) do |value|
-  step %[I visit "/"]
-  step %[I click the "Start now" link]
+  step %[I have started a check]
   step %[I should see "Were you cautioned or convicted?"]
   step %[I choose "Convicted"]
   step %[I should see "How old were you when you got convicted?"]
@@ -61,8 +60,7 @@ When(/^I am completing a basic under 18 "([^"]*)" conviction$/) do |value|
 end
 
 When(/^I am completing a basic 18 or over "([^"]*)" conviction$/) do |value|
-  step %[I visit "/"]
-  step %[I click the "Start now" link]
+  step %[I have started a check]
   step %[I should see "Were you cautioned or convicted?"]
   step %[I choose "Convicted"]
   step %[I should see "How old were you when you got convicted?"]
@@ -89,7 +87,12 @@ When(/^The current date is (\d+)\-(\d+)\-(\d+)$/) do |day, month, year|
   travel_to Date.new(year, month, day)
 end
 
-When(/^I have started an application$/) do
+When(/^I have started a check$/) do
   step %[I visit "/"]
   step %[I click the "Start now" link]
+end
+
+When(/^I am in the conviction known date step$/) do
+  step %[I am completing a basic under 18 "Discharge" conviction]
+  step %[I choose "Bind over"]
 end

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -88,3 +88,8 @@ end
 When(/^The current date is (\d+)\-(\d+)\-(\d+)$/) do |day, month, year|
   travel_to Date.new(year, month, day)
 end
+
+When(/^I have started an application$/) do
+  step %[I visit "/"]
+  step %[I click the "Start now" link]
+end

--- a/features/step_definitions/fixturers.rb
+++ b/features/step_definitions/fixturers.rb
@@ -1,0 +1,25 @@
+Then(/^The form markup should match "([^"]*)"$/) do |fixture|
+  raw_markup = page.all(
+    :css, 'form > div.govuk-form-group'
+  ).map { |div| div['outerHTML'] }.join
+
+  raw_fixture = Pathname.new(
+    File.join('features', 'fixtures', 'files', "#{fixture}.html")
+  ).read
+
+  normaliser = MarkupNormaliser.new(raw_markup, raw_fixture)
+
+  expect(
+    normaliser.markup1
+  ).to eq(
+    normaliser.markup2
+  )
+end
+
+Then(/^The form markup with errors should match "([^"]*)"$/) do |fixture|
+  # Click continue without filling anything, to trigger validation errors
+  step %[I click the "Continue" button]
+
+  # Now check the markup with errors using the above step
+  step %[The form markup should match "#{fixture}"]
+end


### PR DESCRIPTION
During an upgrade to the Design System on C100 it was noticed that the forms were not working properly with hints on check boxes (https://github.com/DFE-Digital/govuk_design_system_formbuilder/pull/211).

We decided to introduce the same mechanism used on C100 in Disclosure Checker.

Story: https://mojdigital.teamwork.com/#/tasks/22441209