### PR TITLE
Implement "indefinite" length for motoring disqualifications

### DIFF
--- a/app/decorators/conviction_decorator.rb
+++ b/app/decorators/conviction_decorator.rb
@@ -18,11 +18,6 @@ module ConvictionDecorator
       ConvictionType::ADULT_MOTORING.eql?(self)
   end
 
-  def motoring_disqualification?
-    ConvictionType::YOUTH_DISQUALIFICATION.eql?(self) ||
-      ConvictionType::ADULT_DISQUALIFICATION.eql?(self)
-  end
-
   def motoring_penalty_points?
     ConvictionType::YOUTH_PENALTY_POINTS.eql?(self) ||
       ConvictionType::ADULT_PENALTY_POINTS.eql?(self)

--- a/app/services/calculators/disqualification_calculator.rb
+++ b/app/services/calculators/disqualification_calculator.rb
@@ -43,26 +43,31 @@ module Calculators
     end
 
     def expiry_date
-      return conviction_start_date.advance(no_length_rehabilitation) if motoring_disqualification_end_date.nil?
-      return conviction_start_date.advance(self.class::REHABILITATION_WITH_ENDORSEMENT) if motoring_endorsement? && within_endorsement_threshold?
+      return ResultsVariant::INDEFINITE if indefinite_length?
 
-      motoring_disqualification_end_date
+      if disclosure_check.conviction_length?
+        conviction_start_date.advance(rehabilitation_with_length)
+      else
+        conviction_start_date.advance(rehabilitation_without_length)
+      end
     end
 
     private
 
-    def no_length_rehabilitation
+    def rehabilitation_without_length
       return self.class::REHABILITATION_WITH_ENDORSEMENT if motoring_endorsement?
 
       self.class::REHABILITATION_WITHOUT_ENDORSEMENT
     end
 
-    def motoring_disqualification_end_date
-      disclosure_check.motoring_disqualification_end_date
+    def rehabilitation_with_length
+      return self.class::REHABILITATION_WITH_ENDORSEMENT if motoring_endorsement? && within_endorsement_threshold?
+
+      conviction_length
     end
 
     def within_endorsement_threshold?
-      distance_in_months(conviction_start_date, motoring_disqualification_end_date) <= self.class::ENDORSEMENT_THRESHOLD
+      conviction_length_in_months <= self.class::ENDORSEMENT_THRESHOLD
     end
   end
 end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -58,7 +58,6 @@ class ConvictionDecisionTree < BaseDecisionTree
 
   def after_known_date
     return results if conviction_subtype.skip_length?
-    return edit(:motoring_disqualification_end_date) if conviction_subtype.motoring_disqualification?
 
     edit(:conviction_length_type)
   end

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -51,6 +51,7 @@ en:
             adult_prison_sentence: What was the length of the sentence?
             adult_suspended_prison_sentence: What was the length of the sentence?
             adult_disqualification: What was the length of the disqualification?
+            youth_disqualification: What was the length of the disqualification?
           explanation:
             detention_html: *sentence_info_with_callout
             detention_training_order_html: *sentence_info

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -392,6 +392,7 @@ en:
         adult_suspended_prison_sentence: Was the length of the sentence given in weeks, months or years?
         adult_prison_sentence: Was the length of the sentence given in weeks, months or years?
         adult_disqualification: Was the length of the disqualification given in weeks, months or years?
+        youth_disqualification: Was the length of the disqualification given in weeks, months or years?
       steps_conviction_conviction_length_form:
         weeks: Number of weeks
         months: Number of months

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -151,5 +151,8 @@ en:
       question: Compensation payment date
     motoring_endorsement:
       question: Motoring endorsement
+      answers:
+        'yes': 'Yes'
+        'no': 'No'
     motoring_disqualification_end_date:
       question: End date

--- a/features/adults/conviction_motoring.feature
+++ b/features/adults/conviction_motoring.feature
@@ -4,28 +4,59 @@ Feature: Adult Conviction
     Then I should see "What was your motoring conviction?"
 
   @happy_path @date_travel
-  Scenario Outline: Motoring convictions
+  Scenario Outline: Motoring disqualification with length
     Given The current date is 03-07-2020
     When I choose "<subtype>"
 
     Then I should see "Did you get an endorsement?"
-    And I choose "Yes"
+    And I choose "<endorsement>"
 
     Then I should see "<known_date_header>"
     And I enter the following date 01-01-2020
-    Then I should see "<motoring_disqualification_end_date_header>"
 
-    And I enter the following date <disqualification_date>
+    Then I should see "<length_type_header>"
+    And  I choose "Months"
+
+    Then I should see "<length_header>"
+    And I fill in "Number of months" with "<length_months>"
+    And I click the "Continue" button
+
     Then I should be on "<result>"
     And I should see "<spent_date>"
 
     Examples:
