### PR TITLE
Validate `known_date` against the `conviction_date`

### DIFF
--- a/app/forms/steps/conviction/known_date_form.rb
+++ b/app/forms/steps/conviction/known_date_form.rb
@@ -6,6 +6,7 @@ module Steps
 
       validates_presence_of :known_date
       validates :known_date, sensible_date: true
+      validate :after_conviction_date?
 
       # As we reuse this form object in multiple views, this is the attribute
       # that will be used to choose the locales for legends and hints.
@@ -14,6 +15,12 @@ module Steps
       end
 
       private
+
+      def after_conviction_date?
+        return if known_date.blank? || disclosure_check.conviction_date.blank?
+
+        errors.add(:known_date, :after_conviction_date) if known_date < disclosure_check.conviction_date
+      end
 
       def persist!
         raise DisclosureCheckNotFound unless disclosure_check

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -28,9 +28,10 @@ en:
         steps/conviction/known_date_form:
           attributes:
             known_date:
-              blank: Enter the date of the conviction in the format dd/mm/yyyy
+              blank: Enter the date in the format dd/mm/yyyy
               invalid: The date is too far in the past. Enter a date after 01/01/1940
-              future: The date of the conviction can’t be in the future
+              future: The date can’t be in the future
+              after_conviction_date: The date can’t be before the conviction date
         steps/conviction/conviction_type_form:
           attributes:
             conviction_type:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -8,7 +8,7 @@ en:
       This is usually the day you were convicted in court. If you do not know the exact date, you can enter an approximate one.
       <span class='nowrap'>For example, 23 9 2018</span>
     order_started_hint_text: &order_started_hint_text |
-      Enter the date your sentence or order started. This might be the day you were convicted or sentenced in court, or the first day you were held on remand.
+      This is usually the day you were convicted or sentenced in court, or the first day you were held on remand.
       <p>If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span></p>
 
     approximate_date_legend: &approximate_date_legend "Approximate date"

--- a/features/fixtures/files/steps_conviction_known_date_with_errors.html
+++ b/features/fixtures/files/steps_conviction_known_date_with_errors.html
@@ -7,7 +7,7 @@
 <span class="nowrap">For example, 23 9 2018</span></span>
 
 <span class="govuk-error-message" id="steps-conviction-known-date-form-known-date-error">
-  <span class="govuk-visually-hidden">Error: </span>Enter the date of the conviction in the format dd/mm/yyyy</span>
+  <span class="govuk-visually-hidden">Error: </span>Enter the date in the format dd/mm/yyyy</span>
   <div class="govuk-date-input">
     <div class="govuk-date-input__item">
       <div class="govuk-form-group">

--- a/spec/forms/steps/conviction/known_date_form_spec.rb
+++ b/spec/forms/steps/conviction/known_date_form_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Conviction::KnownDateForm do
-  it_behaves_like 'a date question form', attribute_name: :known_date
+  it_behaves_like 'a date question form', attribute_name: :known_date do
+    before do
+      allow(subject).to receive(:after_conviction_date?).and_return(true)
+    end
+  end
 
   describe '#i18n_attribute' do
     before do
@@ -10,6 +14,65 @@ RSpec.describe Steps::Conviction::KnownDateForm do
 
     it 'returns the key that will be used to translate legends and hints' do
       expect(subject.i18n_attribute).to eq(:foobar)
+    end
+  end
+
+  context '#after_conviction_date? validation' do
+    let(:disclosure_check) { instance_double(DisclosureCheck, conviction_date: conviction_date, known_date: known_date) }
+    let(:known_date) { nil }
+    let(:conviction_date) { nil }
+    let(:arguments) {
+      {
+        disclosure_check: disclosure_check,
+        known_date: known_date
+      }
+    }
+
+    subject { described_class.new(arguments) }
+
+    context 'when `known_date` is before the conviction date' do
+      let(:conviction_date) { Date.today }
+      let(:known_date) { Date.yesterday }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.added?(:known_date, :after_conviction_date)).to eq(true)
+      end
+    end
+
+    context 'when `known_date` is after the conviction date' do
+      let(:conviction_date) { Date.current - 3.days }
+      let(:known_date) { Date.current - 1.day }
+
+      it 'has no validation errors on the field' do
+        expect(subject).to be_valid
+        expect(subject.errors.added?(:known_date, :after_conviction_date)).to eq(false)
+      end
+    end
+
+    context 'when `conviction_date` is `nil`' do
+      let(:conviction_date) { nil }
+      let(:known_date) { Date.current }
+
+      it 'has no validation errors on the field' do
+        expect(subject).to be_valid
+        expect(subject.errors.added?(:known_date, :after_conviction_date)).to eq(false)
+      end
+    end
+
+    context 'when `known_date` is `nil`' do
+      let(:conviction_date) { Date.current }
+      let(:known_date) { nil }
+
+      it 'has a presence error' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.added?(:known_date, :after_conviction_date)).to eq(false)
+        expect(subject.errors.added?(:known_date, :blank)).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
Ticket: https://trello.com/c/1eRx0JeU

Little follow-up to PR #435 to add a validation to the form so the `known_date` can't be *before* the `conviction_date` as that would not make sense and could invalidate the calculations without the user even noticing.

If `conviction_date` or `known_date` are `nil` then we don't perform this validation (currently for "simples" the `conviction_date` is always nil so we must maintain backwards compatibility).