### PR TITLE
Add an "indefinite" length option to relevant orders

### DIFF
--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -42,7 +42,8 @@ class ResultsPresenter
               expiry_date
             end
 
-    # The tense can be one of these values: spent, not_spent, never_spent or no_record
+    # The tense can be one of these values:
+    #   spent, not_spent, never_spent, indefinite, or no_record
     [disclosure_check.kind, tense].join('_')
   end
 

--- a/app/services/base_calculator.rb
+++ b/app/services/base_calculator.rb
@@ -13,6 +13,10 @@ class BaseCalculator
 
   private
 
+  def indefinite_length?
+    ConvictionLengthType.new(disclosure_check.conviction_length_type.to_s).inquiry.indefinite?
+  end
+
   def conviction_length
     { disclosure_check.conviction_length_type.to_sym => disclosure_check.conviction_length }
   end

--- a/app/services/calculators/addition_calculator.rb
+++ b/app/services/calculators/addition_calculator.rb
@@ -54,9 +54,13 @@ module Calculators
     end
 
     def expiry_date
-      return conviction_end_date.advance(added_time) if disclosure_check.conviction_length?
+      return :indefinite if indefinite_length?
 
-      conviction_start_date.advance(ADDED_TIME_IF_NO_LENGTH)
+      if disclosure_check.conviction_length?
+        conviction_end_date.advance(added_time)
+      else
+        conviction_start_date.advance(ADDED_TIME_IF_NO_LENGTH)
+      end
     end
   end
 end

--- a/app/services/calculators/multiples/same_proceedings.rb
+++ b/app/services/calculators/multiples/same_proceedings.rb
@@ -2,6 +2,7 @@
 #
 #   - Calculation changes for prison sentences (consecutive or concurrent).
 #   - What to do with `no_record` (at the moment we ignore them).
+#   - What to do with `indefinite` (at the moment we ignore them).
 #
 module Calculators
   module Multiples
@@ -22,7 +23,7 @@ module Calculators
       end
 
       def excluded_dates
-        [:no_record].freeze
+        [:no_record, :indefinite].freeze
       end
     end
   end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -64,7 +64,7 @@ class ConvictionDecisionTree < BaseDecisionTree
   end
 
   def after_conviction_length_type
-    return results if step_value(:conviction_length_type).inquiry.no_length?
+    return results if ConvictionLengthType.new(step_value(:conviction_length_type)).without_length?
 
     edit(:conviction_length)
   end

--- a/app/services/conviction_length_choices.rb
+++ b/app/services/conviction_length_choices.rb
@@ -8,10 +8,14 @@ class ConvictionLengthChoices
   ].freeze
 
   def self.choices(conviction_subtype:)
-    if SUBTYPES_HIDE_NO_LENGTH_CHOICE.include?(conviction_subtype)
-      ConvictionLengthType.values - [ConvictionLengthType::NO_LENGTH]
-    else
-      ConvictionLengthType.values
-    end
+    choices = ConvictionLengthType.values.dup
+
+    # Big majority of orders show the `no_length` option, just a few exceptions
+    choices.delete(ConvictionLengthType::NO_LENGTH) if SUBTYPES_HIDE_NO_LENGTH_CHOICE.include?(conviction_subtype)
+
+    # Only `relevant orders` will show the `indefinite` length option
+    choices.delete(ConvictionLengthType::INDEFINITE) unless conviction_subtype.relevant_order?
+
+    choices
   end
 end

--- a/app/value_objects/conviction_length_type.rb
+++ b/app/value_objects/conviction_length_type.rb
@@ -4,7 +4,12 @@ class ConvictionLengthType < ValueObject
     MONTHS = new(:months),
     YEARS = new(:years),
     NO_LENGTH = new(:no_length),
+    INDEFINITE = new(:indefinite),
   ].freeze
+
+  def without_length?
+    [NO_LENGTH, INDEFINITE].include?(self)
+  end
 
   def self.values
     VALUES

