### PR TITLE
Create specs based on given examples

### DIFF
--- a/app/models/disclosure_check.rb
+++ b/app/models/disclosure_check.rb
@@ -6,4 +6,8 @@ class DisclosureCheck < ApplicationRecord
     in_progress: 0,
     completed: 10,
   }
+
+  def relevant_order?
+    ConvictionType.find_constant(conviction_subtype).relevant_order?
+  end
 end

--- a/app/services/calculators/multiples/same_proceedings.rb
+++ b/app/services/calculators/multiples/same_proceedings.rb
@@ -17,10 +17,41 @@ module Calculators
 
       private
 
+      # TODO: This needs confirmation, please visit the following card https://trello.com/c/sZ7qBDwe/
       def expiry_dates
-        @_expiry_dates ||= disclosure_checks.map(
-          &method(:expiry_date_for)
-        )
+        if all_proceedings_are_relevant_orders? || no_relevant_orders?
+          @_expiry_dates ||= disclosure_checks.map(
+            &method(:expiry_date_for)
+          )
+        else
+          expire_date = expiry_date_for(conviction_with_relevant_order)
+          expiry_dates = proceedings_without_relevant_order.map(&method(:expiry_date_for))
+
+          if expiry_dates.max < expire_date
+            expiry_dates
+          else
+            [expire_date]
+          end
+        end
+      end
+
+      def all_proceedings_are_relevant_orders?
+        disclosure_checks.all? { |disclosure_check| disclosure_check.relevant_order? }
+      end
+
+      def no_relevant_orders?
+        disclosure_checks.none? { |disclosure_check| disclosure_check.relevant_order? }
+      end
+
+      # NOTE: Currently we don't the exact behaviour, so I've taken the longest relevant order if there's more than one.
+      # See the following card for more clarification, when provided: https://trello.com/c/sZ7qBDwe/
+      def conviction_with_relevant_order
+        relevant_orders = disclosure_checks.select { |disclosure_check| disclosure_check.relevant_order? }
+        relevant_orders.max_by { |relevant_order| relevant_order.conviction_length }
+      end
+
+      def proceedings_without_relevant_order
+        disclosure_checks - [conviction_with_relevant_order]
       end
     end
   end

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -67,6 +67,15 @@ FactoryBot.define do
       conviction_length { 15 }
     end
 
+    trait :with_attendance_centre_order do
+      adult
+      conviction_with_known_date
+      conviction_type { ConvictionType::ADULT_COMMUNITY_REPARATION }
+      conviction_subtype { ConvictionType::ADULT_ATTENDANCE_CENTRE_ORDER }
+      conviction_length_type { ConvictionLengthType::MONTHS }
+      conviction_length { 8 }
+    end
+
     # Prison
 
     trait :with_conviction_bail do
@@ -97,6 +106,9 @@ FactoryBot.define do
       conviction_with_known_date
       conviction_type { self.under_age.inquiry.yes? ? ConvictionType::YOUTH_MOTORING : ConvictionType::ADULT_MOTORING }
       conviction_subtype { self.under_age.inquiry.yes? ? ConvictionType::YOUTH_DISQUALIFICATION : ConvictionType::ADULT_DISQUALIFICATION }
+      conviction_length { 6 }
+      conviction_length_type { ConvictionLengthType::MONTHS }
+      motoring_endorsement { GenericYesNo::NO }
     end
 
     trait :with_motoring_penalty_points do
@@ -123,6 +135,8 @@ FactoryBot.define do
       conviction_with_known_date
       conviction_type { self.under_age.inquiry.yes? ? ConvictionType::DISCHARGE : ConvictionType::ADULT_DISCHARGE }
       conviction_subtype { self.under_age.inquiry.yes? ? ConvictionType::CONDITIONAL_DISCHARGE : ConvictionType::ADULT_CONDITIONAL_DISCHARGE }
+      conviction_length { 12 }
+      conviction_length_type { ConvictionLengthType::MONTHS }
     end
 
     # Community Reparation

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -121,6 +121,7 @@ FactoryBot.define do
       conviction_with_known_date
       conviction_type { self.under_age.inquiry.yes? ? ConvictionType::YOUTH_MOTORING : ConvictionType::ADULT_MOTORING }
       conviction_subtype { self.under_age.inquiry.yes? ? ConvictionType::YOUTH_MOTORING_FINE : ConvictionType::ADULT_MOTORING_FINE }
+      motoring_endorsement { GenericYesNo::NO }
     end
 
     # Discharge

