### PR TITLE
Ignore relevant orders on overlapping convictions 

### DIFF
--- a/app/models/disclosure_check.rb
+++ b/app/models/disclosure_check.rb
@@ -8,6 +8,9 @@ class DisclosureCheck < ApplicationRecord
   }
 
   def relevant_order?
+    # conviction subtype will be nil if it's a caution
+    return false if conviction_subtype.nil?
+
     ConvictionType.find_constant(conviction_subtype).relevant_order?
   end
 end

--- a/app/services/base_multiples_calculator.rb
+++ b/app/services/base_multiples_calculator.rb
@@ -33,11 +33,17 @@ class BaseMultiplesCalculator
   end
   # :nocov:
 
-  def without_relevant_orders
-    (disclosure_checks - relevant_orders)
+  def spent_date_without_relevant_orders
+    @_spent_date_without_relevant_orders ||= without_relevant_orders.map(
+      &method(:expiry_date_for)
+    ).max
   end
 
   private
+
+  def without_relevant_orders
+    (disclosure_checks - relevant_orders)
+  end
 
   def disclosure_checks
     @_disclosure_checks ||= check_group.disclosure_checks

--- a/app/services/calculators/multiples/multiple_offenses_calculator.rb
+++ b/app/services/calculators/multiples/multiple_offenses_calculator.rb
@@ -40,7 +40,10 @@ module Calculators
           next if conviction == proceeding
 
           other_conviction_date = conviction.conviction_date
-          other_spent_date = conviction.spent_date
+          other_spent_date = conviction.spent_date_without_relevant_orders
+
+          # solo relevant order
+          next if other_spent_date.nil?
 
           next unless spent_date.to_date.in?(
             other_conviction_date..other_spent_date.to_date

--- a/spec/models/disclosure_check_spec.rb
+++ b/spec/models/disclosure_check_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DisclosureCheck, type: :model do
 
   describe '#relevant_order?' do
     context 'when conviction_subtype is nil' do
-      it { expect { subject.relevant_order? }.to raise_error(NoMethodError) }
+      it { expect(subject.relevant_order?).to be false }
     end
 
     context 'when conviction_subtype is not a relevant order' do

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
               conviction?: true,
               conviction_date: Date.new(2020, 1, 1),
               spent_date: Date.new(2022, 1, 1),
+              spent_date_without_relevant_orders: Date.new(2022, 1, 1),
             )
           }
 
@@ -85,6 +86,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
               conviction?: true,
               conviction_date: Date.new(2021, 1, 1),
               spent_date: Date.new(2025, 1, 1),
+              spent_date_without_relevant_orders: Date.new(2025, 1, 1),
             )
           }
 
@@ -101,6 +103,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
               conviction?: true,
               conviction_date: Date.new(2020, 1, 1),
               spent_date: Date.new(2022, 1, 1),
+              spent_date_without_relevant_orders: Date.new(2022, 1, 1),
             )
           }
 
@@ -110,6 +113,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
               conviction?: true,
               conviction_date: Date.new(2023, 1, 1),
               spent_date: Date.new(2025, 1, 1),
+              spent_date_without_relevant_orders: Date.new(2025, 1, 1),
             )
           }
 
@@ -134,6 +138,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
             conviction?: true,
             conviction_date: Date.new(2020, 1, 1),
             spent_date: spent_date_1,
+            spent_date_without_relevant_orders: spent_date_1,
           )
         }
 
@@ -143,6 +148,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
             conviction?: true,
             conviction_date: Date.new(2021, 1, 1),
             spent_date: spent_date_2,
+            spent_date_without_relevant_orders: spent_date_2,
           )
         }
 
@@ -174,6 +180,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
             conviction?: true,
             conviction_date: Date.new(2020, 1, 1),
             spent_date: spent_date_1,
+            spent_date_without_relevant_orders: spent_date_1,
           )
         }
 
@@ -183,6 +190,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
             conviction?: true,
             conviction_date: Date.new(2021, 1, 1),
             spent_date: spent_date_2,
+            spent_date_without_relevant_orders: spent_date_2,
           )
         }
 
@@ -214,6 +222,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
             conviction?: true,
             conviction_date: Date.new(2020, 1, 1),
             spent_date: spent_date_1,
