### PR TITLE
Refactor multiples calculator to work with proceedings

### DIFF
--- a/app/presenters/check_answers_presenter.rb
+++ b/app/presenters/check_answers_presenter.rb
@@ -3,16 +3,14 @@ class CheckAnswersPresenter
 
   def initialize(disclosure_report)
     @disclosure_report = disclosure_report
-
-    calculator.process! if disclosure_report.completed?
   end
 
   def summary
-    disclosure_report.check_groups.with_completed_checks.map.with_index(1) do |check_group, i|
+    calculator.proceedings.map.with_index(1) do |proceeding, i|
       CheckGroupPresenter.new(
         i,
-        check_group,
-        spent_date: calculator.spent_date_for(check_group), # will be `nil` if no date found
+        proceeding.check_group,
+        spent_date: calculator.spent_date_for(proceeding),
         scope: to_partial_path
       )
     end

--- a/app/services/caution_decision_tree.rb
+++ b/app/services/caution_decision_tree.rb
@@ -6,7 +6,7 @@ class CautionDecisionTree < BaseDecisionTree
 
     case step_name
     when :caution_type
-      after_caution_type
+      edit(:known_date)
     when :known_date
       after_known_date
     when :conditional_end_date
@@ -18,13 +18,9 @@ class CautionDecisionTree < BaseDecisionTree
 
   private
 
-  def after_caution_type
-    return edit(:known_date) if caution_type.conditional?
+  def after_known_date
+    return edit(:conditional_end_date) if caution_type.conditional?
 
     results
-  end
-
-  def after_known_date
-    edit(:conditional_end_date)
   end
 end

--- a/features/adults/caution.feature
+++ b/features/adults/caution.feature
@@ -5,20 +5,20 @@ Feature: Caution
     Then I should see "Were you cautioned or convicted?"
     When I choose "Cautioned"
     Then I should see "How old were you when you got cautioned?"
-
-  @happy_path
-  Scenario: Over 18, Simple caution
     And I choose "18 or over"
     Then I should see "What type of caution did you get?"
 
+  @happy_path
+  Scenario: Over 18, Simple caution
     And I choose "Simple caution"
+
+    Then I should see "When did you get the caution?"
+    When I enter a valid date
+
     Then I should see "This caution is spent on the day you receive it"
 
   @happy_path
   Scenario: Over 18, conditional caution
-    And I choose "18 or over"
-
-    Then I should see "What type of caution did you get?"
     And I choose "Conditional caution"
 
     Then I should see "When did you get the caution?"

--- a/features/youth/caution.feature
+++ b/features/youth/caution.feature
@@ -5,13 +5,15 @@ Feature: Caution
     Then I should see "Were you cautioned or convicted?"
     When I choose "Cautioned"
     Then I should see "How old were you when you got cautioned?"
-
     And I choose "Under 18"
     Then I should see "What type of caution did you get?"
 
   @happy_path
   Scenario: Under 18, simple caution
     And I choose "Youth caution"
+
+    Then I should see "When did you get the caution?"
+    When I enter a valid date
 
     Then I should see "This caution is spent on the day you receive it"
 

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -51,7 +51,6 @@ FactoryBot.define do
 
     trait :youth_simple_caution do
       caution_type { CautionType::YOUTH_SIMPLE_CAUTION }
-      known_date { nil }
     end
 
     trait :youth_conditional_caution do

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -36,13 +36,16 @@ RSpec.describe CautionResultPresenter do
 
     context 'for a youth simple caution' do
       it 'returns the correct question-answer pairs' do
-        expect(summary.size).to eq(2)
+        expect(summary.size).to eq(3)
 
         expect(summary[0].question).to eql(:caution_type)
         expect(summary[0].answer).to eql('youth_simple_caution')
 
         expect(summary[1].question).to eql(:under_age)
         expect(summary[1].answer).to eql('yes')
+
+        expect(summary[2].question).to eql(:known_date)
+        expect(summary[2].answer).to eq('31 October 2018')
       end
     end
 

--- a/spec/presenters/check_answers_presenter_spec.rb
+++ b/spec/presenters/check_answers_presenter_spec.rb
@@ -1,26 +1,12 @@
 RSpec.describe CheckAnswersPresenter do