-      | subtype           | known_date_header       | motoring_disqualification_end_date_header | disqualification_date | result               | spent_date                                      |
-      | Disqualification  | When did the ban start? | When did your disqualification end?       | 01-06-2020            | /steps/check/results | This conviction will be spent on 1 January 2025 |
-      | Disqualification  | When did the ban start? | When did your disqualification end?       | 22-05-2023            | /steps/check/results | This conviction will be spent on 1 January 2025 |
+      | subtype          | endorsement | known_date_header       | length_type_header                                                      | length_header                                | length_months | result               | spent_date                                       |
+      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | /steps/check/results | This conviction will be spent on 1 January 2025  |
+      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | /steps/check/results | This conviction was spent on 1 July 2020         |
+      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 70            | /steps/check/results | This conviction will be spent on 1 November 2025 |
+      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 70            | /steps/check/results | This conviction will be spent on 1 November 2025 |
+
+  @happy_path @date_travel
+  Scenario Outline: Motoring disqualification without length or indefinite
+    Given The current date is 03-07-2020
+    When I choose "<subtype>"
+
+    Then I should see "Did you get an endorsement?"
+    And I choose "<endorsement>"
+
+    Then I should see "<known_date_header>"
+    And I enter the following date 01-01-2020
+
+    Then I should see "<length_type_header>"
+    And  I choose "<length_option>"
+
+    Then I should be on "<result>"
+    And I should see "<spent_date>"
+
+    Examples:
+      | subtype          | endorsement | known_date_header       | length_type_header                                                      | length_option       | result               | spent_date                                                                         |
+      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | /steps/check/results | This conviction will be spent on 1 January 2025                                    |
+      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | /steps/check/results | This conviction will be spent on 1 January 2022                                    |
+      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | /steps/check/results | This conviction will stay in place until another order is made to change or end it |
+      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | /steps/check/results | This conviction will stay in place until another order is made to change or end it |
 
   @happy_path  @date_travel
-  Scenario Outline: Motoring convictions without length
+  Scenario Outline: Motoring fine
     Given The current date is 03-07-2020
     When I choose "<subtype>"
 
@@ -43,7 +74,7 @@ Feature: Adult Conviction
       | Fine                       | No          | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 January 2021 |
 
   @happy_path @date_travel
-  Scenario Outline: Motoring convictions without length (penalty points)
+  Scenario Outline: Motoring penalty points
     Given The current date is 03-07-2020
     When I choose "<subtype>"
 

--- a/features/youth/conviction_motoring.feature
+++ b/features/youth/conviction_motoring.feature
@@ -4,29 +4,59 @@ Feature: Youth Conviction
     Then I should see "What was your motoring conviction?"
 
   @happy_path @date_travel
-  Scenario Outline: Motoring convictions
+  Scenario Outline: Motoring disqualification with length
     Given The current date is 03-07-2020
     When I choose "<subtype>"
 
     Then I should see "Did you get an endorsement?"
-    And I choose "Yes"
+    And I choose "<endorsement>"
 
     Then I should see "<known_date_header>"
     And I enter the following date 01-01-2020
 
-    Then I should see "<motoring_disqualification_end_date_header>"
-    And I enter the following date <disqualification_date>
+    Then I should see "<length_type_header>"
+    And  I choose "Months"
+
+    Then I should see "<length_header>"
+    And I fill in "Number of months" with "<length_months>"
+    And I click the "Continue" button
 
     Then I should be on "<result>"
     And I should see "<spent_date>"
 
     Examples:
-      | subtype           | known_date_header          | motoring_disqualification_end_date_header | disqualification_date | result               | spent_date                                   |
-      | Disqualification  | When did the ban start?    | When did your disqualification end?       | 01-06-2020            | /steps/check/results | This conviction will be spent on 1 July 2022 |
-      | Disqualification  | When did the ban start?    | When did your disqualification end?       | 22-05-2023            | /steps/check/results | This conviction will be spent on 22 May 2023 |
+      | subtype          | endorsement | known_date_header       | length_type_header                                                      | length_header                                | length_months | result               | spent_date                                   |
+      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | /steps/check/results | This conviction will be spent on 1 July 2022 |
+      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | /steps/check/results | This conviction was spent on 1 July 2020     |
+      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 40            | /steps/check/results | This conviction will be spent on 1 May 2023  |
+      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 40            | /steps/check/results | This conviction will be spent on 1 May 2023  |
 
   @happy_path @date_travel
