### PR TITLE
Show conviction date step in multiples MVP

### DIFF
--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -8,7 +8,7 @@ class ChecksController < ApplicationController
         navigation_stack: navigation_stack,
         kind: CheckKind::CONVICTION.value,
         under_age: first_check_in_group.under_age,
-        known_date: first_check_in_group.known_date,
+        conviction_date: first_check_in_group.conviction_date,
         check_group: check_group
       )
 

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -25,7 +25,10 @@ class StepController < ApplicationController
         # Used when the step name in the decision tree is not the same as the first
         # (and usually only) attribute in the form.
         as:            opts[:as],
-        next_step:     @next_step
+        next_step:     @next_step,
+        # TODO: following is only for the multiples MVP while it is behind a feature flag.
+        # We propagate this to the decision trees as they don't have access to the session.
+        multiples_enabled: multiples_enabled?
       ).destination
 
       redirect_to destination

--- a/app/forms/steps/check/kind_form.rb
+++ b/app/forms/steps/check/kind_form.rb
@@ -25,7 +25,8 @@ module Steps
           under_age: nil,
           caution_type: nil,
           conviction_type: nil,
-          conviction_subtype: nil
+          conviction_subtype: nil,
+          conviction_date: nil
         )
       end
     end

--- a/app/forms/steps/conviction/conviction_subtype_form.rb
+++ b/app/forms/steps/conviction/conviction_subtype_form.rb
@@ -34,6 +34,7 @@ module Steps
         disclosure_check.update(
           conviction_subtype: conviction_subtype,
           # The following are dependent attributes that need to be reset if form changes
+          known_date: nil,
           conviction_bail: nil,
           conviction_bail_days: nil,
           conviction_length: nil,

--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -3,19 +3,23 @@ class BaseDecisionTree
 
   include ApplicationHelper
 
-  attr_reader :disclosure_check, :record, :step_params, :as, :next_step
+  attr_reader :disclosure_check, :record, :step_params,
+              :as, :next_step, :multiples_enabled
 
-  # rubocop:disable Naming/MethodParameterName
-  def initialize(disclosure_check:, record: nil, step_params: {}, as: nil, next_step: nil)
+  def initialize(disclosure_check:, record: nil, step_params: {}, **options)
     @disclosure_check = disclosure_check
     @record = record
     @step_params = step_params
-    @as = as
-    @next_step = next_step
+    @as = options[:as]
+    @next_step = options[:next_step]
+    @multiples_enabled = options[:multiples_enabled]
   end
-  # rubocop:enable Naming/MethodParameterName
 
   private
+
+  def multiples_enabled?
+    @multiples_enabled
+  end
 
   def step_value(attribute_name)
     step_params.fetch(attribute_name)

--- a/app/services/check_decision_tree.rb
+++ b/app/services/check_decision_tree.rb
@@ -19,6 +19,8 @@ class CheckDecisionTree < BaseDecisionTree
     when CheckKind::CAUTION
       edit('/steps/caution/caution_type')
     when CheckKind::CONVICTION
+      return edit('/steps/conviction/conviction_date') if multiples_enabled?
+
       edit('/steps/conviction/conviction_type')
     end
   end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -8,6 +8,8 @@ class ConvictionDecisionTree < BaseDecisionTree
     return next_step if next_step
 
     case step_name
+    when :conviction_date
+      edit(:conviction_type)
     when :conviction_type
       edit(:conviction_subtype)
     when :conviction_subtype
@@ -92,11 +94,7 @@ class ConvictionDecisionTree < BaseDecisionTree
     known_date_question
   end
 
-  # For multiples, all sentences given as part of the same conviction
-  # share the same start date so we don't need to ask this for each one.
   def known_date_question
-    return after_known_date if disclosure_check.check_group.multiple_sentences?
-
     edit(:known_date)
   end
 end

--- a/spec/controllers/checks_controller_spec.rb
+++ b/spec/controllers/checks_controller_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe ChecksController, type: :controller do
     end
 
     context 'when there is a disclosure check in the session' do
-      let(:disclosure_check) { create(:disclosure_check) }
+      let(:disclosure_check) { create(:disclosure_check, conviction_date: conviction_date) }
       let(:disclosure_report) { disclosure_check.disclosure_report }
+      let(:conviction_date) { Date.new(2018, 10, 25) }
 
       before do
         allow(controller).to receive(:current_disclosure_check).and_return(disclosure_check)
@@ -73,8 +74,8 @@ RSpec.describe ChecksController, type: :controller do
           # have happened at the same age
           expect(last_check.under_age).to eq(GenericYesNo::YES.to_s)
 
-          # we default the start date, as all sentences in the same conviction starts in the same date
-          expect(last_check.known_date).to eq(disclosure_check.known_date)
+          # we default the conviction date, as all sentences in the same conviction share this date
+          expect(last_check.conviction_date).to eq(conviction_date)
 
           # the back link should point to CYA page
           expect(last_check.navigation_stack).to eq([steps_check_check_your_answers_path])

--- a/spec/forms/steps/check/kind_form_spec.rb
+++ b/spec/forms/steps/check/kind_form_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe Steps::Check::KindForm do
           under_age: nil,
           caution_type: nil,
           conviction_type: nil,
-          conviction_subtype: nil
+          conviction_subtype: nil,
+          conviction_date: nil
         ).and_return(true)
 
         expect(subject.save).to be(true)

