### PR TITLE
Refactor and DRY the different result variants

### DIFF
--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -37,13 +37,12 @@ class ResultsPresenter
 
   def variant
     tense = if expiry_date.instance_of?(Date)
-              expiry_date.past? ? :spent : :not_spent
+              expiry_date.past? ? ResultsVariant::SPENT : ResultsVariant::NOT_SPENT
             else
               expiry_date
             end
 
-    # The tense can be one of these values:
-    #   spent, not_spent, never_spent, indefinite, or no_record
+    # The tense can be any of the values defined in `ResultsVariant`
     [disclosure_check.kind, tense].join('_')
   end
 

--- a/app/presenters/spent_date_panel.rb
+++ b/app/presenters/spent_date_panel.rb
@@ -23,7 +23,7 @@ class SpentDatePanel
   # TODO: we use this or similar method in other places. Unify them.
   def tense
     if spent_date.instance_of?(Date)
-      spent_date.past? ? :spent : :not_spent
+      spent_date.past? ? ResultsVariant::SPENT : ResultsVariant::NOT_SPENT
     else
       spent_date
     end

--- a/app/services/base_multiples_calculator.rb
+++ b/app/services/base_multiples_calculator.rb
@@ -10,9 +10,9 @@ class BaseMultiplesCalculator
   end
 
   def spent?
-    return false if spent_date == :never_spent
-    return false if spent_date == :indefinite
-    return true  if spent_date == :spent_simple
+    return false if spent_date == ResultsVariant::NEVER_SPENT
+    return false if spent_date == ResultsVariant::INDEFINITE
+    return true  if spent_date == ResultsVariant::SPENT_SIMPLE
 
     spent_date.past?
   end

--- a/app/services/calculators/addition_calculator.rb
+++ b/app/services/calculators/addition_calculator.rb
@@ -54,7 +54,7 @@ module Calculators
     end
 
     def expiry_date
-      return :indefinite if indefinite_length?
+      return ResultsVariant::INDEFINITE if indefinite_length?
 
       if disclosure_check.conviction_length?
         conviction_end_date.advance(added_time)

--- a/app/services/calculators/caution_calculator.rb
+++ b/app/services/calculators/caution_calculator.rb
@@ -12,7 +12,7 @@ module Calculators
     CONDITIONAL_ADDED_TIME = { months: 3 }.freeze
 
     def expiry_date
-      return :spent_simple unless conditional?
+      return ResultsVariant::SPENT_SIMPLE unless conditional?
       return conditional_end_date if distance_in_months(caution_date, conditional_end_date) < 3
 
       caution_date.advance(CONDITIONAL_ADDED_TIME)

--- a/app/services/calculators/multiples/same_proceedings.rb
+++ b/app/services/calculators/multiples/same_proceedings.rb
@@ -1,13 +1,14 @@
 # TODO: pending things to code or clarify
 #
 #   - Calculation changes for prison sentences (consecutive or concurrent).
-#   - What to do with `indefinite` (at the moment we ignore them).
+#   - What to do with `indefinite` (at the moment we mark the whole conviction as indefinite).
 #
 module Calculators
   module Multiples
     class SameProceedings < BaseMultiplesCalculator
       def spent_date
-        return :never_spent if expiry_dates.include?(:never_spent)
+        return ResultsVariant::NEVER_SPENT if expiry_dates.include?(ResultsVariant::NEVER_SPENT)
+        return ResultsVariant::INDEFINITE  if expiry_dates.include?(ResultsVariant::INDEFINITE)
 
         # Pick the latest date in the collection
         expiry_dates.max
@@ -18,11 +19,7 @@ module Calculators
       def expiry_dates
         @_expiry_dates ||= disclosure_checks.map(
           &method(:expiry_date_for)
-        ) - excluded_dates
-      end
-
-      def excluded_dates
-        [:indefinite].freeze
+        )
       end
     end
   end

--- a/app/services/calculators/sentence_calculator.rb
+++ b/app/services/calculators/sentence_calculator.rb
@@ -55,7 +55,7 @@ module Calculators
       raise InvalidCalculation unless valid?
 
       if conviction_length_in_months > NEVER_SPENT_THRESHOLD
-        :never_spent
+        ResultsVariant::NEVER_SPENT
       else
         conviction_end_date.advance(rehabilitation_period).advance(bail_offset)
       end

