### PR TITLE
Show no length option in `serious crime prevention` orders

### DIFF
--- a/app/services/conviction_length_choices.rb
+++ b/app/services/conviction_length_choices.rb
@@ -5,7 +5,6 @@ class ConvictionLengthChoices
     ConvictionType::ADULT_PRISON_SENTENCE,
     ConvictionType::ADULT_SUSPENDED_PRISON_SENTENCE,
     ConvictionType::ADULT_ATTENDANCE_CENTRE_ORDER,
-    ConvictionType::ADULT_SERIOUS_CRIME_PREVENTION,
   ].freeze
 
   def self.choices(conviction_subtype:)

--- a/spec/services/conviction_length_choices_spec.rb
+++ b/spec/services/conviction_length_choices_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe ConvictionLengthChoices do
         ConvictionType::ADULT_PRISON_SENTENCE,
         ConvictionType::ADULT_SUSPENDED_PRISON_SENTENCE,
         ConvictionType::ADULT_ATTENDANCE_CENTRE_ORDER,
-        ConvictionType::ADULT_SERIOUS_CRIME_PREVENTION,
       ])
     }
   end
@@ -44,7 +43,7 @@ RSpec.describe ConvictionLengthChoices do
       ConvictionType.values.size - described_class::SUBTYPES_HIDE_NO_LENGTH_CHOICE.size
     }
 
-    it { expect(total).to eq(52) }
+    it { expect(total).to eq(53) }
   end
 
   describe '.choices' do


### PR DESCRIPTION
This was noticed as part of a related ticket:
https://trello.com/c/MrEm9UKp

According to the matrix of convictions that should show/hide the "no length was given" radio option, `serious crime prevention orders` should show the option.
It was hidden before.

<img width="1287" alt="Screenshot 2021-01-13 at 12 53 05" src="https://user-images.githubusercontent.com/687910/104455623-7bcb1580-559f-11eb-85f7-8c7e966de8c0.png">
