### PR TITLE
Add approximate date copy to results page

### DIFF
--- a/app/forms/value_object_methods.rb
+++ b/app/forms/value_object_methods.rb
@@ -1,4 +1,11 @@
 module ValueObjectMethods
+  APPROXIMATE_DATE_ATTRS = [
+    :approximate_known_date,
+    :approximate_conviction_date,
+    :approximate_conditional_end_date,
+    :approximate_compensation_payment_date,
+  ].freeze
+
   def self.included(base)
     base.send :include, InstanceMethods
   end
@@ -29,6 +36,10 @@ module ValueObjectMethods
       return conviction_subtype if conviction?
 
       raise 'Unknown or nil check kind'
+    end
+
+    def approximate_dates?
+      APPROXIMATE_DATE_ATTRS.any? { |attr| disclosure_check.try(attr) }
     end
   end
 end

--- a/app/views/steps/check/results/shared/_summary.en.html.erb
+++ b/app/views/steps/check/results/shared/_summary.en.html.erb
@@ -2,7 +2,13 @@
   How this result has been worked out
 </h2>
 
-<p class="govuk-body">The result you’ve been given is based on the current law as well as the information you provided.</p>
+<p class="govuk-body">
+  <% if result.approximate_dates? %>
+    You entered an approximate date so your results will be approximate.
+  <% end %>
+
+  Your results are based on the current law as well as the information you provided.
+</p>
 
 <dl class="govuk-summary-list">
   <%= render result.summary %>

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -65,4 +65,46 @@ RSpec.describe BaseForm do
       end
     end
   end
+
+  describe 'APPROXIMATE_DATE_ATTRS' do
+    it 'returns the expected attributes' do
+      expect(described_class::APPROXIMATE_DATE_ATTRS).to eq([
+        :approximate_known_date,
+        :approximate_conviction_date,
+        :approximate_conditional_end_date,
+        :approximate_compensation_payment_date,
+      ])
+    end
+  end
+
+  describe '#approximate_dates?' do
+    let(:disclosure_check) {
+      instance_double(
+        DisclosureCheck,
+        approximate_conviction_date: approximate_conviction_date,
+        approximate_known_date: approximate_known_date
+      )
+    }
+
+    let(:approximate_conviction_date) { false }
+    let(:approximate_known_date) { false }
+
+    before do
+      allow(subject).to receive(:disclosure_check).and_return(disclosure_check)
+    end
+
+    context 'there is at least one approximate date' do
+      let(:approximate_known_date) { true }
+      it { expect(subject.approximate_dates?).to eq(true) }
+    end
+
+    context 'there are no approximate dates' do
+      it { expect(subject.approximate_dates?).to eq(false) }
+    end
+
+    context 'there are nil values' do
+      let(:approximate_known_date) { nil }
+      it { expect(subject.approximate_dates?).to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://trello.com/c/L2pqJMHo

First part of the work, to add an additional line of copy when we detect there is at least one approximate date in the check.

The other line of copy, shown always, has been tweaked according to content designer.

In a follow-up PR the copy will be implemented in the hint texts.

<img width="1018" alt="Screenshot 2021-02-08 at 13 05 07" src="https://user-images.githubusercontent.com/687910/107223681-65816f80-6a0e-11eb-82fa-1c0a36dee67d.png">
