### PR TITLE
Add factory examples

### DIFF
--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -9,13 +9,29 @@ FactoryBot.define do
     under_age { GenericYesNo::YES }
     caution_type { CautionType::YOUTH_SIMPLE_CAUTION }
 
+    trait :youth do
+      under_age { GenericYesNo::YES }
+    end
+
+    trait :adult do
+      under_age { GenericYesNo::NO }
+    end
+
     trait :caution
 
     trait :conviction do
       kind { CheckKind::CONVICTION }
       known_date { nil }
-      under_age { nil }
       caution_type { nil }
+    end
+
+    trait :with_known_date do
+      known_date { Date.new(2018, 10, 31) }
+    end
+
+    trait :conviction_with_known_date do
+      conviction
+      with_known_date
     end
 
     trait :dto_conviction do
@@ -50,6 +66,34 @@ FactoryBot.define do
       conviction_subtype { ConvictionType::ADULT_SUSPENDED_PRISON_SENTENCE }
       conviction_length_type { ConvictionLengthType::MONTHS }
       conviction_length { 15 }
+    end
+
+    # Financial
+
+    trait :with_fine do
+      conviction_with_known_date
+      conviction_type { self.under_age.inquiry.yes? ? ConvictionType::FINANCIAL : ConvictionType::ADULT_FINANCIAL }
+      conviction_subtype { self.under_age.inquiry.yes? ? ConvictionType::FINE : ConvictionType::ADULT_FINE }
+    end
+
+    # Motoring
+
+    trait :with_motoring_disqualification do
+      conviction_with_known_date
+      conviction_type { self.under_age.inquiry.yes? ? ConvictionType::YOUTH_MOTORING : ConvictionType::ADULT_MOTORING }
+      conviction_subtype { self.under_age.inquiry.yes? ? ConvictionType::YOUTH_DISQUALIFICATION : ConvictionType::ADULT_DISQUALIFICATION }
+    end
+
+    trait :with_motoring_penalty_points do
+      conviction_with_known_date
+      conviction_type { self.under_age.inquiry.yes? ? ConvictionType::YOUTH_MOTORING : ConvictionType::ADULT_MOTORING }
+      conviction_subtype { self.under_age.inquiry.yes? ? ConvictionType::YOUTH_PENALTY_POINTS : ConvictionType::ADULT_PENALTY_POINTS }
+    end
+
+    trait :with_motoring_fine do
+      conviction_with_known_date
+      conviction_type { self.under_age.inquiry.yes? ? ConvictionType::YOUTH_MOTORING : ConvictionType::ADULT_MOTORING }
+      conviction_subtype { self.under_age.inquiry.yes? ? ConvictionType::YOUTH_MOTORING_FINE : ConvictionType::ADULT_MOTORING_FINE }
     end
 
     trait :completed do


### PR DESCRIPTION
Story: https://trello.com/c/kj6dxoFV/58-dc-create-factories-to-ease-testing-multiple-convictions

In this PR I'm introducing the following factories:

- Fine
- Motoring Disqualification
- Motoring Penalty Points
- Motoring Fine

I've also made some small changes that should allow us to create scenarios on both Youth and Adult by simply using the one we need. 

Example of usage:

```ruby
FactoryBot.create(:disclosure_check, :youth, :with_fine_conviction)
FactoryBot.create(:disclosure_check, :adult, :with_fine_conviction)
```

Internally the factory should be handling all other settings.


----

In a later PR I will be introducing the following:
- Conditional Discharge Order
- Community Order Selected
- Prison Sentence
- Bind Order
- Sexual Harm
