### PR TITLE
Add multiple convictions test scenarios and tweak the calculator

### DIFF
--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -335,6 +335,55 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
         expect(subject.spent_date_for(conviction_4)).to eq(Date.new(2025, 12, 31))
       end
     end
+
+    context '4 separate proceedings convictions (3 has a spent date and 4 has never spent)' do
+      before do
+        allow(subject).to receive(:proceedings).and_return([conviction_1, conviction_2, conviction_3, conviction_4])
+      end
+
+      let(:conviction_1) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2020, 1, 1),
+          spent_date: Date.new(2021, 1, 1),
+        )
+      }
+
+      let(:conviction_2) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2020, 6, 1),
+          spent_date: Date.new(2021, 1, 1),
+        )
+      }
+
+      let(:conviction_3) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2023, 1, 1),
+          spent_date: Date.new(2026, 1, 1),
+        )
+      }
+
+      let(:conviction_4) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2025, 1, 1),
+          spent_date: ResultsVariant::NEVER_SPENT,
+        )
+      }
+
+      it 'returns the spent date for the matching check group' do
+        expect(subject.spent_date_for(conviction_1)).to eq(Date.new(2021, 1, 1))
+        expect(subject.spent_date_for(conviction_2)).to eq(Date.new(2021, 1, 1))
+        expect(subject.spent_date_for(conviction_3)).to eq(ResultsVariant::NEVER_SPENT)
+        expect(subject.spent_date_for(conviction_4)).to eq(ResultsVariant::NEVER_SPENT)
+      end
+    end
   end
 
   describe '#all_spent?' do

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -286,6 +286,55 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
         expect(subject.spent_date_for(conviction_3)).to eq(Date.new(2025, 1, 1))
       end
     end
+
+    context '4 separate proceedings convictions' do
+      before do
+        allow(subject).to receive(:proceedings).and_return([conviction_1, conviction_2, conviction_3, conviction_4])
+      end
+
+      let(:conviction_1) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2020, 1, 1),
+          spent_date: Date.new(2021, 1, 1),
+        )
+      }
+
+      let(:conviction_2) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2020, 6, 1),
+          spent_date: Date.new(2021, 1, 1),
+        )
+      }
+
+      let(:conviction_3) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2023, 1, 1),
+          spent_date: ResultsVariant::NEVER_SPENT,
+        )
+      }
+
+      let(:conviction_4) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2025, 1, 1),
+          spent_date: Date.new(2025, 12, 31),
+        )
+      }
+
+      it 'returns the spent date for the matching check group' do
+        expect(subject.spent_date_for(conviction_1)).to eq(Date.new(2021, 1, 1))
+        expect(subject.spent_date_for(conviction_2)).to eq(Date.new(2021, 1, 1))
+        expect(subject.spent_date_for(conviction_3)).to eq(ResultsVariant::NEVER_SPENT)
+        expect(subject.spent_date_for(conviction_4)).to eq(Date.new(2025, 12, 31))
+      end
+    end
   end
 
   describe '#all_spent?' do

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
 
   before do
     # Note: because these are doubles, the method does not work, so we emulate it
-    allow(check_group1).to receive(:multiple_sentences?).and_return(check_group1.disclosure_checks.size > 1)
-    allow(check_group2).to receive(:multiple_sentences?).and_return(check_group2.disclosure_checks.size > 1)
+    allow(check_group1).to receive(:multiple_sentences?).and_return(true)
+    allow(check_group2).to receive(:multiple_sentences?).and_return(false)
   end
 
   context '#process!' do
@@ -32,97 +32,258 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
     end
   end
 
+  # NOTE: Working with doubles so it is a lot more easier to understand what is going on
   describe '#spent_date_for' do
     context 'conviction with 2 sentences, and one simple caution' do
-      let(:disclosure_check1) { build(:disclosure_check, :dto_conviction) }
-      let(:disclosure_check2) { build(:disclosure_check, :suspended_prison_sentence) }
-      let(:disclosure_check3) { build(:disclosure_check, :youth_simple_caution) }
+      before do
+        allow(subject).to receive(:proceedings).and_return([conviction_1, conviction_2])
+      end
+
+      let(:conviction_1) {
+        instance_double(
+          Calculators::Multiples::SameProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2020, 1, 1),
+          spent_date: Date.new(2022, 1, 1),
+        )
+      }
+
+      let(:conviction_2) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: false,
+          conviction_date: nil,
+          spent_date: ResultsVariant::SPENT_SIMPLE,
+        )
+      }
 
       it 'returns the spent date for the matching check group' do
