### PR TITLE
Use the `conviction_date` in multiples calculator

### DIFF
--- a/app/services/base_multiples_calculator.rb
+++ b/app/services/base_multiples_calculator.rb
@@ -6,7 +6,7 @@ class BaseMultiplesCalculator
   end
 
   def kind
-    CheckKind.find_constant(disclosure_checks.first.kind)
+    CheckKind.find_constant(first_disclosure_check.kind)
   end
 
   def conviction?
@@ -21,9 +21,10 @@ class BaseMultiplesCalculator
     spent_date.past?
   end
 
-  def start_date
-    # Pick the earliest date in the collection
-    disclosure_checks.map(&:known_date).min
+  # When there are more than one sentence (checks),
+  # all will share the same conviction date.
+  def conviction_date
+    first_disclosure_check.conviction_date
   end
 
   # :nocov:
@@ -36,6 +37,10 @@ class BaseMultiplesCalculator
 
   def disclosure_checks
     @_disclosure_checks ||= check_group.disclosure_checks
+  end
+
+  def first_disclosure_check
+    @_first_disclosure_check ||= disclosure_checks.first
   end
 
   def expiry_date_for(check)

--- a/app/services/calculators/multiples/multiple_offenses_calculator.rb
+++ b/app/services/calculators/multiples/multiple_offenses_calculator.rb
@@ -25,12 +25,14 @@ module Calculators
         # Cautions are always dealt with separately and do not have drag-through
         return spent_date unless proceeding.conviction?
 
-        # We have to loop through the rest of convictions and check if the spent date
-        # of this group overlaps with the spent date of another group and if so, then
-        # the spent date of this group becomes the spent date of the other group.
+        # We have to loop through all the convictions and check if the spent date
+        # of this conviction overlaps with the rehabilitation of another one and if so,
+        # then the spent date of this conviction becomes the spent date of the other.
         #
-        convictions_by_start_date.each do |conviction|
-          other_start_date = conviction.start_date
+        convictions_by_date.each do |conviction|
+          next if proceeding == conviction
+
+          other_conviction_date = conviction.conviction_date
           other_spent_date = conviction.spent_date
 
           spent_date = ResultsVariant::NEVER_SPENT if other_spent_date == ResultsVariant::NEVER_SPENT
@@ -40,7 +42,7 @@ module Calculators
           next unless spent_date.is_a?(Date)
 
           # If the spent date falls inside another rehabilitation, we do drag-through
-          spent_date = other_spent_date if spent_date.in?(other_start_date..other_spent_date)
+          spent_date = other_spent_date if spent_date.in?(other_conviction_date..other_spent_date)
         end
 
         spent_date
@@ -52,8 +54,8 @@ module Calculators
 
       private
 
-      def convictions_by_start_date
-        @_convictions ||= proceedings.select(&:conviction?).sort_by(&:start_date)
+      def convictions_by_date
+        @_convictions ||= proceedings.select(&:conviction?).sort_by(&:conviction_date)
       end
 
       def process!

--- a/app/services/calculators/multiples/separate_proceedings.rb
+++ b/app/services/calculators/multiples/separate_proceedings.rb
@@ -9,7 +9,7 @@ module Calculators
 
       # The only check inside this group
       def disclosure_check
-        @_disclosure_check ||= disclosure_checks.first
+        @_disclosure_check ||= first_disclosure_check
       end
     end
   end

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
 
     trait :conviction do
       kind { CheckKind::CONVICTION }
+      conviction_date { Date.new(2018, 1, 1) }
       known_date { nil }
       caution_type { nil }
     end
@@ -35,7 +36,7 @@ FactoryBot.define do
     end
 
     trait :dto_conviction do
-      kind { CheckKind::CONVICTION }
+      conviction_with_known_date
       conviction_type { ConvictionType::CUSTODIAL_SENTENCE }
       conviction_subtype { ConvictionType::DETENTION_TRAINING_ORDER }
       conviction_length { 9 }
@@ -43,7 +44,7 @@ FactoryBot.define do
     end
 
     trait :compensation do
-      kind { CheckKind::CONVICTION }
+      conviction_with_known_date
       conviction_type { ConvictionType::FINANCIAL }
       conviction_subtype { ConvictionType::COMPENSATION_TO_A_VICTIM }
       compensation_payment_date { Date.new(2019, 10, 31) }
