### PR TITLE
Fixes overlapping convictions spent_dates

### DIFF
--- a/app/services/calculators/multiples/multiple_offenses_calculator.rb
+++ b/app/services/calculators/multiples/multiple_offenses_calculator.rb
@@ -20,6 +20,10 @@ module Calculators
         # Cautions are always dealt with separately and do not have drag-through
         return spent_date unless proceeding.conviction?
 
+        # Comparison of dates between different convictions
+        # should be done without relevant order dates
+        spent_date_without_relevant_order = proceeding.spent_date_without_relevant_orders
+
         # We have to loop through the other convictions and check if the spent date
         # of this conviction overlaps with the rehabilitation of another one and if so,
         # then the spent date of this conviction becomes the spent date of the other.
@@ -35,9 +39,17 @@ module Calculators
           other_spent_date = conviction.spent_date_without_relevant_orders
 
           # solo relevant order
+          # if there's only one sentence and it is a relevant order
+          # then _spent_date_without_relevant_orders_ is nil which means it's not a date
+          # and we can't proceed to compare overlapping times (neither should we)
+          # because relevant orders do not dictacte the spent_date of another conviction.
           next if other_spent_date.nil?
+          next if spent_date_without_relevant_order.nil?
 
-          next unless spent_date.to_date.in?(
+          # the comparison to know if there's an overlap in conviction dates
+          # should be done without the relevant order
+          # because relevant orders do not dictacte the spent_date of another conviction.
+          next unless spent_date_without_relevant_order.to_date.in?(
             other_conviction_date..other_spent_date.to_date
           )
 

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_spec.rb
@@ -15,6 +15,59 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
 
   # NOTE: Working with doubles so it is a lot more easier to understand what is going on
   describe '#spent_date_for' do
+    context 'relevant orders' do
+      context 'conviction A with 2 sentences (relevant and non relevant),' \
+              'conviction B with 1 relevant order sentence, conviction C with 1 non relevant sentence' do
+
+        before do
+          allow(subject).to receive(:proceedings).and_return([conviction_A, conviction_B, conviction_C])
+        end
+
+        # conviction with:
+        # 1 relevant order, the longest of both, spent_date: 1 Jan 2005
+        # 1 non relevant order, spent_date: 1 Jan 2003
+        let(:conviction_A) {
+          instance_double(
+            Calculators::Multiples::Proceedings,
+            conviction?: true,
+            conviction_date: Date.new(2001, 1, 1),
+            spent_date: Date.new(2005, 1, 1),
+            spent_date_without_relevant_orders: Date.new(2003, 1, 1),
+          )
+        }
+
+        # conviction with non relevant order
+        # overlaps with conviction A
+        let(:conviction_B) {
+          instance_double(
+            Calculators::Multiples::Proceedings,
+            conviction?: true,
+            conviction_date: Date.new(2000, 1, 1),
+            spent_date: Date.new(2002, 1, 1),
+            spent_date_without_relevant_orders: Date.new(2002, 1, 1),
+          )
+        }
+
+        # conviction with non relevant order
+        # overlaps with relevant sentence of conviction A
+        let(:conviction_C) {
+          instance_double(
+            Calculators::Multiples::Proceedings,
+            conviction?: true,
+            conviction_date: Date.new(2004, 6, 1),
+            spent_date: Date.new(2006, 6, 1),
+            spent_date_without_relevant_orders: Date.new(2006, 6, 1),
+          )
+        }
+
+        it 'returns the spent date for the matching check group' do
+          expect(subject.spent_date_for(conviction_A)).to eq(Date.new(2005, 1, 1))
+          expect(subject.spent_date_for(conviction_B)).to eq(Date.new(2003, 1, 1))
+          expect(subject.spent_date_for(conviction_C)).to eq(Date.new(2006, 6, 1))
+        end
+      end
+    end
+
     context 'conviction with 2 sentences, and one simple caution' do
       before do
         allow(subject).to receive(:proceedings).and_return([conviction_1, conviction_2])
@@ -26,6 +79,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: true,
           conviction_date: Date.new(2020, 1, 1),
           spent_date: Date.new(2022, 1, 1),
+          spent_date_without_relevant_orders: Date.new(2022, 1, 1),
         )
       }
 
@@ -35,6 +89,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
           conviction?: false,
           conviction_date: nil,
           spent_date: ResultsVariant::SPENT_SIMPLE,
+          spent_date_without_relevant_orders: ResultsVariant::SPENT_SIMPLE,
         )
       }
 


### PR DESCRIPTION
We almost got it correct before.

To solve the issue of the scenario represented in the graph I had to compare the range of dates without the relevant order.

But first one needs to confirm if a conviction only holds a relevant order, if so, skip the range comparison.

If there's a date that does not belong to a relevant order, then we compare the overlapping, but never with relevant order dates.

My previous mistake was to only consider 1 proceeding, this now considers both proceedings


![image](https://user-images.githubusercontent.com/136777/107056833-aa1cc900-67ca-11eb-8d78-0116fd89d4c0.png)


Story: https://trello.com/c/XJEnGNj6/109-ignore-relevant-order-sentences-in-other-separate-overlapping-convictions