-        expect(subject.spent_date_for(same_proceedings)).to eq(Date.new(2024, 01, 30))
-        expect(subject.spent_date_for(separate_proceedings)).to eq(ResultsVariant::SPENT_SIMPLE)
+        expect(subject.spent_date_for(conviction_1)).to eq(Date.new(2022, 1, 1))
+        expect(subject.spent_date_for(conviction_2)).to eq(ResultsVariant::SPENT_SIMPLE)
       end
     end
 
     context 'conviction with 2 sentences, and another, separate proceedings conviction' do
-      let(:disclosure_check1) { build(:disclosure_check, :dto_conviction) }
-      let(:disclosure_check2) { build(:disclosure_check, :suspended_prison_sentence) }
-      let(:disclosure_check3) { build(:disclosure_check, :with_prison_sentence) }
+      before do
+        allow(subject).to receive(:proceedings).and_return([conviction_1, conviction_2])
+      end
 
       context 'all sentences are dates' do
-        it 'returns the spent date for the matching check group' do
-          expect(subject.spent_date_for(same_proceedings)).to eq(Date.new(2024, 1, 30))
-          expect(subject.spent_date_for(separate_proceedings)).to eq(Date.new(2023, 10, 30))
+        context 'there is overlapping of rehabilitation periods' do
+          let(:conviction_1) {
+            instance_double(
+              Calculators::Multiples::SameProceedings,
+              conviction?: true,
+              conviction_date: Date.new(2020, 1, 1),
+              spent_date: Date.new(2022, 1, 1),
+            )
+          }
+
+          let(:conviction_2) {
+            instance_double(
+              Calculators::Multiples::SeparateProceedings,
+              conviction?: true,
+              conviction_date: Date.new(2021, 1, 1),
+              spent_date: Date.new(2025, 1, 1),
+            )
+          }
+
+          it 'returns the spent date for the matching check group' do
+            expect(subject.spent_date_for(conviction_1)).to eq(Date.new(2025, 1, 1))
+            expect(subject.spent_date_for(conviction_2)).to eq(Date.new(2025, 1, 1))
+          end
+        end
+
+        context 'there is no overlapping of rehabilitation periods' do
+          let(:conviction_1) {
+            instance_double(
+              Calculators::Multiples::SameProceedings,
+              conviction?: true,
+              conviction_date: Date.new(2020, 1, 1),
+              spent_date: Date.new(2022, 1, 1),
+            )
+          }
+
+          let(:conviction_2) {
+            instance_double(
+              Calculators::Multiples::SeparateProceedings,
+              conviction?: true,
+              conviction_date: Date.new(2023, 1, 1),
+              spent_date: Date.new(2025, 1, 1),
+            )
+          }
+
+          it 'returns the spent date for the matching check group' do
+            expect(subject.spent_date_for(conviction_1)).to eq(Date.new(2022, 1, 1))
+            expect(subject.spent_date_for(conviction_2)).to eq(Date.new(2025, 1, 1))
+          end
         end
       end
 
-      # Rules:
+      # Rules (assuming there are overlaps):
       #
-      # - If the first conviction is “never spent” and the second has an end date, then neither changes.
+      #   - Everything (that has an end date) given before a "never spent"
+      #     conviction becomes never spent.
       #
-      # - If the first conviction has an end date and the second conviction is “never spent”,
-      #   then the first conviction changes to “never spent”.
+      #   - Everything afterwards is not affected by the never spent.
       #
       context 'one of the sentences has never spent length' do
+        let(:conviction_1) {
+          instance_double(
+            Calculators::Multiples::SameProceedings,
+            conviction?: true,
+            conviction_date: Date.new(2020, 1, 1),
+            spent_date: spent_date_1,
+          )
+        }
+
+        let(:conviction_2) {
+          instance_double(
+            Calculators::Multiples::SeparateProceedings,
+            conviction?: true,
+            conviction_date: Date.new(2021, 1, 1),
+            spent_date: spent_date_2,
+          )
+        }
+
         context 'never spent sentence goes in the first conviction' do
-          let(:disclosure_check1) { build(:disclosure_check, :with_prison_sentence, conviction_length: 50) }
+          let(:spent_date_1) { ResultsVariant::NEVER_SPENT }
+          let(:spent_date_2) { Date.new(2023, 1, 1) }
 
           it 'returns the spent date for the matching check group' do