--- a/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Steps::Conviction::ConvictionSubtypeForm do
         expect(disclosure_check).to receive(:update).with(
           conviction_subtype: conviction_subtype,
           # Dependent attributes to be reset
+          known_date: nil,
           conviction_bail: nil,
           conviction_bail_days: nil,
           conviction_length: nil,

--- a/spec/services/check_decision_tree_spec.rb
+++ b/spec/services/check_decision_tree_spec.rb
@@ -15,7 +15,13 @@ RSpec.describe CheckDecisionTree do
   let(:kind)             { nil }
   let(:under_age)        { nil }
 
-  subject { described_class.new(disclosure_check: disclosure_check, step_params: step_params, as: as, next_step: next_step) }
+  let(:multiples_enabled) { false }
+
+  subject {
+    described_class.new(
+      disclosure_check: disclosure_check, step_params: step_params, as: as, next_step: next_step, multiples_enabled: multiples_enabled
+    )
+  }
 
   it_behaves_like 'a decision tree'
 
@@ -29,6 +35,7 @@ RSpec.describe CheckDecisionTree do
 
     context 'and answer is `no`' do
       let(:under_age) { GenericYesNo::NO }
+
       context 'for a caution check' do
         let(:kind) { 'caution' }
         it { is_expected.to have_destination('/steps/caution/caution_type', :edit) }
@@ -36,7 +43,15 @@ RSpec.describe CheckDecisionTree do
 
       context 'for a conviction check' do
         let(:kind) { 'conviction' }
-        it { is_expected.to have_destination('/steps/conviction/conviction_type', :edit) }
+
+        context 'and multiples MVP is enabled' do
+          let(:multiples_enabled) { true }
+          it { is_expected.to have_destination('/steps/conviction/conviction_date', :edit) }
+        end
+
+        context 'and multiples MVP is disabled' do
+          it { is_expected.to have_destination('/steps/conviction/conviction_type', :edit) }
+        end
       end
     end
 

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ConvictionDecisionTree do
   let(:disclosure_check) do
     instance_double(
       DisclosureCheck,
-      check_group: check_group,
       conviction_type: conviction_type,
       conviction_subtype: conviction_subtype,
       compensation_paid: compensation_paid,
@@ -24,30 +23,17 @@ RSpec.describe ConvictionDecisionTree do
   let(:compensation_payment_over_100) { nil }
   let(:compensation_receipt_sent) { nil }
 
-  let(:check_group) { instance_double(CheckGroup, multiple_sentences?: multiple_sentences) }
-  let(:multiple_sentences) { false }
-
   subject { described_class.new(disclosure_check: disclosure_check, step_params: step_params, as: as, next_step: next_step) }
 
   it_behaves_like 'a decision tree'
 
-  context 'when the step is `known_date` ' do
-    let(:step_params) { { known_date: 'anything' } }
-
-    context 'when subtype has length' do
-      let(:conviction_subtype) { :detention_training_order }
-      it { is_expected.to have_destination(:conviction_length_type, :edit) }
-    end
-
-    context 'when subtype does not have length' do
-      let(:conviction_subtype) { :fine }
-      it { is_expected.to complete_the_check_and_show_results }
-    end
+  context 'when the step is `conviction_date`' do
+    let(:step_params) { { conviction_date: 'date' } }
+    it { is_expected.to have_destination(:conviction_type, :edit) }
   end
 
   context 'when the step is `conviction_type`' do
-    let(:step_params) { { conviction_type: conviction_type } }
-    let(:conviction_type) { 'referral_supervision_yro' }
+    let(:step_params) { { conviction_type: 'foobar' } }
     it { is_expected.to have_destination(:conviction_subtype, :edit) }
   end
 
@@ -71,15 +57,7 @@ RSpec.describe ConvictionDecisionTree do
 
       context 'when subtype equal youth_penalty_points' do
         let(:conviction_subtype) { :youth_penalty_points }
-
-        context 'for a new sentence in an existing conviction' do
-          let(:multiple_sentences) { true }
-          it { is_expected.to complete_the_check_and_show_results }
-        end
-
-        context 'for a new conviction' do
-          it { is_expected.to have_destination(:known_date, :edit) }
-        end
+        it { is_expected.to have_destination(:known_date, :edit) }
       end
     end
 
@@ -93,15 +71,7 @@ RSpec.describe ConvictionDecisionTree do
 
       context 'when subtype equal adult_penalty_points' do
         let(:conviction_subtype) { :adult_penalty_points }
-
-        context 'for a new sentence in an existing conviction' do
-          let(:multiple_sentences) { true }
-          it { is_expected.to complete_the_check_and_show_results }
-        end
-
-        context 'for a new conviction' do
-          it { is_expected.to have_destination(:known_date, :edit) }
-        end
+        it { is_expected.to have_destination(:known_date, :edit) }
       end
     end
 
@@ -111,14 +81,21 @@ RSpec.describe ConvictionDecisionTree do
     end
 
     context 'for any other conviction subtypes' do
-      context 'for a new sentence in an existing conviction' do
-        let(:multiple_sentences) { true }
-        it { is_expected.to have_destination(:conviction_length_type, :edit) }
-      end
+      it { is_expected.to have_destination(:known_date, :edit) }
+    end
+  end
 
-      context 'for a new conviction' do
-        it { is_expected.to have_destination(:known_date, :edit) }
-      end
+  context 'when the step is `known_date` ' do
+    let(:step_params) { { known_date: 'anything' } }
+
+    context 'when subtype has length' do
+      let(:conviction_subtype) { :detention_training_order }
+      it { is_expected.to have_destination(:conviction_length_type, :edit) }
+    end
+
+    context 'when subtype does not have length' do
+      let(:conviction_subtype) { :fine }
+      it { is_expected.to complete_the_check_and_show_results }
     end
   end
 


### PR DESCRIPTION
Ticket: https://trello.com/c/1eRx0JeU

Ask this new date, but only if we are running the "multiples" MVP (so it will not show for simples or in production).
Revert some of the changes introduced in PR #429.

Unfortunately to do this we have to add some conditional code and propagate the `multiples_enabled` boolean to the decision trees as these do not have access to the controller/session and can't read the cookie.

In a follow-up PR the calculators will need to be updated.