### PR TITLE
Swap order of `indefinite` and `no_length` radio options

### DIFF
--- a/app/services/conviction_length_choices.rb
+++ b/app/services/conviction_length_choices.rb
@@ -10,11 +10,11 @@ class ConvictionLengthChoices
   def self.choices(conviction_subtype:)
     choices = ConvictionLengthType.values.dup
 
-    # Big majority of orders show the `no_length` option, just a few exceptions
-    choices.delete(ConvictionLengthType::NO_LENGTH) if SUBTYPES_HIDE_NO_LENGTH_CHOICE.include?(conviction_subtype)
-
     # Only `relevant orders` will show the `indefinite` length option
     choices.delete(ConvictionLengthType::INDEFINITE) unless conviction_subtype.relevant_order?
+
+    # Big majority of orders show the `no_length` option, just a few exceptions
+    choices.delete(ConvictionLengthType::NO_LENGTH) if SUBTYPES_HIDE_NO_LENGTH_CHOICE.include?(conviction_subtype)
 
     choices
   end

--- a/app/value_objects/conviction_length_type.rb
+++ b/app/value_objects/conviction_length_type.rb
@@ -3,8 +3,8 @@ class ConvictionLengthType < ValueObject
     WEEKS = new(:weeks),
     MONTHS = new(:months),
     YEARS = new(:years),
-    NO_LENGTH = new(:no_length),
     INDEFINITE = new(:indefinite),
+    NO_LENGTH = new(:no_length),
   ].freeze
 
   def without_length?

--- a/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Steps::Conviction::ConvictionLengthTypeForm do
             ConvictionLengthType.new(:weeks),
             ConvictionLengthType.new(:months),
             ConvictionLengthType.new(:years),
-            ConvictionLengthType.new(:no_length),
             ConvictionLengthType.new(:indefinite),
+            ConvictionLengthType.new(:no_length),
           ]
         )
       end

--- a/spec/services/conviction_length_choices_spec.rb
+++ b/spec/services/conviction_length_choices_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe ConvictionLengthChoices do
       ConvictionLengthType::WEEKS,
       ConvictionLengthType::MONTHS,
       ConvictionLengthType::YEARS,
-      ConvictionLengthType::NO_LENGTH,
       ConvictionLengthType::INDEFINITE,
+      ConvictionLengthType::NO_LENGTH,
     ]
   }
 

--- a/spec/value_objects/conviction_length_type_spec.rb
+++ b/spec/value_objects/conviction_length_type_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe ConvictionLengthType do
         weeks
         months
         years
-        no_length
         indefinite
+        no_length
       ))
     end
   end


### PR DESCRIPTION
A recommendation from legal to change the order of the `indefinite` and `no_length` radio options, so the `no_length` is the last one, and kind of a "catch-all" option.

This does not affect calculations in any way and is only a minor interface change.

<img width="656" alt="Screenshot 2021-02-02 at 12 51 31" src="https://user-images.githubusercontent.com/687910/106603225-edbacd00-6555-11eb-8e19-688e07e03517.png">
