### PR TITLE
Sort drag-through loop by conviction start date

### DIFF
--- a/app/services/base_multiples_calculator.rb
+++ b/app/services/base_multiples_calculator.rb
@@ -21,6 +21,11 @@ class BaseMultiplesCalculator
     spent_date.past?
   end
 
+  def start_date
+    # Pick the earliest date in the collection
+    disclosure_checks.map(&:known_date).min
+  end
+
   # :nocov:
   def spent_date
     raise 'implement in subclasses'

--- a/app/services/calculators/multiples/multiple_offenses_calculator.rb
+++ b/app/services/calculators/multiples/multiple_offenses_calculator.rb
@@ -13,7 +13,6 @@ module Calculators
         disclosure_report.check_groups.with_completed_checks.each(&method(:process_group))
       end
 
-      # rubocop:disable Metrics/AbcSize
       def spent_date_for(check_group)
         return unless results.any?
 
@@ -26,7 +25,7 @@ module Calculators
         # of this group overlaps with the spent date of another group and if so, then
         # the spent date of this group becomes the spent date of the other group.
         #
-        results.values.select(&:conviction?).each do |conviction|
+        convictions.each do |conviction|
           other_spent_date = conviction.spent_date
 
           spent_date = ResultsVariant::NEVER_SPENT if other_spent_date == ResultsVariant::NEVER_SPENT
@@ -41,13 +40,16 @@ module Calculators
 
         spent_date
       end
-      # rubocop:enable Metrics/AbcSize
 
       def all_spent?
         results.values.all?(&:spent?)
       end
 
       private
+
+      def convictions
+        @_convictions ||= results.values.select(&:conviction?).sort_by(&:start_date)
+      end
 
       def process_group(check_group)
         results[check_group.id] = if check_group.disclosure_checks.count > 1

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -27,20 +27,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
     end
   end
 
-  context '#spent_date_for' do
-    before do
-      BaseMultiplesCalculator.subclasses.each do |klass|
-        allow_any_instance_of(klass).to receive(:spent_date).and_return("date_#{klass}")
-      end
-    end
-
-    it 'returns the spent date for the matching check group' do
-      expect(subject.spent_date_for(check_group1)).to eq('date_Calculators::Multiples::SameProceedings')
-      expect(subject.spent_date_for(check_group2)).to eq('date_Calculators::Multiples::SeparateProceedings')
-    end
-  end
-
-  describe '#spent_date_for (factories)' do
+  describe '#spent_date_for' do
     context 'conviction with 2 sentences, and one simple caution' do
       let(:disclosure_check1) { build(:disclosure_check, :dto_conviction) }
       let(:disclosure_check2) { build(:disclosure_check, :suspended_prison_sentence) }

--- a/spec/services/calculators/multiples/same_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/same_proceedings_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Calculators::Multiples::SameProceedings do
 
   let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check1, disclosure_check2, disclosure_check3]) }
 
-  let(:disclosure_check1) { instance_double(DisclosureCheck, kind: 'conviction') }
-  let(:disclosure_check2) { instance_double(DisclosureCheck, kind: 'conviction') }
-  let(:disclosure_check3) { instance_double(DisclosureCheck, kind: 'conviction') }
+  let(:disclosure_check1) { instance_double(DisclosureCheck, kind: 'conviction', known_date: known_date1) }
+  let(:disclosure_check2) { instance_double(DisclosureCheck, kind: 'conviction', known_date: known_date2) }
+  let(:disclosure_check3) { instance_double(DisclosureCheck, kind: 'conviction', known_date: known_date3) }
 
   let(:check_result1) { instance_double(CheckResult, expiry_date: Date.new(2015, 10, 31)) }
   let(:check_result2) { instance_double(CheckResult, expiry_date: Date.new(2018, 10, 31)) }
@@ -15,6 +15,10 @@ RSpec.describe Calculators::Multiples::SameProceedings do
 
   let(:check_never_spent) { instance_double(CheckResult, expiry_date: ResultsVariant::NEVER_SPENT) }
   let(:check_indefinite) { instance_double(CheckResult, expiry_date: ResultsVariant::INDEFINITE) }
+
+  let(:known_date1) { Date.new(2018, 1, 1) }
+  let(:known_date2) { Date.new(2015, 1, 1) }
+  let(:known_date3) { Date.new(2016, 1, 1) }
 
   describe '#kind' do
     it 'is always conviction for same proceedings' do
@@ -25,6 +29,12 @@ RSpec.describe Calculators::Multiples::SameProceedings do
   describe '#conviction?' do
     it 'is always true for same proceedings' do
       expect(subject.conviction?).to eq(true)
+    end
+  end
+
+  context '#start_date' do
+    it 'returns the earliest known date from all the dates' do
+      expect(subject.start_date).to eq(known_date2)
     end
   end
 

--- a/spec/services/calculators/multiples/separate_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/separate_proceedings_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe Calculators::Multiples::SeparateProceedings do
   subject { described_class.new(check_group) }
 
   let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check]) }
-  let(:disclosure_check) { instance_double(DisclosureCheck, kind: kind) }
+  let(:disclosure_check) { instance_double(DisclosureCheck, kind: kind, known_date: known_date) }
 
   let(:check_result) { instance_double(CheckResult, expiry_date: expiry_date) }
+  let(:known_date) { Date.new(2015, 12, 25) }
   let(:expiry_date) { Date.new(2018, 10, 31) }
   let(:kind) { nil }
 
@@ -31,6 +32,12 @@ RSpec.describe Calculators::Multiples::SeparateProceedings do
     context 'for a conviction' do
       let(:kind) { 'conviction' }
       it { expect(subject.conviction?).to eq(true) }
+    end
+  end
+
+  context '#start_date' do
+    it 'returns the known date of the caution or conviction' do
+      expect(subject.start_date).to eq(known_date)
     end
   end
 


### PR DESCRIPTION
Ticket: https://trello.com/c/W2K1PV43

Follow-up to PR #427.

As mentioned before the results were not idempotent. This is now solved by having a predictable iteration order in the loop, by conviction `start date`.

The start date for a conviction with more than one sentences is the earliest of the dates.

Some of the scenarios in the Unlock spreadsheet can now be coded into tests with factories and should give us predictable (and accurate) results.

Other scenarios can't be run just yet as they will fail.