### PR TITLE
Mechanism to share/return to the results page

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -6,6 +6,8 @@ module ErrorHandling
       case exception
       when Errors::InvalidSession, ActionController::InvalidAuthenticityToken
         redirect_to invalid_session_errors_path
+      when Errors::ResultsNotFound
+        redirect_to results_not_found_errors_path
       when Errors::CheckCompleted
         redirect_to check_completed_errors_path
       when Errors::ReportCompleted

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -9,6 +9,10 @@ class ErrorsController < ApplicationController
     respond_with_status(:not_found)
   end
 
+  def results_not_found
+    respond_with_status(:not_found)
+  end
+
   def check_completed
     respond_with_status(:unprocessable_entity)
   end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,0 +1,20 @@
+class ResultsController < ApplicationController
+  before_action :setup_session
+
+  def show
+    redirect_to steps_check_results_path(show_results: true)
+  end
+
+  private
+
+  def disclosure_report
+    @_disclosure_report ||= DisclosureReport.completed.find_by(
+      id: params[:report_id]
+    ) || (raise Errors::ResultsNotFound)
+  end
+
+  def setup_session
+    # We pick a `check` from the report, any check will do
+    session[:disclosure_check_id] = disclosure_report.disclosure_checks.last.id
+  end
+end

--- a/app/errors/errors.rb
+++ b/app/errors/errors.rb
@@ -1,4 +1,5 @@
 module Errors
+  class ResultsNotFound < StandardError; end
   class InvalidSession < StandardError; end
   class CheckCompleted < StandardError; end
   class ReportCompleted < StandardError; end

--- a/app/views/errors/results_not_found.html.erb
+++ b/app/views/errors/results_not_found.html.erb
@@ -1,0 +1,12 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <p class="govuk-body"><%=t '.lead_text' %></p>
+    <p class="govuk-body"><%=t '.more_text', report_expiry_days: Rails.configuration.x.checks.complete_purge_after_days %></p>
+
+    <%= link_button :start_again, root_path %>
+  </div>
+</div>

--- a/app/views/layouts/_developer_tools.html.erb
+++ b/app/views/layouts/_developer_tools.html.erb
@@ -1,0 +1,14 @@
+<% content_for(:footer_top) do %>
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Developer Tools
+      </span>
+    </summary>
+    <div class="govuk-details__text app-util--inline-buttons">
+      <h4 class="govuk-heading-s">Share the results page</h4>
+      <%= link_to result_path(current_disclosure_report), result_url(current_disclosure_report),
+                  class: 'govuk-link govuk-link--no-visited-state', rel: 'nofollow' %>
+    </div>
+  </details>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,4 +21,8 @@
   <% render partial: 'layouts/footer_links' %>
 <% end %>
 
+<% if dev_tools_enabled? %>
+  <%= render partial: 'layouts/developer_tools' if current_disclosure_report.try(:completed?) %>
+<% end %>
+
 <%= render file: 'layouts/govuk_template' %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -72,6 +72,8 @@
 
 <footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container ">
+    <%= yield(:footer_top) %>
+
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <%= yield(:footer_links) %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -115,6 +115,11 @@ en:
       page_title: Page not found
       heading: Page not found
       lead_text: If you copied a web address, please check it’s correct.
+    results_not_found:
+      page_title: Results not found
+      heading: Results not found
+      lead_text: We couldn’t find the results you are looking for.
+      more_text: Results are stored for up to %{report_expiry_days} days before they are deleted from this service.
     unhandled:
       page_title: Unexpected error
       heading: Sorry, something went wrong with our service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,8 @@ Rails.application.routes.draw do
     post '', action: :create, as: :group
   end
 
+  resources :results, only: [:show], param: :report_id
+
   resources :pilot, only: [:show]
 
   resource :errors, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
     get :invalid_session
     get :unhandled
     get :not_found
+    get :results_not_found
     get :check_completed
     get :report_completed
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ApplicationController do
   controller do
     def my_url; true; end
     def invalid_session; raise Errors::InvalidSession; end
+    def results_not_found; raise Errors::ResultsNotFound; end
     def check_completed; raise Errors::CheckCompleted; end
     def report_completed; raise Errors::ReportCompleted; end
     def another_exception; raise Exception; end
@@ -23,6 +24,17 @@ RSpec.describe ApplicationController do
 
         get :invalid_session
         expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+
+    context 'Errors::ResultsNotFound' do
+      it 'should not report the exception, and redirect to the error page' do
+        routes.draw { get 'results_not_found' => 'anonymous#results_not_found' }
+
+        expect(Raven).not_to receive(:capture_exception)
+
+        get :results_not_found
+        expect(response).to redirect_to(results_not_found_errors_path)
       end
     end
 

--- a/spec/controllers/results_controller_spec.rb
+++ b/spec/controllers/results_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe ResultsController, type: :controller do
+  describe '#show' do
+   context 'when the disclosure report does not exist' do
+      it 'redirects to the results not found error page' do
+        get :show, params: { report_id: '123' }
+        expect(response).to redirect_to(results_not_found_errors_path)
+      end
+    end
+
+    context 'when the disclosure report exists' do
+      let(:disclosure_check)  { create(:disclosure_check, status: :completed) }
+      let(:disclosure_report) { disclosure_check.disclosure_report }
+
+      before do
+        allow(controller).to receive(:disclosure_report).and_return(disclosure_report)
+      end
+
+      it 'assigns the disclosure check to the current session' do
+        expect(session[:disclosure_check_id]).to be_nil
+        get :show, params: { report_id: disclosure_report.id }
+        expect(session[:disclosure_check_id]).to eq(disclosure_check.id)
+      end
+
+      it 'redirects to the results page' do
+        get :show, params: { report_id: disclosure_report.id }
+        expect(response).to redirect_to('/steps/check/results?show_results=true')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Individual commits for more context.

This, for now, it is only for development/test purposes so it is hidden behind the "developer tools" footer menu.

Maybe in the future this is a feature we can expand and offer to end users so they can also share their results with other people.

The mechanism is simple. We use the ID of the `disclosure_report` to get the checks inside, and we pick one and assign their ID to the session, redirecting back to the results page to render the results by running the calculations again from the database.

As there is no personal identification at any point in the service, even if the link is shared publicly with unknown people, there is no risk at all, but just in case I'm using UUIDs so it is impossible to do enumeration attacks, for example.
Also once a "report" is completed, it cannot be altered/edited.

Reports are purged after 60 days so there is plenty of time to share, but we can also evaluate this in the future.

<img width="714" alt="Screenshot 2021-02-10 at 11 09 33" src="https://user-images.githubusercontent.com/687910/107503170-8a522000-6b91-11eb-9c09-3e17efad0b10.png">
