### PR TITLE
Multiple offences calculator tweaks

### DIFF
--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -3,17 +3,18 @@ class ChecksController < ApplicationController
 
   def create
     if check_group_id
-      # add another conviction in existing proceedings
+      # add another sentence to an existing conviction (same proceedings)
       initialize_disclosure_check(
         navigation_stack: navigation_stack,
         kind: CheckKind::CONVICTION.value,
         under_age: first_check_in_group.under_age,
+        known_date: first_check_in_group.known_date,
         check_group: check_group
       )
 
       redirect_to edit_steps_conviction_conviction_type_path
     else
-      # add another caution or conviction in new proceedings
+      # add a new caution or conviction (separate proceedings)
       initialize_disclosure_check(
         navigation_stack: navigation_stack,
         disclosure_report: current_disclosure_report

--- a/app/forms/steps/conviction/conviction_subtype_form.rb
+++ b/app/forms/steps/conviction/conviction_subtype_form.rb
@@ -34,7 +34,6 @@ module Steps
         disclosure_check.update(
           conviction_subtype: conviction_subtype,
           # The following are dependent attributes that need to be reset if form changes
-          known_date: nil,
           conviction_bail: nil,
           conviction_bail_days: nil,
           conviction_length: nil,

--- a/app/models/check_group.rb
+++ b/app/models/check_group.rb
@@ -3,4 +3,8 @@ class CheckGroup < ApplicationRecord
   has_many :disclosure_checks, dependent: :destroy
 
   scope :with_completed_checks, -> { joins(:disclosure_checks).where(disclosure_checks: { status: :completed }).distinct }
+
+  def multiple_sentences?
+    disclosure_checks.size > 1
+  end
 end

--- a/app/services/calculators/multiples/multiple_offenses_calculator.rb
+++ b/app/services/calculators/multiples/multiple_offenses_calculator.rb
@@ -26,6 +26,7 @@ module Calculators
         # the spent date of this group becomes the spent date of the other group.
         #
         convictions.each do |conviction|
+          other_start_date = conviction.start_date
           other_spent_date = conviction.spent_date
 
           spent_date = ResultsVariant::NEVER_SPENT if other_spent_date == ResultsVariant::NEVER_SPENT
@@ -35,7 +36,7 @@ module Calculators
           next unless spent_date.is_a?(Date)
 
           # If the spent date falls inside another rehabilitation, we do drag-through
-          spent_date = other_spent_date if other_spent_date >= spent_date
+          spent_date = other_spent_date if spent_date.in?(other_start_date..other_spent_date)
         end
 
         spent_date
@@ -52,7 +53,7 @@ module Calculators
       end
 
       def process_group(check_group)
-        results[check_group.id] = if check_group.disclosure_checks.count > 1
+        results[check_group.id] = if check_group.multiple_sentences?
                                     # multiple sentences inside the same proceedings
                                     SameProceedings.new(check_group)
                                   else

--- a/app/services/calculators/multiples/same_proceedings.rb
+++ b/app/services/calculators/multiples/same_proceedings.rb
@@ -11,6 +11,7 @@ module Calculators
         return ResultsVariant::INDEFINITE  if expiry_dates.include?(ResultsVariant::INDEFINITE)
 
         # Pick the latest date in the collection
+        # All sentences in same proceedings start the same date, overlapping
         expiry_dates.max
       end
 

--- a/app/services/calculators/multiples/separate_proceedings.rb
+++ b/app/services/calculators/multiples/separate_proceedings.rb
@@ -1,8 +1,3 @@
-# TODO: pending things to code or clarify
-#
-#   - This calculator is not finished, it just returns the spent date for the
-#     caution/conviction, nothing else. We are awaiting some clarifications.
-#
 module Calculators
   module Multiples
     class SeparateProceedings < BaseMultiplesCalculator

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -92,7 +92,11 @@ class ConvictionDecisionTree < BaseDecisionTree
     known_date_question
   end
 
+  # For multiples, all sentences given as part of the same conviction
+  # share the same start date so we don't need to ask this for each one.
   def known_date_question
+    return after_known_date if disclosure_check.check_group.multiple_sentences?
+
     edit(:known_date)
   end
 end

--- a/spec/controllers/checks_controller_spec.rb
+++ b/spec/controllers/checks_controller_spec.rb
@@ -73,6 +73,9 @@ RSpec.describe ChecksController, type: :controller do
           # have happened at the same age
           expect(last_check.under_age).to eq(GenericYesNo::YES.to_s)
 
+          # we default the start date, as all sentences in the same conviction starts in the same date
+          expect(last_check.known_date).to eq(disclosure_check.known_date)
+
           # the back link should point to CYA page
           expect(last_check.navigation_stack).to eq([steps_check_check_your_answers_path])
         end

--- a/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
@@ -45,7 +45,6 @@ RSpec.describe Steps::Conviction::ConvictionSubtypeForm do
         expect(disclosure_check).to receive(:update).with(
           conviction_subtype: conviction_subtype,
           # Dependent attributes to be reset
-          known_date: nil,
           conviction_bail: nil,
           conviction_bail_days: nil,
           conviction_length: nil,

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
   let(:disclosure_check3) { instance_double(DisclosureCheck, kind: 'caution') }
 
   before do
+    # Note: because these are doubles, the method does not work, so we emulate it
+    allow(check_group1).to receive(:multiple_sentences?).and_return(check_group1.disclosure_checks.size > 1)
+    allow(check_group2).to receive(:multiple_sentences?).and_return(check_group2.disclosure_checks.size > 1)
+
     subject.process!
   end
 

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ConvictionDecisionTree do
   let(:disclosure_check) do
     instance_double(
       DisclosureCheck,
+      check_group: check_group,
       conviction_type: conviction_type,
       conviction_subtype: conviction_subtype,
       compensation_paid: compensation_paid,
@@ -23,6 +24,8 @@ RSpec.describe ConvictionDecisionTree do
   let(:compensation_payment_over_100) { nil }
   let(:compensation_receipt_sent) { nil }
 
+  let(:check_group) { instance_double(CheckGroup, multiple_sentences?: multiple_sentences) }
+  let(:multiple_sentences) { false }
 
   subject { described_class.new(disclosure_check: disclosure_check, step_params: step_params, as: as, next_step: next_step) }
 
@@ -68,7 +71,15 @@ RSpec.describe ConvictionDecisionTree do
 
       context 'when subtype equal youth_penalty_points' do
         let(:conviction_subtype) { :youth_penalty_points }
-        it { is_expected.to have_destination(:known_date, :edit) }
+
+        context 'for a new sentence in an existing conviction' do
+          let(:multiple_sentences) { true }
+          it { is_expected.to complete_the_check_and_show_results }
+        end
+
+        context 'for a new conviction' do
+          it { is_expected.to have_destination(:known_date, :edit) }
+        end
       end
     end
 
@@ -82,7 +93,15 @@ RSpec.describe ConvictionDecisionTree do
 
       context 'when subtype equal adult_penalty_points' do
         let(:conviction_subtype) { :adult_penalty_points }
-        it { is_expected.to have_destination(:known_date, :edit) }
+
+        context 'for a new sentence in an existing conviction' do
+          let(:multiple_sentences) { true }
+          it { is_expected.to complete_the_check_and_show_results }
+        end
+
+        context 'for a new conviction' do
+          it { is_expected.to have_destination(:known_date, :edit) }
+        end
       end
     end
 
@@ -92,7 +111,14 @@ RSpec.describe ConvictionDecisionTree do
     end
 
     context 'for any other conviction subtypes' do
-      it { is_expected.to have_destination(:known_date, :edit) }
+      context 'for a new sentence in an existing conviction' do
+        let(:multiple_sentences) { true }
+        it { is_expected.to have_destination(:conviction_length_type, :edit) }
+      end
+
+      context 'for a new conviction' do
+        it { is_expected.to have_destination(:known_date, :edit) }
+      end
     end
   end
 


### PR DESCRIPTION
Ticket: https://trello.com/c/W2K1PV43

Follow-up to PR #428.

Using a range is more accurate as there were some edge cases where otherwises the loop would return wrong results.

Also, tweak the multiples journey to not ask again for the conviction date, in same proceedings, as the start date is shared between all sentences.