--- a/app/value_objects/results_variant.rb
+++ b/app/value_objects/results_variant.rb
@@ -1,0 +1,13 @@
+class ResultsVariant < ValueObject
+  VALUES = [
+    SPENT        = new(:spent),
+    NOT_SPENT    = new(:not_spent),
+    NEVER_SPENT  = new(:never_spent),
+    SPENT_SIMPLE = new(:spent_simple),
+    INDEFINITE   = new(:indefinite),
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+end

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -93,6 +93,7 @@ en:
           page_title: When your caution or conviction is spent
 
   # Multiple cautions or convictions (feature-flagged, still WIP)
+  # Ensure all the values declared in `ResultsVariant` have their corresponding locale here.
   results/shared/spent_date_panel:
     spent:
       title_html: This %{kind} was spent on <span class="nowrap">%{date}</span>
@@ -100,6 +101,10 @@ en:
       title_html: This %{kind} will be spent on <span class="nowrap">%{date}</span>
     never_spent:
       title_html: This %{kind} will never be spent
+    spent_simple:
+      title_html: This %{kind} is spent on the day you receive it
+    indefinite:
+      title_html: This %{kind} is not spent and will stay in place until another order is made to change or end it
 
   results/shared/date_format:
     exact: '%{date}'

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe ConvictionResultPresenter do
     end
 
     context 'never spent conviction' do
-      let(:expiry_date) { :never_spent }
+      let(:expiry_date) { 'never_spent' }
       it { expect(subject.variant).to eq('conviction_never_spent') }
     end
 
     context 'indefinite length conviction' do
-      let(:expiry_date) { :indefinite }
+      let(:expiry_date) { 'indefinite' }
       it { expect(subject.variant).to eq('conviction_indefinite') }
     end
   end

--- a/spec/presenters/spent_date_panel_spec.rb
+++ b/spec/presenters/spent_date_panel_spec.rb
@@ -11,17 +11,17 @@ RSpec.describe SpentDatePanel do
   describe '#scope' do
     context 'for a past date' do
       let(:spent_date) { Date.yesterday }
-      it { expect(subject.scope).to eq([partial_path, :spent]) }
+      it { expect(subject.scope).to eq([partial_path, ResultsVariant::SPENT]) }
     end
 
     context 'for a future date' do
       let(:spent_date) { Date.tomorrow }
-      it { expect(subject.scope).to eq([partial_path, :not_spent]) }
+      it { expect(subject.scope).to eq([partial_path, ResultsVariant::NOT_SPENT]) }
     end
 
-    context 'when offense will never be spent' do
-      let(:spent_date) { :never_spent }
-      it { expect(subject.scope).to eq([partial_path, :never_spent]) }
+    context 'when `spent_date` is not a date, it just returns its value' do
+      let(:spent_date) { :foobar }
+      it { expect(subject.scope).to eq([partial_path, :foobar]) }
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe SpentDatePanel do
     end
 
     context 'it is not a date instance' do
-      let(:spent_date) { :never_spent }
+      let(:spent_date) { :foobar }
       it { expect(subject.date).to be_nil }
     end
   end

--- a/spec/services/calculators/addition_calculator_spec.rb
+++ b/spec/services/calculators/addition_calculator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Calculators::AdditionCalculator do
 
       context 'with an indefinite conviction length' do
         let(:conviction_length_type) { 'indefinite' }
-        it { expect(subject.expiry_date).to eq(:indefinite) }
+        it { expect(subject.expiry_date).to eq(ResultsVariant::INDEFINITE) }
       end
 
       context 'with a conviction length' do
@@ -41,7 +41,7 @@ RSpec.describe Calculators::AdditionCalculator do
 
       context 'with an indefinite conviction length' do
         let(:conviction_length_type) { 'indefinite' }
-        it { expect(subject.expiry_date).to eq(:indefinite) }
+        it { expect(subject.expiry_date).to eq(ResultsVariant::INDEFINITE) }
       end
 
       context 'with a conviction length' do
@@ -61,7 +61,7 @@ RSpec.describe Calculators::AdditionCalculator do
 
       context 'with an indefinite conviction length' do
         let(:conviction_length_type) { 'indefinite' }
-        it { expect(subject.expiry_date).to eq(:indefinite) }
+        it { expect(subject.expiry_date).to eq(ResultsVariant::INDEFINITE) }
       end
 
       context 'with a conviction length' do

--- a/spec/services/calculators/caution_calculator_spec.rb
+++ b/spec/services/calculators/caution_calculator_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Calculators::CautionCalculator do
       let(:known_date) { nil }
       let(:conditional_end_date) { nil }
 
-      it 'returns `:spent_simple` without doing any date calculations' do
+      it 'returns the `spent_simple` variant without doing any date calculations' do
         # This is because simple cautions are spent on the day they given.
-        expect(subject.expiry_date).to eq(:spent_simple)
+        expect(subject.expiry_date).to eq(ResultsVariant::SPENT_SIMPLE)
       end
     end
 

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
     end
 
     context 'when there is an offence that will never be spent' do
-      let(:spent_dates) { [:never_spent, Date.yesterday] }
+      let(:spent_dates) { [ResultsVariant::NEVER_SPENT, Date.yesterday] }
 
       it 'returns false' do
         expect(subject.all_spent?).to eq(false)
@@ -57,7 +57,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
     end
 
     context 'when there is an offence with `spent_simple`' do
-      let(:spent_dates) { [Date.yesterday, :spent_simple] }
+      let(:spent_dates) { [Date.yesterday, ResultsVariant::SPENT_SIMPLE] }
 
       it 'considers the spent_simple as spent' do
         expect(subject.all_spent?).to eq(true)
@@ -65,7 +65,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
     end
 
     context 'when there is an offence with `indefinite`' do
-      let(:spent_dates) { [:indefinite, Date.tomorrow] }
+      let(:spent_dates) { [ResultsVariant::INDEFINITE, Date.tomorrow] }
 
       it 'excludes the `indefinite` offence, and check the other dates' do
         expect(subject.all_spent?).to eq(false)

--- a/spec/services/calculators/multiples/same_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/same_proceedings_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Calculators::Multiples::SameProceedings do
   let(:check_result2) { instance_double(CheckResult, expiry_date: Date.new(2018, 10, 31)) }
   let(:check_result3) { instance_double(CheckResult, expiry_date: Date.new(2016, 10, 31)) }
 
-  let(:check_never_spent) { instance_double(CheckResult, expiry_date: :never_spent) }
-  let(:check_indefinite) { instance_double(CheckResult, expiry_date: :indefinite) }
+  let(:check_never_spent) { instance_double(CheckResult, expiry_date: ResultsVariant::NEVER_SPENT) }
+  let(:check_indefinite) { instance_double(CheckResult, expiry_date: ResultsVariant::INDEFINITE) }
 
   describe '#kind' do
     it 'is always conviction for same proceedings' do
@@ -29,7 +29,7 @@ RSpec.describe Calculators::Multiples::SameProceedings do
       end
 
       it 'returns `never_spent`' do
-        expect(subject.spent_date).to eq(:never_spent)
+        expect(subject.spent_date).to eq(ResultsVariant::NEVER_SPENT)
       end
     end
 
@@ -48,8 +48,8 @@ RSpec.describe Calculators::Multiples::SameProceedings do
         allow(CheckResult).to receive(:new).and_return(check_result1, check_result2, check_indefinite)
       end
 
-      it 'ignores the conviction with `indefinite` and picks the latest date' do
-        expect(subject.spent_date).to eq(Date.new(2018, 10, 31))
+      it 'returns `indefinite`' do
+        expect(subject.spent_date).to eq(ResultsVariant::INDEFINITE)
       end
     end
   end

--- a/spec/services/calculators/sentence_calculator_spec.rb
+++ b/spec/services/calculators/sentence_calculator_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Calculators::SentenceCalculator do
 
       context 'never spent for conviction length over 4 years' do
         let(:conviction_months) { 49 }
-        it { expect(subject.expiry_date).to eq(:never_spent) }
+        it { expect(subject.expiry_date).to eq(ResultsVariant::NEVER_SPENT) }
       end
 
       context 'there is no upper limit' do
@@ -82,7 +82,7 @@ RSpec.describe Calculators::SentenceCalculator do
 
       context 'never spent for conviction length over 4 years' do
         let(:conviction_months) { 49 }
-        it { expect(subject.expiry_date).to eq(:never_spent) }
+        it { expect(subject.expiry_date).to eq(ResultsVariant::NEVER_SPENT) }
       end
 
       context 'there is no upper limit' do

--- a/spec/value_objects/results_variant_spec.rb
+++ b/spec/value_objects/results_variant_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe ResultsVariant do
+  describe '.values' do
+    it 'returns all possible values' do
+      expect(described_class.values.map(&:to_s)).to eq(%w(
+        spent
+        not_spent
+        never_spent
+        spent_simple
+        indefinite
+      ))
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://trello.com/c/LS4gr8Uh

Over the last few months, we've had to add some "exceptions" to the rule and some cautions or convictions do not return just a date when they are spent, some returns special variants, like:

* never_spent
* spent_simple
* indefinite

We also had before `no_record` for FPN but this is no longer necessary as we've removed FPN from the service.

Unify in the `ResultsVariant` value-object all these possible result variants and always use them through the value-object so it is easy to either remove them, add more or change them in the future.