### PR TITLE
Ensure we work with completed checks

### DIFF
--- a/app/services/calculators/multiples/proceedings.rb
+++ b/app/services/calculators/multiples/proceedings.rb
@@ -45,7 +45,7 @@ module Calculators
       private
 
       def disclosure_checks
-        @_disclosure_checks ||= check_group.disclosure_checks
+        @_disclosure_checks ||= check_group.disclosure_checks.completed
       end
 
       def first_disclosure_check

--- a/spec/services/calculators/multiples/proceedings_spec.rb
+++ b/spec/services/calculators/multiples/proceedings_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe Calculators::Multiples::Proceedings do
   subject { described_class.new(check_group) }
 
-  let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check1, disclosure_check2, disclosure_check3]) }
+  let(:check_group) { instance_double(CheckGroup, disclosure_checks: disclosure_checks_scope) }
+  let(:disclosure_checks_scope) { double('scope', completed: [disclosure_check1, disclosure_check2, disclosure_check3]) }
 
   let(:disclosure_check1) { instance_double(DisclosureCheck, kind: kind, conviction_date: conviction_date, relevant_order?: false) }
   let(:disclosure_check2) { instance_double(DisclosureCheck, kind: kind, relevant_order?: false) }
@@ -103,7 +104,7 @@ RSpec.describe Calculators::Multiples::Proceedings do
   end
 
   describe '#spent_date_without_relevant_orders' do
-    let(:check_group) { instance_double(CheckGroup, disclosure_checks: [disclosure_check1, disclosure_check2]) }
+    let(:disclosure_checks_scope) { double('scope', completed: [disclosure_check1, disclosure_check2]) }
 
     context 'filters our relevant orders' do
       context 'only some are relevant orders' do


### PR DESCRIPTION
Ticket: https://trello.com/c/HML7Aa42

As part of a recent refactor we probably missed the fact a check could be left incomplete (despite the "report" being completed).

Ensuring we work always with the collection of completed `disclosure_check` inside a Proceeding.