### PR TITLE
Bump design system version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # This gem complies with the GOV.UK Design System
 # https://design-system.service.gov.uk
 # https://govuk-form-builder.netlify.app
-gem 'govuk_design_system_formbuilder', '~> 2.1.2'
+gem 'govuk_design_system_formbuilder', '~> 2.1.8'
 
 gem 'jquery-rails'
 gem 'pg', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ DEPENDENCIES
   cucumber-rails
   dotenv-rails
   factory_bot_rails
-  govuk_design_system_formbuilder (~> 2.1.2)
+  govuk_design_system_formbuilder (~> 2.1.8)
   i18n-debug
   i18n-tasks (~> 0.9.28)
   jquery-rails

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "^3.11.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-govuk-frontend@^3.9.1:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.9.1.tgz#731aa62f5d956aa9999726027a1e25c8b7e52fc4"
-  integrity sha512-ouOoDUj0QwDA4uCHIBkGCFMpORuTRcSuDscOrz7V1PBcOecntLglxJAZAuNm+j2sPo7anoScHU0ZSeE2QIoeAg==
+govuk-frontend@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.11.0.tgz#5bc38629ec8b290220c2c389dcd664114a045db1"
+  integrity sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg==


### PR DESCRIPTION
Ticket: https://trello.com/c/cPMnLjfr

Bump `govuk-frontend` to latest version `3.11.0`.

It includes bug fixes. No breaking changes.