--- a/app/views/steps/check/results/show.en.html+conviction_indefinite.erb
+++ b/app/views/steps/check/results/show.en.html+conviction_indefinite.erb
@@ -1,0 +1,32 @@
+<% title t('.page_title') %>
+<% track_transaction name: 'Conviction check completed', category: 'Completed checks', dimensions: { spent: 'indefinite' } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        This conviction is not spent
+      </h1>
+      <div class="govuk-panel__body">
+        This conviction will stay in place until another order is made to change or end it.
+      </div>
+    </div>
+
+    <p class="govuk-body">
+      The conviction will appear on every type of
+      <a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#background-checks">criminal
+        record check</a>.
+    </p>
+
+    <%= render partial: 'steps/check/results/shared/meaning' %>
+
+    <%= render partial: 'steps/check/results/shared/motoring' if @presenter.conviction_type.motoring? %>
+
+    <%= render partial: 'steps/check/results/shared/summary', locals: { result: @presenter } %>
+
+    <%= render partial: 'steps/check/results/shared/disclaimer' %>
+
+    <%= render partial: 'steps/check/results/shared/feedback' %>
+  </div>
+</div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -291,6 +291,7 @@ en:
           months: Months
           years: Years
           no_length: No length was given
+          indefinite: Until further order
       steps_conviction_conviction_length_form:
         weeks: Number of weeks
         months: Number of months

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -145,6 +145,7 @@ en:
         months: '%{length} months'
         years: '%{length} years'
         no_length: No length was given
+        indefinite: Until further order
     compensation_payment_date:
       question: Compensation payment date
     motoring_endorsement:

--- a/features/adults/conviction_custodial_sentence.feature
+++ b/features/adults/conviction_custodial_sentence.feature
@@ -53,3 +53,24 @@ Feature: Conviction
     Examples:
       | subtype        | known_date_header              | length_type_header                                           | length_header                     | result               |
       | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? | /steps/check/results |
+
+  @happy_path @date_travel
+  Scenario Outline: Hospital orders (with no length or indefinite length)
+    Given The current date is 15-12-2020
+    When I am completing a basic 18 or over "Custody or hospital order" conviction
+
+    Then I should see "What sentence were you given?"
+
+    When I choose "<subtype>"
+    Then I should see "<known_date_header>"
+
+    And I enter the following date 01-01-2020
+    Then I should see "<length_type_header>"
+
+    When I choose "<length_type>"
+    Then I should see "<result>"
+
+    Examples:
+      | subtype        | known_date_header              | length_type_header                                           | length_type         | result                                                                             |
+      | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | No length was given | This conviction will be spent on 1 January 2022                                    |
+      | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | Until further order | This conviction will stay in place until another order is made to change or end it |

--- a/features/youth/conviction_custodial_sentence.feature
+++ b/features/youth/conviction_custodial_sentence.feature
@@ -53,3 +53,24 @@ Feature: Conviction
     Examples:
       | subtype        | known_date_header              | length_type_header                                           | length_header                     | result               |
       | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? | /steps/check/results |
+
+  @happy_path @date_travel
+  Scenario Outline: Hospital orders (with no length or indefinite length)
+    Given The current date is 15-12-2020
+    When I am completing a basic under 18 "Custody or hospital order" conviction
+
+    Then I should see "What sentence were you given?"
+
+    When I choose "<subtype>"
+    Then I should see "<known_date_header>"
+
+    And I enter the following date 01-01-2020
+    Then I should see "<length_type_header>"
+
+    When I choose "<length_type>"
+    Then I should see "<result>"
+
+    Examples:
+      | subtype        | known_date_header              | length_type_header                                           | length_type         | result                                                                             |
+      | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | No length was given | This conviction will be spent on 1 January 2022                                    |
+      | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | Until further order | This conviction will stay in place until another order is made to change or end it |

--- a/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
@@ -39,6 +39,26 @@ RSpec.describe Steps::Conviction::ConvictionLengthTypeForm do
         )
       end
     end
+
+    context 'for a `Youth referral order`' do
+      let(:conviction_subtype) { ConvictionType::REFERRAL_ORDER.to_s }
+
+      it 'includes `no_length` and `indefinite` in the values' do
+        expect(ConvictionLengthChoices).to receive(:choices).with(
+          conviction_subtype: ConvictionType::REFERRAL_ORDER
+        ).and_call_original
+
+        expect(subject.values).to eq(
+          [
+            ConvictionLengthType.new(:weeks),
+            ConvictionLengthType.new(:months),
+            ConvictionLengthType.new(:years),
+            ConvictionLengthType.new(:no_length),
+            ConvictionLengthType.new(:indefinite),
+          ]
+        )
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe ConvictionResultPresenter do
       it { expect(subject.variant).to eq('conviction_never_spent') }
     end
 
