### PR TITLE
Fix BaseMultiplesCalculator to consider spent_simple

### DIFF
--- a/app/services/base_multiples_calculator.rb
+++ b/app/services/base_multiples_calculator.rb
@@ -12,6 +12,7 @@ class BaseMultiplesCalculator
   def spent?
     return false if spent_date == :never_spent
     return true  if spent_date == :no_record
+    return true  if spent_date == :spent_simple
 
     spent_date.past?
   end

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
       end
     end
 
+    context 'when there is an offence with `spent_simple`' do
+      let(:spent_dates) { [Date.yesterday, :spent_simple] }
+
+      it 'considers the spent_simple as spent' do
+        expect(subject.all_spent?).to eq(true)
+      end
+    end
+
     context 'when there is an offence with `no_record`' do
       let(:spent_dates) { [:no_record, Date.tomorrow] }
 


### PR DESCRIPTION
Back in pull request [#364](https://github.com/ministryofjustice/disclosure-checker/pull/364) the simple caution was simplified and the date question was skipped.

While this is currently working, this work is necessary in preparation for multiple convictions.

This fixes the following error:

```
NoMethodError:
       undefined method `past?' for :spent_simple:Symbol
```

When a user has a simple caution, that caution is spent on the day it was given, therefore the return value is true.

Story: https://trello.com/c/Gbnpo8Hu