-            expect(subject.spent_date_for(same_proceedings)).to eq(ResultsVariant::NEVER_SPENT)
-            expect(subject.spent_date_for(separate_proceedings)).to eq(Date.new(2023, 10, 30))
+            expect(subject.spent_date_for(conviction_1)).to eq(ResultsVariant::NEVER_SPENT)
+            expect(subject.spent_date_for(conviction_2)).to eq(Date.new(2023, 1, 1))
           end
         end
 
         context 'never spent sentence goes in the second conviction' do
-          let(:disclosure_check3) { build(:disclosure_check, :with_prison_sentence, conviction_length: 50) }
+          let(:spent_date_1) { Date.new(2023, 1, 1) }
+          let(:spent_date_2) { ResultsVariant::NEVER_SPENT }
 
           it 'returns the spent date for the matching check group' do
-            expect(subject.spent_date_for(same_proceedings)).to eq(ResultsVariant::NEVER_SPENT)
-            expect(subject.spent_date_for(separate_proceedings)).to eq(ResultsVariant::NEVER_SPENT)
+            expect(subject.spent_date_for(conviction_1)).to eq(ResultsVariant::NEVER_SPENT)
+            expect(subject.spent_date_for(conviction_2)).to eq(ResultsVariant::NEVER_SPENT)
           end
         end
       end
 
       context 'one of the sentences has indefinite length' do
+        let(:conviction_1) {
+          instance_double(
+            Calculators::Multiples::SameProceedings,
+            conviction?: true,
+            conviction_date: Date.new(2020, 1, 1),
+            spent_date: spent_date_1,
+          )
+        }
+
+        let(:conviction_2) {
+          instance_double(
+            Calculators::Multiples::SeparateProceedings,
+            conviction?: true,
+            conviction_date: Date.new(2021, 1, 1),
+            spent_date: spent_date_2,
+          )
+        }
+
         context 'indefinite sentence goes in the first conviction' do
-          let(:disclosure_check1) { build(:disclosure_check, :with_motoring_disqualification, conviction_length_type: 'indefinite') }
+          let(:spent_date_1) { ResultsVariant::INDEFINITE }
+          let(:spent_date_2) { Date.new(2023, 1, 1) }
 
           it 'returns the spent date for the matching check group' do
-            expect(subject.spent_date_for(same_proceedings)).to eq(ResultsVariant::INDEFINITE)
-            expect(subject.spent_date_for(separate_proceedings)).to eq(Date.new(2023, 10, 30))
+            expect(subject.spent_date_for(conviction_1)).to eq(ResultsVariant::INDEFINITE)
+            expect(subject.spent_date_for(conviction_2)).to eq(Date.new(2023, 1, 1))
           end
         end
 
         context 'indefinite sentence goes in the second conviction' do
-          let(:disclosure_check3) { build(:disclosure_check, :with_motoring_disqualification, conviction_length_type: 'indefinite') }
+          let(:spent_date_1) { Date.new(2023, 1, 1) }
+          let(:spent_date_2) { ResultsVariant::INDEFINITE }
 
           it 'returns the spent date for the matching check group' do
-            expect(subject.spent_date_for(same_proceedings)).to eq(ResultsVariant::INDEFINITE)
-            expect(subject.spent_date_for(separate_proceedings)).to eq(ResultsVariant::INDEFINITE)
+            expect(subject.spent_date_for(conviction_1)).to eq(ResultsVariant::INDEFINITE)
+            expect(subject.spent_date_for(conviction_2)).to eq(ResultsVariant::INDEFINITE)
           end
         end
       end
 
-      context 'one of the sentences is `never spent` and the other is `indefinite`' do
+      context 'one of the sentences is never spent and the other is indefinite' do
+        let(:conviction_1) {
+          instance_double(
+            Calculators::Multiples::SameProceedings,
+            conviction?: true,
+            conviction_date: Date.new(2020, 1, 1),
+            spent_date: spent_date_1,
+          )
+        }
+
+        let(:conviction_2) {
+          instance_double(
+            Calculators::Multiples::SeparateProceedings,
+            conviction?: true,
+            conviction_date: Date.new(2021, 1, 1),
+            spent_date: spent_date_2,
+          )
+        }
+
         context 'never spent sentence goes in the first conviction and indefinite in the second conviction' do
