### PR TITLE
Add new conviction date step

### DIFF
--- a/app/controllers/steps/conviction/conviction_date_controller.rb
+++ b/app/controllers/steps/conviction/conviction_date_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Conviction
+    class ConvictionDateController < Steps::ConvictionStepController
+      def edit
+        @form_object = ConvictionDateForm.build(current_disclosure_check)
+      end
+
+      def update
+        update_and_advance(ConvictionDateForm, as: :conviction_date)
+      end
+    end
+  end
+end

--- a/app/forms/steps/conviction/conviction_date_form.rb
+++ b/app/forms/steps/conviction/conviction_date_form.rb
@@ -1,0 +1,22 @@
+module Steps
+  module Conviction
+    class ConvictionDateForm < BaseForm
+      attribute :conviction_date, MultiParamDate
+      attribute :approximate_conviction_date, Boolean
+
+      validates_presence_of :conviction_date
+      validates :conviction_date, sensible_date: true
+
+      private
+
+      def persist!
+        raise DisclosureCheckNotFound unless disclosure_check
+
+        disclosure_check.update(
+          conviction_date: conviction_date,
+          approximate_conviction_date: approximate_conviction_date
+        )
+      end
+    end
+  end
+end

--- a/app/views/steps/conviction/conviction_date/edit.html.erb
+++ b/app/views/steps/conviction/conviction_date/edit.html.erb
@@ -1,0 +1,18 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_date_field :conviction_date, form_group: { classes: 'app-util--compact-form-group' } %>
+
+      <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
+        form: f, attribute: :approximate_conviction_date
+      } %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -30,6 +30,9 @@ en:
       known_date:
         edit:
           page_title: Start date
+      conviction_date:
+        edit:
+          page_title: Conviction date
       conviction_type:
         edit:
           page_title: Conviction type

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -19,6 +19,12 @@ en:
               blank: Enter the date the conditions ended in the format dd/mm/yyyy
               invalid: The date is too far in the past. Enter a date after 01/01/1940
               after_caution_date: The date conditions ended must be after the caution date
+        steps/conviction/conviction_date_form:
+          attributes:
+            conviction_date:
+              blank: Enter the date you were convicted in the format dd/mm/yyyy
+              invalid: The date is too far in the past. Enter a date after 01/01/1940
+              future: The date you were convicted can’t be in the future
         steps/conviction/known_date_form:
           attributes:
             known_date:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -8,8 +8,8 @@ en:
       This is usually the day you were convicted in court. If you do not know the exact date, you can enter an approximate one.
       <span class='nowrap'>For example, 23 9 2018</span>
     order_started_hint_text: &order_started_hint_text |
-      Enter the date your sentence or order started. This might be the day you were sentenced in court or the first day you were held on remand. If you do not know the exact date, you can enter an approximate one.
-      <p>For example, 23 9 2018</p>
+      Enter the date your sentence or order started. This might be the day you were convicted or sentenced in court, or the first day you were held on remand.
+      <p>If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span></p>
 
     approximate_date_legend: &approximate_date_legend "Approximate date"
     approximate_date_checkbox: &approximate_date_checkbox "This is not the exact date"
@@ -180,6 +180,8 @@ en:
         conviction_html: Select your age when you got convicted, not when you committed the offence
       steps_caution_conditional_end_date_form:
         conditional_end_date_html: "Enter the date you agreed the conditions would end. This might have included paying a fine or compensation. If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>"
+      steps_conviction_conviction_date_form:
+        conviction_date_html: This is the day you were found guilty of the offence. If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>
       steps_conviction_known_date_form:
         # default key
         default_html: *court_sentence_hint_text
@@ -268,6 +270,9 @@ en:
       steps_caution_caution_type_form:
         caution_type_options:
           <<: *CAUTION_TYPES
+      steps_conviction_conviction_date_form:
+        approximate_conviction_date_options:
+          'true': *approximate_date_checkbox
       steps_conviction_known_date_form:
         approximate_known_date_options:
           'true': *approximate_date_checkbox
@@ -318,6 +323,9 @@ en:
       steps_caution_conditional_end_date_form:
         conditional_end_date: When did the conditions end?
         approximate_conditional_end_date: *approximate_date_legend
+      steps_conviction_conviction_date_form:
+        conviction_date: When were you convicted?
+        approximate_conviction_date: *approximate_date_legend
       steps_conviction_known_date_form:
         approximate_known_date: *approximate_date_legend
         # default key

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     end
 
     namespace :conviction do
+      edit_step :conviction_date
       edit_step :known_date
       edit_step :conviction_type
       edit_step :conviction_subtype

--- a/db/migrate/20210201114508_add_conviction_date.rb
+++ b/db/migrate/20210201114508_add_conviction_date.rb
@@ -1,0 +1,6 @@
+class AddConvictionDate < ActiveRecord::Migration[5.2]
+  def change
+    add_column :disclosure_checks, :conviction_date, :date
+    add_column :disclosure_checks, :approximate_conviction_date, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_29_153053) do
+ActiveRecord::Schema.define(version: 2021_02_01_114508) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -48,6 +48,8 @@ ActiveRecord::Schema.define(version: 2021_01_29_153053) do
     t.boolean "approximate_compensation_payment_date", default: false
     t.string "compensation_payment_over_100"
     t.string "compensation_receipt_sent"
+    t.date "conviction_date"
+    t.boolean "approximate_conviction_date", default: false
     t.index ["check_group_id"], name: "index_disclosure_checks_on_check_group_id"
     t.index ["status"], name: "index_disclosure_checks_on_status"
   end

--- a/spec/controllers/steps/conviction/conviction_date_controller_spec.rb
+++ b/spec/controllers/steps/conviction/conviction_date_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Conviction::ConvictionDateController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Conviction::ConvictionDateForm, ConvictionDecisionTree
+end

--- a/spec/forms/steps/conviction/conviction_date_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_date_form_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Conviction::ConvictionDateForm do
+  it_behaves_like 'a date question form', attribute_name: :conviction_date
+end


### PR DESCRIPTION
Ticket: https://trello.com/c/1eRx0JeU

We need to capture and extra date, which will be needed for proper multiple sentences inside a conviction calculations.

Up until now for these calculations we've been using the `known_date` but that is incorrect as that's the date the sentence started. We need the date of the conviction, which might be different.

This PR only adds the new DB fields and controller/view/form but it does not link it yet to the decision tree, that will be done in a follow-up PR.

Also, once we have all this wired up, we will need to update th multiples calculators (uh oh).

<img width="682" alt="Screenshot 2021-02-01 at 12 15 09" src="https://user-images.githubusercontent.com/687910/106457647-2e97e080-6487-11eb-81ba-de72216bbe6e.png">