--- a/spec/services/calculators/multiples/convictions_based_in_possible_scenarios_spec.rb
+++ b/spec/services/calculators/multiples/convictions_based_in_possible_scenarios_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
+  subject { described_class.new(disclosure_report) }
+
+  let(:disclosure_report) { DisclosureReport.new }
+  let(:first_group) { disclosure_report.check_groups.build }
+  let(:second_group) { disclosure_report.check_groups.build }
+
+  def save_report
+    disclosure_report.completed!
+  end
+
+  context 'adult' do
+    context 'when same proceedings' do
+      context 'when a relevant order is the longest sentence' do
+        before do
+          first_group.disclosure_checks << build(:disclosure_check, :adult, :with_discharge_order, :completed, known_date: Date.new(2000, 1, 1), conviction_length: 36)
+          first_group.disclosure_checks << build(:disclosure_check, :adult, :with_motoring_disqualification, :completed, known_date: Date.new(2000, 1, 1))
+          save_report
+        end
+
+        it 'ignores the relevant order' do
+          expect(subject.spent_date_for(subject.results[first_group.id])).to eq(Date.new(2000, 7, 1))
+        end
+      end
+    end
+
+    context 'with separate proceedings' do
+      let(:first_proceeding) { subject.results[first_group.id] }
+      let(:second_proceeding) { subject.results[second_group.id] }
+
+      context 'two convictions that overlap in time' do
+        before do
+          first_group.disclosure_checks << build(:disclosure_check, :adult, :with_discharge_order, :completed, known_date: Date.new(2000, 12, 2))
+          second_group.disclosure_checks << build(:disclosure_check, :adult, :with_fine, :completed, known_date: Date.new(2001, 8, 6))
+
+          save_report
+        end
+
+        it 'has separate proceedings' do
+          expect(first_proceeding).to be_kind_of(Calculators::Multiples::SeparateProceedings)
+          expect(second_proceeding).to be_kind_of(Calculators::Multiples::SeparateProceedings)
+        end
+
+        it 'calculates the spent date of the latest date for both convictions' do
+          expect(subject.spent_date_for(first_proceeding)).to eq(Date.new(2002, 8, 6))
+          expect(subject.spent_date_for(second_proceeding)).to eq(Date.new(2002, 8, 6))
+        end
+      end
+
+      context 'two convictions that do not overlap in time' do
+        before do
+          first_group.disclosure_checks << build(:disclosure_check, :adult, :with_fine, :completed, known_date: Date.new(2000, 1, 1))
+          second_group.disclosure_checks << build(:disclosure_check, :adult, :with_fine, :completed, known_date: Date.new(2005, 5, 5))
+
+          save_report
+        end
+
+        it 'calculates the spent date of each conviction separately' do
+          expect(subject.spent_date_for(first_proceeding)).to eq(Date.new(2001, 1, 1))
+          expect(subject.spent_date_for(second_proceeding)).to eq(Date.new(2006, 5, 5))
+        end
+      end
+
+      context '4 convictions, 2 of them overlap and the other 2 overlap but one is never spent' do
+        let(:third_group) { disclosure_report.check_groups.build }
+        let(:fourth_group) { disclosure_report.check_groups.build }
+        let(:third_proceeding) { subject.results[third_group.id] }
+        let(:forth_proceeding) { subject.results[fourth_group.id] }
+
+        before do
+          first_group.disclosure_checks << build(:disclosure_check, :adult, :with_fine, :completed, known_date: Date.new(2000, 12, 2))
+          second_group.disclosure_checks << build(:disclosure_check, :adult, :with_fine, :completed, known_date: Date.new(2001, 2, 2))
+
+          third_group.disclosure_checks << build(:disclosure_check, :with_prison_sentence, :completed, known_date: Date.new(2005, 1, 1), conviction_length: 60)
+          fourth_group.disclosure_checks << build(:disclosure_check, :adult, :with_sexual_harm_order, :completed, known_date: Date.new(2005, 4, 2))
+
+          save_report
+        end
+
+        it 'calculates the first 2 convictions as the same spent date' do
+          expect(subject.spent_date_for(first_proceeding)).not_to eq(ResultsVariant::NEVER_SPENT)
+
+          expect(subject.spent_date_for(first_proceeding)).to eq(subject.spent_date_for(second_proceeding))
+          expect(subject.spent_date_for(first_proceeding)).to eq(Date.new(2002, 2, 2))
+        end
+
+        it 'calculates the second 2 convictions as never spent' do
+          expect(subject.spent_date_for(third_proceeding)).to eq(subject.spent_date_for(forth_proceeding))
+          expect(subject.spent_date_for(third_proceeding)).to eq(ResultsVariant::NEVER_SPENT)
+        end
+      end
+
+      context 'when a never spent conviction is present' do
+        before do
+          first_group.disclosure_checks << build(:disclosure_check, :with_prison_sentence, :completed, known_date: Date.new(2005, 1, 1), conviction_length: 60)
+        end
+
+        it 'should be never spent' do
+          save_report
+          expect(subject.spent_date_for(first_proceeding)).to eq(ResultsVariant::NEVER_SPENT)
+        end
+
+        context 'and another conviction is added after, with a given spent date' do
+          before do
+            second_group.disclosure_checks << build(:disclosure_check, :with_attendance_centre_order, :completed, known_date: Date.new(2005, 4, 1))
+          end
+
+          it 'should keep same given end date and not become `never spent`' do
+            save_report
+
+            expect(subject.spent_date_for(first_proceeding)).to eq(ResultsVariant::NEVER_SPENT)
+            expect(subject.spent_date_for(second_proceeding)).to eq(Date.new(2005, 12, 1))
+          end
+        end
+
+        context 'and is added within another conviction timeline that had a given spent date' do
+          before do
+            second_group.disclosure_checks << build(:disclosure_check, :with_attendance_centre_order, :completed, known_date: Date.new(2004, 10, 1))
+          end
+
+          it 'should both become never spent' do
+            save_report
+
+            expect(subject.spent_date_for(first_proceeding)).to eq(ResultsVariant::NEVER_SPENT)
+            expect(subject.spent_date_for(second_proceeding)).to eq(ResultsVariant::NEVER_SPENT)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/calculators/multiples/convictions_based_in_possible_scenarios_spec.rb
+++ b/spec/services/calculators/multiples/convictions_based_in_possible_scenarios_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
 
   context 'adult' do
     context 'when same proceedings' do