+    context 'indefinite length conviction' do
+      let(:expiry_date) { :indefinite }
+      it { expect(subject.variant).to eq('conviction_indefinite') }
+    end
+
     context 'no record (motoring-specific)' do
       let(:expiry_date) { :no_record }
       it { expect(subject.variant).to eq('conviction_no_record') }

--- a/spec/services/calculators/addition_calculator_spec.rb
+++ b/spec/services/calculators/addition_calculator_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Calculators::AdditionCalculator do
         it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
       end
 
+      context 'with an indefinite conviction length' do
+        let(:conviction_length_type) { 'indefinite' }
+        it { expect(subject.expiry_date).to eq(:indefinite) }
+      end
+
       context 'with a conviction length' do
         let(:conviction_length) { 5 }
         let(:conviction_length_type) { 'years' }
@@ -34,6 +39,11 @@ RSpec.describe Calculators::AdditionCalculator do
         it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
       end
 
+      context 'with an indefinite conviction length' do
+        let(:conviction_length_type) { 'indefinite' }
+        it { expect(subject.expiry_date).to eq(:indefinite) }
+      end
+
       context 'with a conviction length' do
         let(:conviction_length) { 5 }
         let(:conviction_length_type) { 'years' }
@@ -47,6 +57,11 @@ RSpec.describe Calculators::AdditionCalculator do
     context '#expiry_date' do
       context 'without a conviction length' do
         it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
+      end
+
+      context 'with an indefinite conviction length' do
+        let(:conviction_length_type) { 'indefinite' }
+        it { expect(subject.expiry_date).to eq(:indefinite) }
       end
 
       context 'with a conviction length' do

--- a/spec/services/calculators/multiples/same_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/same_proceedings_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Calculators::Multiples::SameProceedings do
 
   let(:check_never_spent) { instance_double(CheckResult, expiry_date: :never_spent) }
   let(:check_no_record) { instance_double(CheckResult, expiry_date: :no_record) }
+  let(:check_indefinite) { instance_double(CheckResult, expiry_date: :indefinite) }
 
   describe '#kind' do
     it 'is always conviction for same proceedings' do
@@ -39,6 +40,16 @@ RSpec.describe Calculators::Multiples::SameProceedings do
       end
 
       it 'picks the latest date' do
+        expect(subject.spent_date).to eq(Date.new(2018, 10, 31))
+      end
+    end
+
+    context 'when there is at least one `indefinite` date' do
+      before do
+        allow(CheckResult).to receive(:new).and_return(check_result1, check_result2, check_indefinite)
+      end
+
+      it 'ignores the conviction with `indefinite` and picks the latest date' do
         expect(subject.spent_date).to eq(Date.new(2018, 10, 31))
       end
     end

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -119,6 +119,11 @@ RSpec.describe ConvictionDecisionTree do
       it { is_expected.to complete_the_check_and_show_results }
     end
 
+    context 'and the answer is `indefinite`' do
+      let(:conviction_length_type) { ConvictionLengthType::INDEFINITE.to_s }
+      it { is_expected.to complete_the_check_and_show_results }
+    end
+
     context 'and the answer is other than `no_length`' do
       let(:conviction_length_type) { ConvictionLengthType::MONTHS.to_s }
       it { is_expected.to have_destination(:conviction_length, :edit) }

--- a/spec/services/conviction_length_choices_spec.rb
+++ b/spec/services/conviction_length_choices_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ConvictionLengthChoices do
       ConvictionLengthType::MONTHS,
       ConvictionLengthType::YEARS,
       ConvictionLengthType::NO_LENGTH,
+      ConvictionLengthType::INDEFINITE,
     ]
   }
 
@@ -50,7 +51,7 @@ RSpec.describe ConvictionLengthChoices do
     context 'youth custodial sentence detention' do
       let(:conviction_subtype) { ConvictionType::DETENTION }
 
-      it 'excludes `no_length` in the choices' do
+      it 'excludes `no_length` and `indefinite` in the choices' do
         expect(subject).to eq(all_choices_except_no_length)
       end
     end