+            spent_date_without_relevant_orders: spent_date_1,
           )
         }
 
@@ -223,6 +232,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
             conviction?: true,
             conviction_date: Date.new(2021, 1, 1),
             spent_date: spent_date_2,
+            spent_date_without_relevant_orders: spent_date_2,
           )
         }
 
@@ -259,6 +269,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2020, 1, 1),
           spent_date: Date.new(2021, 1, 1),
+          spent_date_without_relevant_orders: Date.new(2021, 1, 1),
         )
       }
 
@@ -268,6 +279,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2020, 10, 25),
           spent_date: ResultsVariant::NEVER_SPENT,
+          spent_date_without_relevant_orders: ResultsVariant::NEVER_SPENT,
         )
       }
 
@@ -277,6 +289,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2023, 1, 1),
           spent_date: Date.new(2025, 1, 1),
+          spent_date_without_relevant_orders: Date.new(2025, 1, 1),
         )
       }
 
@@ -298,6 +311,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2020, 1, 1),
           spent_date: Date.new(2021, 1, 1),
+          spent_date_without_relevant_orders: Date.new(2021, 1, 1),
         )
       }
 
@@ -307,6 +321,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2020, 6, 1),
           spent_date: Date.new(2021, 1, 1),
+          spent_date_without_relevant_orders: Date.new(2021, 1, 1),
         )
       }
 
@@ -316,6 +331,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2023, 1, 1),
           spent_date: ResultsVariant::NEVER_SPENT,
+          spent_date_without_relevant_orders: ResultsVariant::NEVER_SPENT,
         )
       }
 
@@ -325,6 +341,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2025, 1, 1),
           spent_date: Date.new(2025, 12, 31),
+          spent_date_without_relevant_orders: Date.new(2025, 12, 31),
         )
       }
 
@@ -347,6 +364,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2020, 1, 1),
           spent_date: Date.new(2021, 1, 1),
+          spent_date_without_relevant_orders: Date.new(2021, 1, 1),
         )
       }
 
@@ -356,6 +374,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2020, 6, 1),
           spent_date: Date.new(2021, 1, 1),
+          spent_date_without_relevant_orders: Date.new(2021, 1, 1),
         )
       }
 
@@ -365,6 +384,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2023, 1, 1),
           spent_date: Date.new(2026, 1, 1),
+          spent_date_without_relevant_orders: Date.new(2026, 1, 1),
         )
       }
 
@@ -374,6 +394,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2025, 1, 1),
           spent_date: ResultsVariant::NEVER_SPENT,
+          spent_date_without_relevant_orders: ResultsVariant::NEVER_SPENT,
         )
       }
 

--- a/spec/services/calculators/multiples/same_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/same_proceedings_spec.rb
@@ -66,12 +66,48 @@ RSpec.describe Calculators::Multiples::SameProceedings do
         expect(subject.spent_date).to eq(ResultsVariant::INDEFINITE)
       end
     end
-  end
 
-  describe '#without_relevant_orders' do
-    it 'does not return relevant orders' do
-      expect(subject.without_relevant_orders).not_to include(disclosure_check3)
-      expect(subject.without_relevant_orders).to include(disclosure_check1, disclosure_check2)
+    describe '#spent_date_without_relevant_orders' do
+      let(:conviction_subtype) { ConvictionType::ADULT_ABSOLUTE_DISCHARGE }
+      let(:conviction_subtype2) { ConvictionType::ADULT_CONDITIONAL_DISCHARGE }
+
+      let(:disclosure_check1) do
+        instance_double(
+          DisclosureCheck,
+          kind: CheckKind::CONVICTION.to_s,
+          known_date: conviction_date,
+          conviction_date: conviction_date,
+          relevant_order?: conviction_subtype.relevant_order?,
+          conviction_subtype: conviction_subtype.value,
+          conviction_type: conviction_subtype.parent.value
+        )
+      end
+
+      let(:disclosure_check2) do
+        instance_double(
+          DisclosureCheck,
+          kind: CheckKind::CONVICTION.to_s,
+          known_date: conviction_date,
+          conviction_date: conviction_date,
+          relevant_order?: conviction_subtype2.relevant_order?,
+          conviction_subtype: conviction_subtype2.value,
+          conviction_type: conviction_subtype2.parent.value
+        )
+      end
+
+      context 'when there are two sentences and one is a relevant order' do
+        it 'returns the expiry date of the non relevant order' do
+          expect(subject.spent_date_without_relevant_orders).to eq(Date.new(2018, 1, 1))
+        end
+      end
+
+      context 'when there is two sentences that are relevant orders' do
+        let(:conviction_subtype) { ConvictionType::ADULT_CONDITIONAL_DISCHARGE }
+
+        it 'returns nil' do
+          expect(subject.spent_date_without_relevant_orders).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/services/calculators/multiples/separate_proceedings_spec.rb
+++ b/spec/services/calculators/multiples/separate_proceedings_spec.rb
@@ -53,21 +53,33 @@ RSpec.describe Calculators::Multiples::SeparateProceedings do
     end
   end
 
