### PR TITLE
Amend hint text to clarify approximate dates

### DIFF
--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -25,6 +25,13 @@ module CustomFormHelpers
     ).html_safe
   end
 
+  # Used to customise lead text when reusing the same view
+  def i18n_lead_text
+    I18n.t(
+      object.i18n_attribute, scope: scope_for_locale(:lead_text), default: :default
+    )
+  end
+
   private
 
   def submit_button(i18n_key, opts = {}, &block)

--- a/app/views/steps/caution/conditional_end_date/edit.html.erb
+++ b/app/views/steps/caution/conditional_end_date/edit.html.erb
@@ -6,7 +6,9 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_date_field :conditional_end_date, form_group: { classes: 'app-util--compact-form-group' } %>
+      <%= f.govuk_date_field :conditional_end_date, form_group: { classes: 'app-util--compact-form-group' } do
+        tag.p t('.lead_text'), class: 'govuk-body-m'
+      end %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_conditional_end_date

--- a/app/views/steps/conviction/compensation_payment_date/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_date/edit.html.erb
@@ -8,7 +8,9 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_date_field :compensation_payment_date,
           form_group: { classes: 'app-util--compact-form-group' },
-          caption: { text: f.i18n_caption } %>
+          caption: { text: f.i18n_caption } do
+        tag.p t('.lead_text'), class: 'govuk-body-m'
+      end %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_compensation_payment_date

--- a/app/views/steps/conviction/conviction_date/edit.html.erb
+++ b/app/views/steps/conviction/conviction_date/edit.html.erb
@@ -6,7 +6,9 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_date_field :conviction_date, form_group: { classes: 'app-util--compact-form-group' } %>
+      <%= f.govuk_date_field :conviction_date, form_group: { classes: 'app-util--compact-form-group' } do
+        tag.p t('.lead_text'), class: 'govuk-body-m'
+      end %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_conviction_date

--- a/app/views/steps/conviction/known_date/edit.html.erb
+++ b/app/views/steps/conviction/known_date/edit.html.erb
@@ -8,8 +8,9 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_date_field :known_date, form_group: { classes: 'app-util--compact-form-group' },
             legend: { text: f.i18n_legend },
-            hint: { text: f.i18n_hint },
-            caption: { text: f.i18n_caption } %>
+            caption: { text: f.i18n_caption } do
+        tag.p f.i18n_lead_text, class: 'govuk-body-m'
+      end %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_known_date

--- a/config/locales/en/caution.yml
+++ b/config/locales/en/caution.yml
@@ -12,6 +12,7 @@ en:
       conditional_end_date:
         edit:
           page_title: End date of conditions
+          lead_text: Enter the date you agreed the conditions would end. This might have included paying a fine or compensation.
           details:
             title: My conditions have not ended
             body_html: |

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -33,6 +33,7 @@ en:
       conviction_date:
         edit:
           page_title: Conviction date
+          lead_text: This is the day you were found guilty of the offence.
       conviction_type:
         edit:
           page_title: Conviction type
@@ -69,6 +70,7 @@ en:
       compensation_payment_date:
         edit:
           page_title: Compensation payment date
+          lead_text: If you paid the compensation in stages, enter the date you made the final payment.
       compensation_payment_receipt:
         edit:
           page_title: Compensation receipt sent to DBS

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -1,15 +1,13 @@
 ---
 en:
   dictionary:
-    court_sentence_hint_text: &court_sentence_hint_text |
-      This is usually the day you were sentenced in court. If you do not know the exact date, you can enter an approximate one.
-      <span class='nowrap'>For example, 23 9 2018</span>
-    court_conviction_hint_text: &court_conviction_hint_text |
-      This is usually the day you were convicted in court. If you do not know the exact date, you can enter an approximate one.
-      <span class='nowrap'>For example, 23 9 2018</span>
-    order_started_hint_text: &order_started_hint_text |
+    date_hint_text: &date_hint_text |
+      If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
+      <p>For example, 23 9 2018</p>
+    court_conviction_lead_text: &court_conviction_lead_text |
+      This is usually the day you were convicted in court.
+    order_started_lead_text: &order_started_lead_text |
       This is usually the day you were convicted or sentenced in court, or the first day you were held on remand.
-      <p>If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span></p>
 
     approximate_date_legend: &approximate_date_legend "Approximate date"
     approximate_date_checkbox: &approximate_date_checkbox "This is not the exact date"
@@ -174,33 +172,18 @@ en:
           caution: You were given an official warning by the police
           conviction: You were found guilty of a crime in court
       steps_caution_known_date_form:
-        known_date_html: If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>
+        known_date_html: *date_hint_text
       steps_check_under_age_form:
         caution_html: Select your age when you got the caution, not when you committed the offence
         conviction_html: Select your age when you got convicted, not when you committed the offence
       steps_caution_conditional_end_date_form:
-        conditional_end_date_html: "Enter the date you agreed the conditions would end. This might have included paying a fine or compensation. If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>"
+        conditional_end_date_html: *date_hint_text
       steps_conviction_conviction_date_form:
-        conviction_date_html: This is the day you were found guilty of the offence. If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>
+        conviction_date_html: *date_hint_text
       steps_conviction_known_date_form:
