### PR TITLE
Remove unused DB field

### DIFF
--- a/db/migrate/20210129153053_remove_approximate_end_date.rb
+++ b/db/migrate/20210129153053_remove_approximate_end_date.rb
@@ -1,0 +1,5 @@
+class RemoveApproximateEndDate < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :disclosure_checks, :approximate_motoring_disqualification_end_date, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_22_092339) do
+ActiveRecord::Schema.define(version: 2021_01_29_153053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 2021_01_22_092339) do
     t.boolean "approximate_known_date", default: false
     t.boolean "approximate_conditional_end_date", default: false
     t.boolean "approximate_compensation_payment_date", default: false
-    t.boolean "approximate_motoring_disqualification_end_date", default: false
     t.string "compensation_payment_over_100"
     t.string "compensation_receipt_sent"
     t.index ["check_group_id"], name: "index_disclosure_checks_on_check_group_id"


### PR DESCRIPTION
We removed the approximate motoring disqualification end date step in PR #424 but forgot to also remove this DB field, as it is no longer used in any other place.