### PR TITLE
More tweaks to the MultipleOffensesCalculator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   NewCops: enable
   Exclude:
     - './*'

--- a/app/value_objects/results_variant.rb
+++ b/app/value_objects/results_variant.rb
@@ -7,6 +7,17 @@ class ResultsVariant < ValueObject
     INDEFINITE   = new(:indefinite),
   ].freeze
 
+  # Needed so we are able to do ranges and compare dates with special variants
+  def to_date
+    case self
+    when NEVER_SPENT
+      Date::Infinity.new
+    when INDEFINITE
+      # absurdly in the future, but sooner than "infinity"
+      Date.new(2049, 1, 1)
+    end
+  end
+
   def self.values
     VALUES
   end

--- a/spec/value_objects/results_variant_spec.rb
+++ b/spec/value_objects/results_variant_spec.rb
@@ -12,4 +12,34 @@ RSpec.describe ResultsVariant do
       ))
     end
   end
+
+  describe '#to_date' do
+    subject { described_class.new(value) }
+
+    context 'when the variant is `never_spent`' do
+      let(:value) { 'never_spent' }
+
+      it 'considers an infinity date' do
+        expect(subject.to_date).to eq(Date::Infinity.new)
+      end
+    end
+
+    context 'when the variant is `indefinite`' do
+      let(:value) { 'indefinite' }
+
+      it 'considers a very far in the future date but not infinite' do
+        expect(subject.to_date).to eq(Date.new(2049, 1, 1))
+      end
+    end
+
+    # This is just a smoke test, it should not fail unless this service
+    # and the code has been around for maaaaany years LOL.
+    context 'when current date is over the `indefinite` date' do
+      let(:value) { 'indefinite' }
+
+      it 'fails if the `indefinite` date is no longer in the future' do
+        expect(subject.to_date.future?).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://trello.com/c/PcAlcOaz

This work relates to the edge case where under certain circunstances a never spent, or indefinite conviction could take over the other convictions even if there was no overlapping between them.

In doing this I realised the loop can be simplified further, if we trick the special variants into behave like a Date in terms of ranges.

What this means is:
- A `ResultsVariant::NEVER_SPENT` is like an infinity date, it has no end.
- A `ResultsVariant::INDEFINITE` is a very far in the future date, but is not infinity (this difference is important as one takes precedence over the other).

There might be further tweaks/fixes to do and also it is still pending the work for relevant orders that _might_ affect the loop or the date we need to use on it. But that will come in separate PR(s).