-  Scenario Outline: Motoring convictions without length
+  Scenario Outline: Motoring disqualification without length or indefinite
+    Given The current date is 03-07-2020
+    When I choose "<subtype>"
+
+    Then I should see "Did you get an endorsement?"
+    And I choose "<endorsement>"
+
+    Then I should see "<known_date_header>"
+    And I enter the following date 01-01-2020
+
+    Then I should see "<length_type_header>"
+    And  I choose "<length_option>"
+
+    Then I should be on "<result>"
+    And I should see "<spent_date>"
+
+    Examples:
+      | subtype          | endorsement | known_date_header       | length_type_header                                                      | length_option       | result               | spent_date                                                                         |
+      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | /steps/check/results | This conviction will be spent on 1 July 2022                                       |
+      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | /steps/check/results | This conviction will be spent on 1 January 2022                                    |
+      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | /steps/check/results | This conviction will stay in place until another order is made to change or end it |
+      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | /steps/check/results | This conviction will stay in place until another order is made to change or end it |
+
+  @happy_path @date_travel
+  Scenario Outline: Motoring fine
     Given The current date is 03-07-2020
     When I choose "<subtype>"
 
@@ -45,7 +75,7 @@ Feature: Youth Conviction
       | Fine                       | No          | When were you given the fine?            | /steps/check/results | This conviction was spent on 1 July 2020        |
 
   @happy_path @date_travel
-  Scenario Outline: Motoring convictions without length (penalty points)
+  Scenario Outline: Motoring penalty points
     Given The current date is 03-07-2020
     When I choose "<subtype>"
 

--- a/spec/decorators/conviction_decorator_spec.rb
+++ b/spec/decorators/conviction_decorator_spec.rb
@@ -47,18 +47,6 @@ RSpec.describe ConvictionDecorator do
     end
   end
 
-  describe '#motoring_disqualification?' do
-    context 'for an adult `ADULT_DISQUALIFICATION` conviction type' do
-      subject { ConvictionType::ADULT_DISQUALIFICATION }
-      it { expect(subject.motoring_disqualification?).to eq(true) }
-    end
-
-    context 'for a youth `YOUTH_DISQUALIFICATION` conviction type' do
-      subject { ConvictionType::YOUTH_DISQUALIFICATION }
-      it { expect(subject.motoring_disqualification?).to eq(true) }
-    end
-  end
-
   describe '#bailable_offense?' do
     context 'for a youth `DETENTION` conviction type' do
       subject { ConvictionType::DETENTION }

--- a/spec/services/calculators/disqualification_calculator_spec.rb
+++ b/spec/services/calculators/disqualification_calculator_spec.rb
@@ -5,39 +5,49 @@ RSpec.describe Calculators::DisqualificationCalculator do
 
   let(:disclosure_check) { build(:disclosure_check,
                                  under_age: under_age,
-                                 known_date: known_date,
                                  motoring_endorsement: motoring_endorsement,
-                                 motoring_disqualification_end_date: motoring_disqualification_end_date) }
+                                 known_date: known_date,
+                                 conviction_length: conviction_length,
+                                 conviction_length_type: conviction_length_type) }
 
-  let(:known_date) { Date.new(2018, 10, 31) }
   let(:motoring_endorsement) { GenericYesNo::NO }
-  let(:motoring_disqualification_end_date) { Date.new(2020, 10, 31) }
+  let(:known_date) { Date.new(2018, 10, 31) }
+  let(:conviction_length) { nil }
+  let(:conviction_length_type) { nil }
 
   describe Calculators::DisqualificationCalculator::Youths do
     let(:under_age) { GenericYesNo::YES }
 
     context '#expiry_date' do
-      context 'with a motoring_disqualification_end_date' do
+      context 'with a length' do
         context 'with a motoring endorsement' do
           let(:motoring_endorsement) { GenericYesNo::YES }
 
           context 'less than or equal to 2.5 years' do
+            let(:conviction_length) { 2 }
+            let(:conviction_length_type) { 'years' }
+
             it { expect(subject.expiry_date.to_s).to eq((known_date + 30.months).to_s) }
           end
 
           context 'greater than 2.5 years' do
-            let(:motoring_disqualification_end_date) { Date.new(2025, 10, 31) }
-            it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+            let(:conviction_length) { 3 }
+            let(:conviction_length_type) { 'years' }
+
+            it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
           end
         end
 
         context 'without a motoring endorsement' do
-          it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+          let(:conviction_length) { 3 }
+          let(:conviction_length_type) { 'years' }
+
+          it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
         end
       end
 
-      context 'without a motoring_disqualification_end_date' do
-        let(:motoring_disqualification_end_date) { nil }
+      context 'without a length' do
+        let(:conviction_length) { 'no_length' }
 
         context 'with a motoring endorsement' do
           let(:motoring_endorsement) { GenericYesNo::YES }