-  describe '#without_relevant_orders' do
+  describe '#spent_date_without_relevant_orders' do
+    let(:conviction_subtype) { ConvictionType::ADULT_ABSOLUTE_DISCHARGE }
+
+    let(:disclosure_check) do
+      instance_double(
+        DisclosureCheck,
+        kind: CheckKind::CONVICTION.to_s,
+        known_date: conviction_date,
+        conviction_date: conviction_date,
+        relevant_order?: conviction_subtype.relevant_order?,
+        conviction_subtype: conviction_subtype.value,
+        conviction_type: conviction_subtype.parent.value
+      )
+    end
+
     context 'when a disclosure_check is not a relevant order' do
-      it 'includes the disclosure_check' do
-        expect(subject.without_relevant_orders).to include(disclosure_check)
+      it 'returns the expiry date' do
+        expect(subject.spent_date_without_relevant_orders).to eq(Date.new(2015, 12, 25))
       end
     end
 
-    context 'when a disclosure_check is a relevant order' do
-      let(:disclosure_check) { instance_double(DisclosureCheck, kind: kind, conviction_date: conviction_date, relevant_order?: true) }
+    context 'when there is one relevant order' do
+      let(:conviction_subtype) { ConvictionType::ADULT_CONDITIONAL_DISCHARGE }
 
-      it 'does not include the disclosure_check' do
-        expect(subject.without_relevant_orders).not_to include(disclosure_check)
+      it 'returns nil' do
+        expect(subject.spent_date_without_relevant_orders).to be_nil
       end
-
-      it { expect(subject.without_relevant_orders).to be_empty }
     end
   end
 end

--- a/spec/services/calculators/multiples/written_scenarios_spec.rb
+++ b/spec/services/calculators/multiples/written_scenarios_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
+  subject { described_class.new(disclosure_report) }
+
+  let(:disclosure_report) { DisclosureReport.new }
+  let(:first_proceeding_group) { disclosure_report.check_groups.build }
+  let(:second_proceeding_group) { disclosure_report.check_groups.build }
+
+  let(:first_proceedings) { subject.results[first_proceeding_group.id] }
+  let(:second_proceedings) { subject.results[second_proceeding_group.id] }
+
+  def save_report
+    disclosure_report.completed!
+  end
+
+  context 'two separate convictions' do
+    context 'scenario 1' do
+      # Scenario 1
+      # Adult person was convicted of assault on 1 August 2009 and received:
+      # - a 3 month suspended sentence (This would become spent on 1 November 2011.)
+      #
+      # On 10 June 2011, he was convicted of battery and sentenced to:
+      # - a 6 month custodial sentence
+      # - a restraining order until further notice
+      # - a fine for £50
+      #
+      # The 2011 conviction would remain unspent until further notice, due to the restraining order.
+      # Their first conviction in 2009 would will be extended until 10 December 2013
+      # due to the custodial sentence they received in the 10 June 2011.
+      # However, the rehabilitation period would not be affected by the restraining order.
+
+      let(:first_conviction_date) { Date.new(2009, 8, 1) }
+      let(:second_conviction_date) { Date.new(2011, 6, 10) }
+      let(:expected_first_conviction_spent_date) { Date.new(2013, 12, 10) }
+      let(:expected_second_conviction_spent_date) { ResultsVariant::INDEFINITE }
+
+      let(:suspended_prison_sentence) do
+        build(
+          :disclosure_check,
+          :suspended_prison_sentence,
+          :completed,
+          known_date: first_conviction_date,
+          conviction_date: first_conviction_date,
+          conviction_length: 3
+        )
+      end
+
+      let(:custodial_sentence) do
+        build(
+          :disclosure_check,
+          :with_prison_sentence,
+          :completed,
+          known_date: second_conviction_date,
+          conviction_date: second_conviction_date,
+          conviction_length: 6
+        )
+      end
+
+      let(:restraining_order) do
+        build(
+          :disclosure_check,
+          :with_restraining_order,
+          :completed,
+          known_date: second_conviction_date,
+          conviction_date: second_conviction_date,
+          conviction_length: nil,
+          conviction_length_type: ConvictionLengthType::INDEFINITE
+        )
+      end
+
+      let(:financial_fine) do
+        build(
+          :disclosure_check,
+          :adult,
+          :with_fine,
+          :completed,
+          known_date: second_conviction_date,
+          conviction_date: second_conviction_date
+        )
+      end
+
+      before do
+        first_proceeding_group.disclosure_checks << suspended_prison_sentence
+        second_proceeding_group.disclosure_checks << custodial_sentence
+        second_proceeding_group.disclosure_checks << restraining_order
+        second_proceeding_group.disclosure_checks << financial_fine
+
+        save_report
+      end
+
+      it 'returns the date for the first proceeeding' do
+        expect(subject.spent_date_for(first_proceedings)).to eq(expected_first_conviction_spent_date)
+      end
+
+      it 'returns indefinite for the second proceeding' do
+        expect(subject.spent_date_for(second_proceedings)).to eq(expected_second_conviction_spent_date)
+      end
+    end
+  end
+end