-          let(:disclosure_check1) { build(:disclosure_check, :with_prison_sentence, conviction_length: 50) }
-          let(:disclosure_check3) { build(:disclosure_check, :with_motoring_disqualification, conviction_length_type: 'indefinite') }
+          let(:spent_date_1) { ResultsVariant::NEVER_SPENT }
+          let(:spent_date_2) { ResultsVariant::INDEFINITE }
 
           it 'returns the spent date for the matching check group' do
-            expect(subject.spent_date_for(same_proceedings)).to eq(ResultsVariant::NEVER_SPENT)
-            expect(subject.spent_date_for(separate_proceedings)).to eq(ResultsVariant::INDEFINITE)
+            expect(subject.spent_date_for(conviction_1)).to eq(ResultsVariant::NEVER_SPENT)
+            expect(subject.spent_date_for(conviction_2)).to eq(ResultsVariant::INDEFINITE)
           end
         end
 
         context 'indefinite sentence goes in the first conviction and never spent in the second conviction' do
-          let(:disclosure_check1) { build(:disclosure_check, :with_motoring_disqualification, conviction_length_type: 'indefinite') }
-          let(:disclosure_check3) { build(:disclosure_check, :with_prison_sentence, conviction_length: 50) }
+          let(:spent_date_1) { ResultsVariant::INDEFINITE }
+          let(:spent_date_2) { ResultsVariant::NEVER_SPENT }
 
           it 'returns the spent date for the matching check group' do
-            expect(subject.spent_date_for(same_proceedings)).to eq(ResultsVariant::NEVER_SPENT)
-            expect(subject.spent_date_for(separate_proceedings)).to eq(ResultsVariant::NEVER_SPENT)
+            expect(subject.spent_date_for(conviction_1)).to eq(ResultsVariant::NEVER_SPENT)
+            expect(subject.spent_date_for(conviction_2)).to eq(ResultsVariant::NEVER_SPENT)
           end
         end
+      end
+    end
+
+    context '3 separate proceedings convictions' do
+      before do
+        allow(subject).to receive(:proceedings).and_return([conviction_1, conviction_2, conviction_3])
+      end
+
+      let(:conviction_1) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2020, 1, 1),
+          spent_date: Date.new(2021, 1, 1),
+        )
+      }
+
+      let(:conviction_2) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2020, 10, 25),
+          spent_date: ResultsVariant::NEVER_SPENT,
+        )
+      }
+
+      let(:conviction_3) {
+        instance_double(
+          Calculators::Multiples::SeparateProceedings,
+          conviction?: true,
+          conviction_date: Date.new(2023, 1, 1),
+          spent_date: Date.new(2025, 1, 1),
+        )
+      }
+
+      it 'returns the spent date for the matching check group' do
+        expect(subject.spent_date_for(conviction_1)).to eq(ResultsVariant::NEVER_SPENT)
+        expect(subject.spent_date_for(conviction_2)).to eq(ResultsVariant::NEVER_SPENT)
+        expect(subject.spent_date_for(conviction_3)).to eq(Date.new(2025, 1, 1))
       end
     end
   end


### PR DESCRIPTION
Ticket: https://trello.com/c/PcAlcOaz

Note: this does NOT yet cover the relevant orders.

But in particular with this PR we are trying to cover these scenarios:

* If a conviction is received before another conviction is spent, neither conviction will become spent until the rehabilitation periods for both are over i.e. the longest one applies to both. To clarify some cases and exceptions:

  * If the first conviction has an end date and the second conviction is “never spent”, then the first conviction changes to “never spent”

  * If the first conviction is “never spent” and the second has an end date, then neither changes

The following scenarios are covered with tests and pass our current algorithm implemented in `MultipleOffensesCalculator`:

![image (1)](https://user-images.githubusercontent.com/687910/106921111-94909c00-6703-11eb-948f-bd73f2f34ba0.png)

---

<img width="567" alt="Screenshot 2021-02-04 at 16 11 43" src="https://user-images.githubusercontent.com/687910/106921266-c4d83a80-6703-11eb-9ec9-4b8e2a02de7d.png">

---

<img width="580" alt="Screenshot 2021-02-04 at 16 12 45" src="https://user-images.githubusercontent.com/687910/106921555-079a1280-6704-11eb-80eb-ba3d02f53d95.png">