@@ -48,6 +58,11 @@ RSpec.describe Calculators::DisqualificationCalculator do
           it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
         end
       end
+
+      context 'with an indefinite length' do
+        let(:conviction_length_type) { 'indefinite' }
+        it { expect(subject.expiry_date).to eq(ResultsVariant::INDEFINITE) }
+      end
     end
   end
 
@@ -55,35 +70,49 @@ RSpec.describe Calculators::DisqualificationCalculator do
     let(:under_age) { GenericYesNo::NO }
 
     context '#expiry_date' do
-      context 'with a motoring_disqualification_end_date' do
-        context 'with a motoring endorsement ' do
+      context 'with a length' do
+        context 'with a motoring endorsement' do
           let(:motoring_endorsement) { GenericYesNo::YES }
 
-          context 'less than or equal 5 years' do
-            it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+          context 'less than or equal to 5 years' do
+            let(:conviction_length) { 4 }
+            let(:conviction_length_type) { 'years' }
+
+            it { expect(subject.expiry_date.to_s).to eq((known_date + 60.months).to_s) }
           end
 
           context 'greater than 5 years' do
-            let(:motoring_disqualification_end_date) { Date.new(2025, 10, 31) }
-            it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+            let(:conviction_length) { 6 }
+            let(:conviction_length_type) { 'years' }
+
+            it { expect(subject.expiry_date.to_s).to eq((known_date + 72.months).to_s) }
           end
         end
 
-        context 'without a motoring endorsement ' do
-          it { expect(subject.expiry_date.to_s).to eq(motoring_disqualification_end_date.to_s) }
+        context 'without a motoring endorsement' do
+          let(:conviction_length) { 3 }
+          let(:conviction_length_type) { 'years' }
+
+          it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
         end
       end
 
-      context 'without a motoring_disqualification_end_date' do
-        let(:motoring_disqualification_end_date) { nil }
-        context 'with a motoring endorsement ' do
+      context 'without a length' do
+        let(:conviction_length) { 'no_length' }
+
+        context 'with a motoring endorsement' do
           let(:motoring_endorsement) { GenericYesNo::YES }
           it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
         end
 
-        context 'without a motoring endorsement ' do
+        context 'without a motoring endorsement' do
           it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
         end
+      end
+
+      context 'with an indefinite length' do
+        let(:conviction_length_type) { 'indefinite' }
+        it { expect(subject.expiry_date).to eq(ResultsVariant::INDEFINITE) }
       end
     end
   end

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -30,20 +30,15 @@ RSpec.describe ConvictionDecisionTree do
 
   context 'when the step is `known_date` ' do
     let(:step_params) { { known_date: 'anything' } }
-    let(:conviction_subtype) { :detention_training_order }
 
-    context 'when subtype not equal fine or adult_disqualification' do
+    context 'when subtype has length' do
+      let(:conviction_subtype) { :detention_training_order }
       it { is_expected.to have_destination(:conviction_length_type, :edit) }
     end
 
-    context 'when subtype equal fine' do
+    context 'when subtype does not have length' do
       let(:conviction_subtype) { :fine }
       it { is_expected.to complete_the_check_and_show_results }
-    end
-
-    context 'when subtype equal adult_disqualification' do
-      let(:conviction_subtype) { :adult_disqualification }
-      it { is_expected.to have_destination(:motoring_disqualification_end_date, :edit) }
     end
   end
 
@@ -183,11 +178,6 @@ RSpec.describe ConvictionDecisionTree do
       let(:compensation_receipt_sent) { GenericYesNo::NO }
       it { is_expected.to have_destination(:compensation_unable_to_tell, :show) }
     end
-  end
-
-  context 'when the step is `motoring_disqualification_end_date`' do
-    let(:step_params) { { motoring_disqualification_end_date: 'anything' } }
-    it { is_expected.to complete_the_check_and_show_results }
   end
 
   context 'when the step is `motoring_endorsement`' do


### PR DESCRIPTION
Ticket: https://trello.com/c/PhgvFgKM

This is a follow-up to PR #351.
Individual commits for more details.

For motoring disqualifications we should also support an "indefinite / until further order" option, but because motoring disqualifications did not "flow" through the conviction length type step as other orders, they did not get the "indefinite" functionality we implemented in PR #418.

With this PR we change the disqualification journey to ask for a length, instead of an end date, and update the calculator to work with this. This way we also expose the `no length was given` and the `until further order` options.

**Note**: in a future PR we will remove the unused step/views/locales, and the DB attribute.

<img width="577" alt="Screenshot 2021-01-21 at 12 12 15" src="https://user-images.githubusercontent.com/687910/105349971-5f079100-5be2-11eb-907e-6ec3174094a0.png">