--- a/spec/services/calculators/multiples/written_scenarios_spec.rb
+++ b/spec/services/calculators/multiples/written_scenarios_spec.rb
@@ -194,14 +194,12 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
       # - a fine for £50
       #
       # The 2011 conviction would remain unspent until further notice, due to the restraining order.
-      # Their first conviction in 2009 would will be extended until 10 December 2013
+      # Their first conviction in 2009 would will be extended until >> 10 December 2013 <<
       # due to the custodial sentence they received in the 10 June 2011.
       # However, the rehabilitation period would not be affected by the restraining order.
 
       let(:first_conviction_date) { Date.new(2009, 8, 1) }
       let(:second_conviction_date) { Date.new(2011, 6, 10) }
-      let(:expected_first_conviction_spent_date) { Date.new(2013, 12, 9) }
-      let(:expected_second_conviction_spent_date) { ResultsVariant::INDEFINITE }
 
       let(:suspended_prison_sentence) do
         build(
@@ -225,6 +223,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
         )
       end
 
+      # relevant order
       let(:restraining_order) do
         build(
           :disclosure_check,
@@ -258,11 +257,11 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
       end
 
       it 'returns the date for the first proceeeding' do
-        expect(subject.spent_date_for(first_proceedings)).to eq(expected_first_conviction_spent_date)
+        expect(subject.spent_date_for(first_proceedings)).to eq(Date.new(2013, 12, 9))
       end
 
       it 'returns indefinite for the second proceeding' do
-        expect(subject.spent_date_for(second_proceedings)).to eq(expected_second_conviction_spent_date)
+        expect(subject.spent_date_for(second_proceedings)).to eq(ResultsVariant::INDEFINITE)
       end
     end
   end


### PR DESCRIPTION
The solution proposed here is to have two different methods, the existing #spent_date
which is used to iterate through all sentences.

And the new method #spent_date_without_relevant_orders,
which means it will ignore any relevant order sentence and
output the spent_date of a non relevant order.

It's possible that there's only a relevant order left, so
in this case the #spent_date_without_relevant_orders will return nil.

Hence having to check for a nil spent_date in the algorithm of MultipleOffensesCalculator.

All doubles have been adapted to represent their existing scenarios.
More examples should be added to represent relevant orders.

Scenarios have been written based on examples supplied in:

- Nacro Guidance
- https://www.gov.uk/guidance/rehabilitation-periods
- https://hub.unlock.org.uk/knowledgebase/detailedguideroa

Story: https://trello.com/c/XJEnGNj6/109-ignore-relevant-order-sentences-in-other-separate-overlapping-convictions