@@ -58,7 +59,7 @@ RSpec.describe ConvictionLengthChoices do
     context 'youth custodial sentence detention training order' do
       let(:conviction_subtype) { ConvictionType::DETENTION_TRAINING_ORDER }
 
-      it 'excludes `no_length` in the choices' do
+      it 'excludes `no_length` and `indefinite` in the choices' do
         expect(subject).to eq(all_choices_except_no_length)
       end
     end
@@ -66,7 +67,7 @@ RSpec.describe ConvictionLengthChoices do
     context 'adult custodial prison sentence' do
       let(:conviction_subtype) { ConvictionType::ADULT_PRISON_SENTENCE }
 
-      it 'excludes `no_length` in the choices' do
+      it 'excludes `no_length` and `indefinite` in the choices' do
         expect(subject).to eq(all_choices_except_no_length)
       end
     end
@@ -74,7 +75,7 @@ RSpec.describe ConvictionLengthChoices do
     context 'adult custodial suspended prison sentence' do
       let(:conviction_subtype) { ConvictionType::ADULT_SUSPENDED_PRISON_SENTENCE }
 
-      it 'excludes `no_length` in the choices' do
+      it 'excludes `no_length` and `indefinite` in the choices' do
         expect(subject).to eq(all_choices_except_no_length)
       end
     end
@@ -84,7 +85,7 @@ RSpec.describe ConvictionLengthChoices do
     context 'youth prevention and reparation orders' do
       let(:conviction_subtype) { ConvictionType::SEXUAL_HARM_PREVENTION_ORDER }
 
-      it 'includes `no_length` in the choices' do
+      it 'includes `no_length` and `indefinite` in the choices' do
         expect(subject).to eq(all_choices)
       end
     end
@@ -92,7 +93,7 @@ RSpec.describe ConvictionLengthChoices do
     context 'bind over convictions' do
       let(:conviction_subtype) { ConvictionType::BIND_OVER }
 
-      it 'includes `no_length` in the choices' do
+      it 'includes `no_length` and `indefinite` in the choices' do
         expect(subject).to eq(all_choices)
       end
     end
@@ -100,7 +101,7 @@ RSpec.describe ConvictionLengthChoices do
     context 'adult bind over convictions' do
       let(:conviction_subtype) { ConvictionType::ADULT_BIND_OVER }
 
-      it 'includes `no_length` in the choices' do
+      it 'includes `no_length` and `indefinite` in the choices' do
         expect(subject).to eq(all_choices)
       end
     end

--- a/spec/value_objects/conviction_length_type_spec.rb
+++ b/spec/value_objects/conviction_length_type_spec.rb
@@ -1,6 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe ConvictionLengthType do
+  describe '#without_length?' do
+    subject { described_class.new(value).without_length? }
+
+    context 'weeks' do
+      let(:value) { :weeks }
+      it { expect(subject).to eq(false) }
+    end
+
+    context 'months' do
+      let(:value) { :months }
+      it { expect(subject).to eq(false) }
+    end
+
+    context 'years' do
+      let(:value) { :years }
+      it { expect(subject).to eq(false) }
+    end
+
+    context 'no_length' do
+      let(:value) { :no_length }
+      it { expect(subject).to eq(true) }
+    end
+
+    context 'indefinite' do
+      let(:value) { :indefinite }
+      it { expect(subject).to eq(true) }
+    end
+  end
+
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(%w(
@@ -8,6 +37,7 @@ RSpec.describe ConvictionLengthType do
         months
         years
         no_length
+        indefinite
       ))
     end
   end


### PR DESCRIPTION
Ticket: https://trello.com/c/MrEm9UKp

Individual commits for more detail.

Relevant orders need to expose a new "length" option apart from the existing ones. In total now there are up to 5 different options: weeks, months, years, no length, indefinite (until further order).

If the conviction has an indefinite length, then a different results page, specific for indefinite is shown to the user.

**Note**: 18 out of 20 relevant orders now have the ability of selecting indefinite option. We still have 2 more that requires it but will be done as part of a separate ticket as will require design and probably a new question to ask. These are motoring disqualifications (youths and adults).

<img width="637" alt="Screenshot 2021-01-18 at 12 27 02" src="https://user-images.githubusercontent.com/687910/104915411-8105d700-5988-11eb-8af6-f4d5b2e77eff.png">
