### PR TITLE
Submit to sentry missing template exceptions

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -3,4 +3,9 @@ Raven.configure do |config|
   config.environments = %w( production )
   config.silence_ready = true
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+
+  # Ensure we get ActionView::MissingTemplate errors
+  config.excluded_exceptions -= %w(
+    ActionView::MissingTemplate
+  )
 end


### PR DESCRIPTION
As part of ticket https://trello.com/c/HML7Aa42 we found out that Sentry by default was ignoring (not submitting) any `ActionView::MissingTemplate` errors so it was more difficult to find out where our code was failing.

Remove from the list of excluded exceptions `ActionView::MissingTemplate` so we can get these, including their backtrace.