+      let(:same_proceedings) { subject.results[first_group.id] }
+
       context 'when a relevant order is the longest sentence' do
         before do
           first_group.disclosure_checks << build(:disclosure_check, :adult, :with_discharge_order, :completed, known_date: Date.new(2000, 1, 1), conviction_length: 36)
@@ -21,13 +23,12 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
         end
 
         it 'ignores the relevant order' do
-          expect(subject.spent_date_for(subject.results[first_group.id])).to eq(Date.new(2000, 7, 1))
+          expect(subject.spent_date_for(same_proceedings)).to eq(Date.new(2000, 7, 1))
         end
       end
     end
 
     context 'with separate proceedings' do
-      let(:first_proceeding) { subject.results[first_group.id] }
       let(:second_proceeding) { subject.results[second_group.id] }
 
       context 'two convictions that overlap in time' do

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
   let(:disclosure_check2) { instance_double(DisclosureCheck, kind: 'conviction') }
   let(:disclosure_check3) { instance_double(DisclosureCheck, kind: 'caution') }
 
-  let(:same_proceedings) { subject.results['100'] }
-  let(:separate_proceedings) { subject.results['200'] }
+  let(:same_proceedings) { subject.results[check_group1.id] }
+  let(:separate_proceedings) { subject.results[check_group2.id] }
 
   before do
     # Note: because these are doubles, the method does not work, so we emulate it
@@ -24,11 +24,11 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
 
   context '#process!' do
     it 'adds to the results the check groups having more than one disclosure check' do
-      expect(subject.results['100']).to be_kind_of(Calculators::Multiples::SameProceedings)
+      expect(same_proceedings).to be_kind_of(Calculators::Multiples::SameProceedings)
     end
 
     it 'adds to the results the check groups having only one disclosure check' do
-      expect(subject.results['200']).to be_kind_of(Calculators::Multiples::SeparateProceedings)
+      expect(separate_proceedings).to be_kind_of(Calculators::Multiples::SeparateProceedings)
     end
   end
 


### PR DESCRIPTION
This commit brings a new set of tests that have been based on some scenarios,
so that we can improve the calculatios of multiple convictions (same proceedings or separte proceedings)

I've marked a test as pending for same proceedings since we haven't tackled yet relevant orders.

Although another test showed that we are marking all separate convictions as
never spent if there's a never spent conviction in one of the groups.

This is not correct, only the convictions that overlap would be considered never spent,
any convictions which are spent before should not be considered "never spent".

It may be better to bring the screenshot explaining the scenario with 4 convictions

![image](https://user-images.githubusercontent.com/136777/106019893-0db44180-60bb-11eb-91b5-985070065fee.png)



**This Pull Request will fail** but I'd like to confirm this before attempting a fix on the calculator.

Story: https://trello.com/c/W2K1PV43/40-dc-calculations-for-separate-proceedings