### PR TITLE
Copy changes for youth cautions in results page

### DIFF
--- a/app/value_objects/caution_type.rb
+++ b/app/value_objects/caution_type.rb
@@ -18,6 +18,10 @@ class CautionType < ValueObject
     ].include?(self)
   end
 
+  def youth?
+    YOUTH_TYPES.include?(self)
+  end
+
   def calculator_class
     Calculators::CautionCalculator
   end

--- a/app/views/steps/check/results/shared/_meaning_cautions.en.html.erb
+++ b/app/views/steps/check/results/shared/_meaning_cautions.en.html.erb
@@ -1,0 +1,34 @@
+<% if caution_type.youth? %>
+
+  <h3 class="govuk-heading-s">
+    If a basic or standard criminal record check is requested
+  </h3>
+
+  <p class="govuk-body">
+    You don’t need to tell people about this caution, reprimand or warning once it is spent, as you were under 18 when
+    you received it. It won’t appear on a
+    <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#basic-dbs">basic
+      or standard criminal record check</a>.
+  </p>
+
+  <h3 class="govuk-heading-s">
+    If an enhanced criminal record check is requested
+  </h3>
+
+  <p class="govuk-body">
+    You probably won’t need to tell people about this caution, reprimand or warning once it is spent, as you were under
+    18 when you received it.
+  </p>
+
+  <p class="govuk-body">
+    However, some kinds of jobs may need you to give details of all cautions, reprimands and warnings even when they are
+    spent. Read more about
+    <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#enhanced-dbs">enhanced
+      criminal record checks</a>.
+  </p>
+
+<% else %>
+
+  <%= render partial: 'steps/check/results/shared/meaning' %>
+
+<% end %>

--- a/app/views/steps/check/results/show.en.html+caution_not_spent.erb
+++ b/app/views/steps/check/results/show.en.html+caution_not_spent.erb
@@ -13,7 +13,7 @@
       </div>
     </div>
 
-    <%= render partial: 'steps/check/results/shared/meaning' %>
+    <%= render partial: 'steps/check/results/shared/meaning_cautions', locals: { caution_type: @presenter.caution_type } %>
 
     <%= render partial: 'steps/check/results/shared/summary', locals: { result: @presenter } %>
 

--- a/app/views/steps/check/results/show.en.html+caution_spent.erb
+++ b/app/views/steps/check/results/show.en.html+caution_spent.erb
@@ -13,7 +13,7 @@
       </div>
     </div>
 
-    <%= render partial: 'steps/check/results/shared/meaning' %>
+    <%= render partial: 'steps/check/results/shared/meaning_cautions', locals: { caution_type: @presenter.caution_type } %>
 
     <%= render partial: 'steps/check/results/shared/summary', locals: { result: @presenter } %>
 

--- a/app/views/steps/check/results/show.en.html+caution_spent_simple.erb
+++ b/app/views/steps/check/results/show.en.html+caution_spent_simple.erb
@@ -13,7 +13,7 @@
       </div>
     </div>
 
-    <%= render partial: 'steps/check/results/shared/meaning' %>
+    <%= render partial: 'steps/check/results/shared/meaning_cautions', locals: { caution_type: @presenter.caution_type } %>
 
     <%= render partial: 'steps/check/results/shared/summary', locals: { result: @presenter } %>
 

--- a/spec/value_objects/caution_type_spec.rb
+++ b/spec/value_objects/caution_type_spec.rb
@@ -62,6 +62,30 @@ RSpec.describe CautionType do
     end
   end
 
+  describe '#youth?' do
+    subject { described_class.new(value).youth? }
+
+    context 'youth_conditional_caution' do
+      let(:value) { :youth_conditional_caution }
+      it { expect(subject).to eq(true) }
+    end
+
+    context 'adult_conditional_caution' do
+      let(:value) { :adult_conditional_caution }
+      it { expect(subject).to eq(false) }
+    end
+
+    context 'youth_simple_caution' do
+      let(:value) { :youth_simple_caution }
+      it { expect(subject).to eq(true) }
+    end
+
+    context 'adult_simple_caution' do
+      let(:value) { :adult_simple_caution }
+      it { expect(subject).to eq(false) }
+    end
+  end
+
   describe '#calculator_class' do
     subject { described_class.new(:youth_conditional_caution) }
 


### PR DESCRIPTION
Ticket: https://trello.com/c/eRalDg7Z

Legislation changes were made that relate to Disclosure Checker on 28 November 2020. These were brought to the team's attention on 11 January.

Youth cautions, reprimands and warnings will no longer be automatically disclosed to employers on a Standard or Enhanced Disclosure and Barring Service (DBS) certificate.

Copy changes in the results page when we detect it is a youth caution. No changes for adult cautions (or convictions).

<img width="1002" alt="Screenshot 2021-02-11 at 10 11 22" src="https://user-images.githubusercontent.com/687910/107623627-8b4a8680-6c51-11eb-9827-c13be720cd62.png">
