### PR TITLE
Adds methods to identify and ignore relevant orders to BaseMultiplesCalculator

### DIFF
--- a/app/services/base_multiples_calculator.rb
+++ b/app/services/base_multiples_calculator.rb
@@ -33,6 +33,10 @@ class BaseMultiplesCalculator
   end
   # :nocov:
 
+  def without_relevant_orders
+    (disclosure_checks - relevant_orders)
+  end
+
   private
 
   def disclosure_checks
@@ -41,6 +45,10 @@ class BaseMultiplesCalculator
 
   def first_disclosure_check
     @_first_disclosure_check ||= disclosure_checks.first
+  end
+
+  def relevant_orders
+    @_relevant_orders ||= disclosure_checks.select(&:relevant_order?)
   end
 
   def expiry_date_for(check)

--- a/spec/services/calculators/multiples/same_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/same_proceedings_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Calculators::Multiples::SameProceedings do
 
   let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check1, disclosure_check2, disclosure_check3]) }
 
-  let(:disclosure_check1) { instance_double(DisclosureCheck, kind: 'conviction', conviction_date: conviction_date) }
-  let(:disclosure_check2) { instance_double(DisclosureCheck, kind: 'conviction') }
-  let(:disclosure_check3) { instance_double(DisclosureCheck, kind: 'conviction') }
+  let(:disclosure_check1) { instance_double(DisclosureCheck, kind: 'conviction', conviction_date: conviction_date, relevant_order?: false) }
+  let(:disclosure_check2) { instance_double(DisclosureCheck, kind: 'conviction', relevant_order?: false) }
+  let(:disclosure_check3) { instance_double(DisclosureCheck, kind: 'conviction', relevant_order?: true) }
 
   let(:check_result1) { instance_double(CheckResult, expiry_date: Date.new(2015, 10, 31)) }
   let(:check_result2) { instance_double(CheckResult, expiry_date: Date.new(2018, 10, 31)) }
@@ -65,6 +65,13 @@ RSpec.describe Calculators::Multiples::SameProceedings do
       it 'returns `indefinite`' do
         expect(subject.spent_date).to eq(ResultsVariant::INDEFINITE)
       end
+    end
+  end
+
+  describe '#without_relevant_orders' do
+    it 'does not return relevant orders' do
+      expect(subject.without_relevant_orders).not_to include(disclosure_check3)
+      expect(subject.without_relevant_orders).to include(disclosure_check1, disclosure_check2)
     end
   end
 end

--- a/spec/services/calculators/multiples/separate_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/separate_proceedings_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Calculators::Multiples::SeparateProceedings do
   subject { described_class.new(check_group) }
 
   let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check]) }
-  let(:disclosure_check) { instance_double(DisclosureCheck, kind: kind, conviction_date: conviction_date) }
+  let(:disclosure_check) { instance_double(DisclosureCheck, kind: kind, conviction_date: conviction_date, relevant_order?: false) }
 
   let(:check_result) { instance_double(CheckResult, expiry_date: expiry_date) }
   let(:conviction_date) { Date.new(2015, 12, 25) }
@@ -50,6 +50,24 @@ RSpec.describe Calculators::Multiples::SeparateProceedings do
 
     it 'calculates and returns the spent date of the caution or conviction' do
       expect(subject.spent_date).to eq(expiry_date)
+    end
+  end
+
+  describe '#without_relevant_orders' do
+    context 'when a disclosure_check is not a relevant order' do
+      it 'includes the disclosure_check' do
+        expect(subject.without_relevant_orders).to include(disclosure_check)
+      end
+    end
+
+    context 'when a disclosure_check is a relevant order' do
+      let(:disclosure_check) { instance_double(DisclosureCheck, kind: kind, conviction_date: conviction_date, relevant_order?: true) }
+
+      it 'does not include the disclosure_check' do
+        expect(subject.without_relevant_orders).not_to include(disclosure_check)
+      end
+
+      it { expect(subject.without_relevant_orders).to be_empty }
     end
   end
 end


### PR DESCRIPTION
Follow up on #442 where the method `#relevant_order?` was added to DisclosureCheck.
And taken the idea of ignoring relevant orders from #438 

We need this capabilities of ignoring relevant orders when comparing two convictions,
relevant orders only affect their own Conviction without interfering with other Convictions.

By discarding the relevant orders, we will be able to loop through several
convictions without compromising their spent date with the relevant order spent
date.

I've added this method in BaseMultiplesCalculator as I think we may need the
method in both SameProceedings and SeparateProceedings so that it can be used
in MultipleOffensesCalculator.

This addition is a non-breaking change to current behaviour.

Story: https://trello.com/c/7scNWWCF/