-  let!(:disclosure_check) { create(:disclosure_check, :completed) }
-  let!(:disclosure_report) { disclosure_check.disclosure_report }
+  let(:disclosure_check) { create(:disclosure_check, :dto_conviction, :completed) }
+  let(:disclosure_report) { disclosure_check.disclosure_report }
 
   subject { described_class.new(disclosure_report) }
 
   describe '.initialize' do
-    context 'calculate the spent dates of the whole report' do
-      context 'when the report is still in progress' do
-        it 'does not process the offenses just yet' do
-          expect(subject.calculator.results).to be_empty
-        end
-      end
-
-      context 'when the report is completed' do
-        before do
-          allow(disclosure_report).to receive(:completed?).and_return(true)
-        end
-
-        it 'processes the offenses for later use' do
-          expect(subject.calculator.results).not_to be_empty
-        end
-      end
+    it 'processes the check groups (proceedings) for later use' do
+      expect(subject.calculator.results).not_to be_empty
     end
   end
 
@@ -36,16 +22,32 @@ RSpec.describe CheckAnswersPresenter do
     let(:summary) { subject.summary }
     let(:spent_date) { 'date' }
 
-    before do
-      allow(subject.calculator).to receive(:spent_date_for).and_return(spent_date)
+    context 'when the report is completed' do
+      before do
+        disclosure_report.completed!
+      end
+
+      it 'returns CheckGroupPresenter with spent dates' do
+        expect(summary.size).to eq(1)
+        expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
+        expect(summary[0].number).to eql(1)
+        expect(summary[0].check_group).to eql(disclosure_check.check_group)
+        expect(summary[0].spent_date).to eq(Date.new(2020, 7, 1))
+      end
     end
 
-    it 'returns CheckGroupPresenter' do
-      expect(summary.size).to eq(1)
-      expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
-      expect(summary[0].number).to eql(1)
-      expect(summary[0].check_group).to eql(disclosure_check.check_group)
-      expect(summary[0].spent_date).to eq(spent_date)
+    context 'when the report is not yet completed' do
+      before do
+        disclosure_report.in_progress!
+      end
+
+      it 'returns CheckGroupPresenter without spent dates' do
+        expect(summary.size).to eq(1)
+        expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
+        expect(summary[0].number).to eql(1)
+        expect(summary[0].check_group).to eql(disclosure_check.check_group)
+        expect(summary[0].spent_date).to eq(nil)
+      end
     end
   end
 end

--- a/spec/services/caution_decision_tree_spec.rb
+++ b/spec/services/caution_decision_tree_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CautionDecisionTree do
     context 'and type is `youth simple caution`' do
       let(:caution_type) { CautionType::YOUTH_SIMPLE_CAUTION.value }
 
-      it { is_expected.to complete_the_check_and_show_results }
+      it { is_expected.to have_destination(:known_date, :edit) }
     end
 
     context 'and type is `youth conditional caution`' do
@@ -38,7 +38,7 @@ RSpec.describe CautionDecisionTree do
     context 'and type is `adult simple caution`' do
       let(:caution_type) { CautionType::ADULT_SIMPLE_CAUTION.value }
 
-      it { is_expected.to complete_the_check_and_show_results }
+      it { is_expected.to have_destination(:known_date, :edit) }
     end
 
     context 'and type is `adult conditional caution`' do
@@ -54,6 +54,11 @@ RSpec.describe CautionDecisionTree do
     context 'and type is `conditional caution`' do
       let(:caution_type)  { CautionType::ADULT_CONDITIONAL_CAUTION.value }
       it { is_expected.to have_destination(:conditional_end_date, :edit) }
+    end
+
+    context 'and type is not `conditional caution`' do
+      let(:caution_type) { CautionType::ADULT_SIMPLE_CAUTION.value }
+      it { is_expected.to complete_the_check_and_show_results }
     end
   end
 


### PR DESCRIPTION
Instead of working with "check_group" objects, it is best to work with proceedings (meaning SameProceedings or SeparateProceedings) classes.

A bit of refactor to the calculator interface, so now instead of passing a check_group to the `#spent_date_for` method we pass the proceeding directly. Internally it knows what to do.

Also no need to call `#process!` manually anymore as that is now part of the initialization.

Finally, making sure the proceedings are returned always sorted by start date, in the "Check your answers" and in the results page.

For this sorting to work properly, I've reintroduce the simple caution "known date" step, otherwise we can't sort as for simple cautions we removed the date step.
The results page for simple caution however are left as before: `This caution is spent on the day you receive it`.