@@ -59,8 +60,8 @@ FactoryBot.define do
     end
 
     trait :suspended_prison_sentence do
-      under_age { GenericYesNo::NO }
-      kind { CheckKind::CONVICTION }
+      conviction_with_known_date
+      adult
       conviction_type { ConvictionType::ADULT_CUSTODIAL_SENTENCE }
       conviction_subtype { ConvictionType::ADULT_SUSPENDED_PRISON_SENTENCE }
       conviction_length_type { ConvictionLengthType::MONTHS }

--- a/spec/services/calculators/multiples/same_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/same_proceedings_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Calculators::Multiples::SameProceedings do
 
   let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check1, disclosure_check2, disclosure_check3]) }
 
-  let(:disclosure_check1) { instance_double(DisclosureCheck, kind: 'conviction', known_date: known_date1) }
-  let(:disclosure_check2) { instance_double(DisclosureCheck, kind: 'conviction', known_date: known_date2) }
-  let(:disclosure_check3) { instance_double(DisclosureCheck, kind: 'conviction', known_date: known_date3) }
+  let(:disclosure_check1) { instance_double(DisclosureCheck, kind: 'conviction', conviction_date: conviction_date) }
+  let(:disclosure_check2) { instance_double(DisclosureCheck, kind: 'conviction') }
+  let(:disclosure_check3) { instance_double(DisclosureCheck, kind: 'conviction') }
 
   let(:check_result1) { instance_double(CheckResult, expiry_date: Date.new(2015, 10, 31)) }
   let(:check_result2) { instance_double(CheckResult, expiry_date: Date.new(2018, 10, 31)) }
@@ -16,9 +16,7 @@ RSpec.describe Calculators::Multiples::SameProceedings do
   let(:check_never_spent) { instance_double(CheckResult, expiry_date: ResultsVariant::NEVER_SPENT) }
   let(:check_indefinite) { instance_double(CheckResult, expiry_date: ResultsVariant::INDEFINITE) }
 
-  let(:known_date1) { Date.new(2018, 1, 1) }
-  let(:known_date2) { Date.new(2015, 1, 1) }
-  let(:known_date3) { Date.new(2016, 1, 1) }
+  let(:conviction_date) { Date.new(2018, 1, 1) }
 
   describe '#kind' do
     it 'is always conviction for same proceedings' do
@@ -32,9 +30,9 @@ RSpec.describe Calculators::Multiples::SameProceedings do
     end
   end
 
-  context '#start_date' do
-    it 'returns the earliest known date from all the dates' do
-      expect(subject.start_date).to eq(known_date2)
+  context '#conviction_date' do
+    it 'returns the date of the conviction (using the first sentence)' do
+      expect(subject.conviction_date).to eq(conviction_date)
     end
   end
 

--- a/spec/services/calculators/multiples/separate_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/separate_proceedings_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Calculators::Multiples::SeparateProceedings do
   subject { described_class.new(check_group) }
 
   let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check]) }
-  let(:disclosure_check) { instance_double(DisclosureCheck, kind: kind, known_date: known_date) }
+  let(:disclosure_check) { instance_double(DisclosureCheck, kind: kind, conviction_date: conviction_date) }
 
   let(:check_result) { instance_double(CheckResult, expiry_date: expiry_date) }
-  let(:known_date) { Date.new(2015, 12, 25) }
+  let(:conviction_date) { Date.new(2015, 12, 25) }
   let(:expiry_date) { Date.new(2018, 10, 31) }
   let(:kind) { nil }
 
@@ -35,9 +35,9 @@ RSpec.describe Calculators::Multiples::SeparateProceedings do
     end
   end
 
-  context '#start_date' do
-    it 'returns the known date of the caution or conviction' do
-      expect(subject.start_date).to eq(known_date)
+  context '#conviction_date' do
+    it 'returns the date of the conviction' do
+      expect(subject.conviction_date).to eq(conviction_date)
     end
   end
 


### PR DESCRIPTION
Ticket: https://trello.com/c/1eRx0JeU

Instead of the `start_date` (which is the `known_date` DB field), we need to use the new `conviction_date` because although some times both dates can be the same, when deciding if a spent date falls inside another rehabilitation period, we have to use the date of the conviction, not when the sentence or order started, as per legal clarification.