### PR TITLE
First attempt to perform drag-through calculations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,12 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Max: 20
 
+Metrics/CyclomaticComplexity:
+  Max: 9
+
+Metrics/PerceivedComplexity:
+  Max: 9
+
 Style/HashEachMethods:
   Enabled: true
 

--- a/app/services/base_multiples_calculator.rb
+++ b/app/services/base_multiples_calculator.rb
@@ -9,6 +9,10 @@ class BaseMultiplesCalculator
     CheckKind.find_constant(disclosure_checks.first.kind)
   end
 
+  def conviction?
+    kind.inquiry.conviction?
+  end
+
   def spent?
     return false if spent_date == ResultsVariant::NEVER_SPENT
     return false if spent_date == ResultsVariant::INDEFINITE

--- a/app/services/calculators/multiples/multiple_offenses_calculator.rb
+++ b/app/services/calculators/multiples/multiple_offenses_calculator.rb
@@ -13,9 +13,35 @@ module Calculators
         disclosure_report.check_groups.with_completed_checks.each(&method(:process_group))
       end
 
+      # rubocop:disable Metrics/AbcSize
       def spent_date_for(check_group)
-        results[check_group.id]&.spent_date
+        return unless results.any?
+
+        spent_date = results[check_group.id].spent_date
+
+        # Cautions are always dealt with separately and do not have drag-through
+        return spent_date unless results[check_group.id].conviction?
+
+        # We have to loop through the rest of convictions and check if the spent date
+        # of this group overlaps with the spent date of another group and if so, then
+        # the spent date of this group becomes the spent date of the other group.
+        #
+        results.values.select(&:conviction?).each do |conviction|
+          other_spent_date = conviction.spent_date
+
+          spent_date = ResultsVariant::NEVER_SPENT if other_spent_date == ResultsVariant::NEVER_SPENT
+          spent_date = ResultsVariant::INDEFINITE  if other_spent_date == ResultsVariant::INDEFINITE
+
+          # Continue with next conviction if it is a variant
+          next unless spent_date.is_a?(Date)
+
+          # If the spent date falls inside another rehabilitation, we do drag-through
+          spent_date = other_spent_date if other_spent_date >= spent_date
+        end
+
+        spent_date
       end
+      # rubocop:enable Metrics/AbcSize
 
       def all_spent?
         results.values.all?(&:spent?)

--- a/spec/presenters/check_answers_presenter_spec.rb
+++ b/spec/presenters/check_answers_presenter_spec.rb
@@ -34,25 +34,18 @@ RSpec.describe CheckAnswersPresenter do
 
   describe '#summary' do
     let(:summary) { subject.summary }
+    let(:spent_date) { 'date' }
 
-    context 'for a single youth caution' do
-      it 'returns CheckGroupPresenter' do
-        expect(summary.size).to eq(1)
-        expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
-        expect(summary[0].number).to eql(1)
-        expect(summary[0].check_group).to eql(disclosure_check.check_group)
-        expect(summary[0].spent_date).to be_nil
-      end
+    before do
+      allow(subject.calculator).to receive(:spent_date_for).and_return(spent_date)
+    end
 
-      context 'when there is a spent date for the group' do
-        before do
-          allow(subject.calculator).to receive(:spent_date_for).and_return('date')
-        end
-
-        it 'returns CheckGroupPresenter' do
-          expect(summary[0].spent_date).to eq('date')
-        end
-      end
+    it 'returns CheckGroupPresenter' do
+      expect(summary.size).to eq(1)
+      expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
+      expect(summary[0].number).to eql(1)
+      expect(summary[0].check_group).to eql(disclosure_check.check_group)
+      expect(summary[0].spent_date).to eq(spent_date)
     end
   end
 end

--- a/spec/services/calculators/multiples/same_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/same_proceedings_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Calculators::Multiples::SameProceedings do
     end
   end
 
+  describe '#conviction?' do
+    it 'is always true for same proceedings' do
+      expect(subject.conviction?).to eq(true)
+    end
+  end
+
   context '#spent_date' do
     context 'when there is at least one `never_spent` date' do
       before do

--- a/spec/services/calculators/multiples/separate_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/separate_proceedings_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe Calculators::Multiples::SeparateProceedings do
     end
   end
 
+  describe '#conviction?' do
+    context 'for a caution' do
+      let(:kind) { 'caution' }
+      it { expect(subject.conviction?).to eq(false) }
+    end
+
+    context 'for a conviction' do
+      let(:kind) { 'conviction' }
+      it { expect(subject.conviction?).to eq(true) }
+    end
+  end
+
   context '#spent_date' do
     before do
       allow(CheckResult).to receive(:new).with(


### PR DESCRIPTION
Ticket: https://trello.com/c/W2K1PV43

This is a first (and admittedly not very elegant) attempt to perform drag-through calculations for **separate proceedings**, meaning we need to extend the spent date of a conviction if the rehabilitation period of said conviction overlaps (even if it is just 1 day) with the rehabilitation period of another conviction.

Note, some limitations with this first version that will be sorted out in follow-up PRs:

- The loop is not sorted by conviction date, so the final result is not idempotent (depends on the order the convictions are added to the "basket"). This loop will need to be sorted.

- We will need to do something similar, if not identical, in the `SameProceedings` calculator, because the sentences inside a conviction can also have drag-through, but there are some exceptions.