-        # default key
-        default_html: *court_sentence_hint_text
-        # alternative keys defined with `i18_attribute`
-        referral_order_html: Enter the date of your first youth offender panel meeting. If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>
-        bind_over_html: *court_conviction_hint_text
-        absolute_discharge_html: *court_conviction_hint_text
-        conditional_discharge_html: *court_conviction_hint_text
-        adult_bind_over_html: *court_conviction_hint_text
-        adult_absolute_discharge_html: *court_conviction_hint_text
-        adult_conditional_discharge_html: *court_conviction_hint_text
-        detention_training_order_html: *order_started_hint_text
-        detention_html: *order_started_hint_text
-        adult_prison_sentence_html: *order_started_hint_text
-        adult_suspended_prison_sentence_html: *order_started_hint_text
-        adult_disqualification_html: If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>
-        youth_disqualification_html: If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>
+        known_date_html: *date_hint_text
       steps_conviction_compensation_payment_date_form:
-        compensation_payment_date_html: If you paid the compensation in stages, enter the date you made the final payment. If you do not know the exact date, you can enter an approximate one. <span class='nowrap'>For example, 23 9 2018</span>
+        compensation_payment_date_html: *date_hint_text
       steps_conviction_compensation_payment_receipt_form:
         compensation_receipt_sent: You must send the compensation payment receipt to the Disclosure and Barring service for the convition to be spent.
       steps_conviction_motoring_endorsement_form:
@@ -395,3 +378,22 @@ en:
         weeks: Number of weeks
         months: Number of months
         years: Number of years
+
+    lead_text:
+      steps_conviction_known_date_form:
+        # default key
+        default: This is usually the day you were sentenced in court.
+        # alternative keys defined with `i18_attribute`
+        referral_order: Enter the date of your first youth offender panel meeting.
+        bind_over: *court_conviction_lead_text
+        absolute_discharge: *court_conviction_lead_text
+        conditional_discharge: *court_conviction_lead_text
+        adult_bind_over: *court_conviction_lead_text
+        adult_absolute_discharge: *court_conviction_lead_text
+        adult_conditional_discharge: *court_conviction_lead_text
+        detention_training_order: *order_started_lead_text
+        detention: *order_started_lead_text
+        adult_prison_sentence: *order_started_lead_text
+        adult_suspended_prison_sentence: *order_started_lead_text
+        adult_disqualification: ''
+        youth_disqualification: ''

--- a/features/fixtures/files/steps_conviction_known_date.html
+++ b/features/fixtures/files/steps_conviction_known_date.html
@@ -1,11 +1,15 @@
 <div class="govuk-form-group app-util--compact-form-group">
-  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-hint">
+  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-hint steps-conviction-known-date-form-known-date-supplemental">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
     </legend>
 
-    <span class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">This is usually the day you were convicted in court. If you do not know the exact date, you can enter an approximate one.
-<span class="nowrap">For example, 23 9 2018</span></span>
+<div id="steps-conviction-known-date-form-known-date-supplemental"><p class="govuk-body-m">This is usually the day you were convicted in court.
+</p></div>
+
+<span class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
+<p>For example, 23 9 2018</p>
+</span>
 
     <div class="govuk-date-input">
       <div class="govuk-date-input__item">

--- a/features/fixtures/files/steps_conviction_known_date_with_errors.html
+++ b/features/fixtures/files/steps_conviction_known_date_with_errors.html
@@ -1,10 +1,15 @@
 <div class="govuk-form-group govuk-form-group--error app-util--compact-form-group">
-  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-error steps-conviction-known-date-form-known-date-hint">
+  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-error steps-conviction-known-date-form-known-date-hint steps-conviction-known-date-form-known-date-supplemental">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
     </legend>
-    <span class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">This is usually the day you were convicted in court. If you do not know the exact date, you can enter an approximate one.
-<span class="nowrap">For example, 23 9 2018</span></span>
+
+<div id="steps-conviction-known-date-form-known-date-supplemental"><p class="govuk-body-m">This is usually the day you were convicted in court.
+</p></div>
+
+<span class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
+<p>For example, 23 9 2018</p>
+</span>
 
 <span class="govuk-error-message" id="steps-conviction-known-date-form-known-date-error">
   <span class="govuk-visually-hidden">Error: </span>Enter the date in the format dd/mm/yyyy</span>

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -68,4 +68,18 @@ RSpec.describe CustomFormHelpers, type: :helper do
       builder.i18n_hint
     end
   end
+
+  describe '#i18n_lead_text' do
+    before do
+      allow(form_object).to receive(:i18n_attribute).and_return(:foobar)
+    end
+
+    it 'seeks the expected locale key' do
+      expect(I18n).to receive(:t).with(
+        :foobar, scope: [:helpers, :lead_text, :disclosure_check], default: :default
+      )
+
+      builder.i18n_lead_text
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://trello.com/c/L2pqJMHo

Follow-up to PR #449.

We want to introduce some extra copy in all the dates hint text. However in doing this I realised we had many different hint texts depending if it was a caution/conviction and the type of the offence.

In order to make this more easy to maintain so we only have 1 hint text for all dates and it appears in the same place always, I've moved out from the hint text and into the `lead` paragraph some of the copy previously had in the hint text itself.

**Example 1**
<img width="668" alt="Screenshot 2021-02-08 at 16 44 40" src="https://user-images.githubusercontent.com/687910/107362333-85796780-6ad0-11eb-859b-c5aacccf0c7a.png">

---

**Example 2**
<img width="662" alt="Screenshot 2021-02-08 at 16 21 42" src="https://user-images.githubusercontent.com/687910/107362368-90cc9300-6ad0-11eb-9003-84eac7ee1f20.png">
