### PR TITLE
Adds method #relevant_order? to DisclosureCheck

### DIFF
--- a/app/models/disclosure_check.rb
+++ b/app/models/disclosure_check.rb
@@ -6,4 +6,8 @@ class DisclosureCheck < ApplicationRecord
     in_progress: 0,
     completed: 10,
   }
+
+  def relevant_order?
+    ConvictionType.find_constant(conviction_subtype).relevant_order?
+  end
 end

--- a/spec/models/disclosure_check_spec.rb
+++ b/spec/models/disclosure_check_spec.rb
@@ -4,4 +4,22 @@ RSpec.describe DisclosureCheck, type: :model do
   subject { described_class.new(attributes) }
 
   let(:attributes) { {} }
+
+  describe '#relevant_order?' do
+    context 'when conviction_subtype is nil' do
+      it { expect { subject.relevant_order? }.to raise_error(NoMethodError) }
+    end
+
+    context 'when conviction_subtype is not a relevant order' do
+      let(:attributes) { super().merge(conviction_subtype: 'absolute_discharge') }
+
+      it { expect(subject.relevant_order?).to be false }
+    end
+
+    context 'when conviction_subtype is a relevant order' do
+      let(:attributes) { super().merge(conviction_subtype: 'conditional_discharge') }
+
+      it { expect(subject.relevant_order?).to be true }
+    end
+  end
 end


### PR DESCRIPTION
It's necessary to identify which disclosure check objects have a conviction subtype that is identified as a relevant order.

A relevant order has an important role when it comes to 'drag through' other convictions within the same timeline, meaning, relevant orders only relate to the conviction that they’re linked to, they don’t ‘drag through’ other convictions.

Therefore, a relevant order sentence shall not influence another conviction that it's not part of.

Consider the following scenario:

Marisa, age 38, a company director was convicted on **02/08/15** of fraud.

As a result, she received:
-  a six-month custodial sentence (would become ‘spent’ **02/02/18**) and;
-  a six-year company director disqualification (would become ‘spent’ **02/08/21**).

The fraud conviction would therefore become ‘spent’ on **02/08/21** as the _company director disqualification_ (a *relevant order*) has the longest rehabilitation period in the proceedings.

A few years later, Marisa was convicted of drugs possession on 19/05/18 and received:
- a 12-month community order which may become ‘spent’ on 19/05/20 .

Although the drugs conviction overlaps with her first conviction, it will still become ‘spent’ on 19/05/20 as it only overlaps
with the company director disqualification (a relevant order).

As the company director disqualification is a relevant order it **will not** be used to extend the rehabilitation order of the second conviction.

---

Therefore, even though the longest date of the first conviction is the relevant order, which surpasses the spent date of the second (separate conviction) it does not affect the date the second conviction is spent because it's a relevant order, meaning that there is no 'drag through' effect.

Story: https://trello.com/c/ImE62qTS