### PR TITLE
Delete some old code no longer needed for `no_record`

### DIFF
--- a/app/services/base_multiples_calculator.rb
+++ b/app/services/base_multiples_calculator.rb
@@ -11,7 +11,7 @@ class BaseMultiplesCalculator
 
   def spent?
     return false if spent_date == :never_spent
-    return true  if spent_date == :no_record
+    return false if spent_date == :indefinite
     return true  if spent_date == :spent_simple
 
     spent_date.past?

--- a/app/services/calculators/multiples/same_proceedings.rb
+++ b/app/services/calculators/multiples/same_proceedings.rb
@@ -1,7 +1,6 @@
 # TODO: pending things to code or clarify
 #
 #   - Calculation changes for prison sentences (consecutive or concurrent).
-#   - What to do with `no_record` (at the moment we ignore them).
 #   - What to do with `indefinite` (at the moment we ignore them).
 #
 module Calculators
@@ -23,7 +22,7 @@ module Calculators
       end
 
       def excluded_dates
-        [:no_record, :indefinite].freeze
+        [:indefinite].freeze
       end
     end
   end

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -31,11 +31,6 @@ RSpec.describe ConvictionResultPresenter do
       let(:expiry_date) { :indefinite }
       it { expect(subject.variant).to eq('conviction_indefinite') }
     end
-
-    context 'no record (motoring-specific)' do
-      let(:expiry_date) { :no_record }
-      it { expect(subject.variant).to eq('conviction_no_record') }
-    end
   end
 
   describe '#summary' do

--- a/spec/presenters/spent_date_panel_spec.rb
+++ b/spec/presenters/spent_date_panel_spec.rb
@@ -23,11 +23,6 @@ RSpec.describe SpentDatePanel do
       let(:spent_date) { :never_spent }
       it { expect(subject.scope).to eq([partial_path, :never_spent]) }
     end
-
-    context 'when offense has no record' do
-      let(:spent_date) { :no_record }
-      it { expect(subject.scope).to eq([partial_path, :no_record]) }
-    end
   end
 
   describe '#date' do

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -64,10 +64,10 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
       end
     end
 
-    context 'when there is an offence with `no_record`' do
-      let(:spent_dates) { [:no_record, Date.tomorrow] }
+    context 'when there is an offence with `indefinite`' do
+      let(:spent_dates) { [:indefinite, Date.tomorrow] }
 
-      it 'considers the no_record as spent, and check the other dates' do
+      it 'excludes the `indefinite` offence, and check the other dates' do
         expect(subject.all_spent?).to eq(false)
       end
     end

--- a/spec/services/calculators/multiples/same_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/same_proceedings_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Calculators::Multiples::SameProceedings do
   let(:check_result3) { instance_double(CheckResult, expiry_date: Date.new(2016, 10, 31)) }
 
   let(:check_never_spent) { instance_double(CheckResult, expiry_date: :never_spent) }
-  let(:check_no_record) { instance_double(CheckResult, expiry_date: :no_record) }
   let(:check_indefinite) { instance_double(CheckResult, expiry_date: :indefinite) }
 
   describe '#kind' do
@@ -50,16 +49,6 @@ RSpec.describe Calculators::Multiples::SameProceedings do
       end
 
       it 'ignores the conviction with `indefinite` and picks the latest date' do
-        expect(subject.spent_date).to eq(Date.new(2018, 10, 31))
-      end
-    end
-
-    context 'when there is at least one `no_record` date' do
-      before do
-        allow(CheckResult).to receive(:new).and_return(check_result1, check_result2, check_no_record)
-      end
-
-      it 'ignores the conviction with `no_record` and picks the latest date' do
         expect(subject.spent_date).to eq(Date.new(2018, 10, 31))
       end
     end


### PR DESCRIPTION
We've removed FPN in PR #419, so we don't use anymore the special result `no_record`.
Some code can be cleaned up.

As part of a following PR I'm refactoring the different variants we have (never_spent, spent_simple, indefinite, etc) as it is becoming increasingly difficult to find all the places where we are using them and will be easier to work with a single value-object.