### PR TITLE
Revert removal of FPNs

### DIFF
--- a/app/decorators/conviction_decorator.rb
+++ b/app/decorators/conviction_decorator.rb
@@ -18,6 +18,11 @@ module ConvictionDecorator
       ConvictionType::ADULT_MOTORING.eql?(self)
   end
 
+  def motoring_penalty_notice?
+    ConvictionType::YOUTH_PENALTY_NOTICE.eql?(self) ||
+      ConvictionType::ADULT_PENALTY_NOTICE.eql?(self)
+  end
+
   def motoring_penalty_points?
     ConvictionType::YOUTH_PENALTY_POINTS.eql?(self) ||
       ConvictionType::ADULT_PENALTY_POINTS.eql?(self)

--- a/app/services/calculators/motoring/adult/penalty_notice.rb
+++ b/app/services/calculators/motoring/adult/penalty_notice.rb
@@ -1,0 +1,20 @@
+module Calculators
+  module Motoring
+    module Adult
+      # If an endorsement was received
+      # start_date + 5 years
+
+      # If an endorsement was not received
+      # Go to different result page: https://moj-disclosure-checker.herokuapp.com/motoring/v3/fpn-no-conviction
+      class PenaltyNotice < BaseCalculator
+        REHABILITATION_1 = { months: 60 }.freeze
+
+        def expiry_date
+          return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
+
+          :no_record
+        end
+      end
+    end
+  end
+end

--- a/app/services/calculators/motoring/youth/penalty_notice.rb
+++ b/app/services/calculators/motoring/youth/penalty_notice.rb
@@ -1,0 +1,20 @@
+module Calculators
+  module Motoring
+    module Youth
+      # If an endorsement was received
+      # start_date + 2.5 years
+
+      # If an endorsement was not received
+      # Go to different result page: https://moj-disclosure-checker.herokuapp.com/motoring/v3/fpn-no-conviction
+      class PenaltyNotice < BaseCalculator
+        REHABILITATION_1 = { months: 30 }.freeze
+
+        def expiry_date
+          return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
+
+          :no_record
+        end
+      end
+    end
+  end
+end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -14,8 +14,10 @@ class ConvictionDecisionTree < BaseDecisionTree
       edit(:conviction_subtype)
     when :conviction_subtype
       after_conviction_subtype
-    when :conviction_bail_days, :motoring_endorsement
+    when :conviction_bail_days
       known_date_question
+    when :motoring_endorsement
+      after_motoring_endorsement
     when :conviction_bail
       after_conviction_bail
     when :known_date
@@ -86,10 +88,20 @@ class ConvictionDecisionTree < BaseDecisionTree
     results
   end
 
+  def after_motoring_endorsement
+    return results if penalty_notice_without_endorsement?
+
+    known_date_question
+  end
+
   def after_conviction_bail
     return edit(:conviction_bail_days) if step_value(:conviction_bail).inquiry.yes?
 
     known_date_question
+  end
+
+  def penalty_notice_without_endorsement?
+    conviction_subtype.motoring_penalty_notice? && GenericYesNo.new(disclosure_check.motoring_endorsement).no?
   end
 
   def known_date_question

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -70,6 +70,7 @@ class ConvictionType < ValueObject
 
     YOUTH_DISQUALIFICATION             = new(:youth_disqualification,           parent: YOUTH_MOTORING, relevant_order: true, calculator_class: Calculators::DisqualificationCalculator::Youths),
     YOUTH_MOTORING_FINE                = new(:youth_motoring_fine,              parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Youth::Fine),
+    YOUTH_PENALTY_NOTICE               = new(:youth_penalty_notice,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Youth::PenaltyNotice),
     YOUTH_PENALTY_POINTS               = new(:youth_penalty_points,             parent: YOUTH_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Youth::PenaltyPoints),
 
     ######################
@@ -98,6 +99,7 @@ class ConvictionType < ValueObject
 
     ADULT_DISQUALIFICATION              = new(:adult_disqualification,             parent: ADULT_MOTORING, relevant_order: true, calculator_class: Calculators::DisqualificationCalculator::Adults),
     ADULT_MOTORING_FINE                 = new(:adult_motoring_fine,                parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Adult::Fine),
+    ADULT_PENALTY_NOTICE                = new(:adult_penalty_notice,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Adult::PenaltyNotice),
     ADULT_PENALTY_POINTS                = new(:adult_penalty_points,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Adult::PenaltyPoints),
 
     ADULT_HOSPITAL_ORDER                = new(:adult_hospital_order,               parent: ADULT_CUSTODIAL_SENTENCE, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),

--- a/app/views/steps/check/results/show.en.html+conviction_no_record.erb
+++ b/app/views/steps/check/results/show.en.html+conviction_no_record.erb
@@ -1,0 +1,29 @@
+<% title t('.page_title') %>
+<% track_transaction name: 'Conviction check completed', category: 'Completed checks', dimensions: { spent: 'no_date' } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        This fixed penalty notice (FPN) was not a conviction
+      </h1>
+    </div>
+
+    <p class="govuk-body">
+      You will never need to tell people about this when they ask about your criminal record.
+    </p>
+
+    <div class="govuk-inset-text">
+      Your result is for guidance only. For more information, read <a class="govuk-link" href="#disclaimer">using your results</a>.
+    </div>
+
+    <%= render partial: 'steps/check/results/shared/motoring' if @presenter.conviction_type.motoring? %>
+
+    <%= render partial: 'steps/check/results/shared/summary', locals: { result: @presenter } %>
+
+    <%= render partial: 'steps/check/results/shared/disclaimer' %>
+
+    <%= render partial: 'steps/check/results/shared/feedback' %>
+  </div>
+</div>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -91,10 +91,12 @@ en:
       # adult_motoring
       adult_disqualification: Disqualification
       adult_motoring_fine: Fine
+      adult_penalty_notice: Fixed Penalty notice (FPN)
       adult_penalty_points: Penalty points
       # adult_motoring
       youth_disqualification: Disqualification
       youth_motoring_fine: Fine
+      youth_penalty_notice: Fixed Penalty notice (FPN)
       youth_penalty_points: Penalty points
       # adult_discharge
       adult_bind_over: Bind over
@@ -221,10 +223,12 @@ en:
           # adult_motoring
           adult_disqualification: You were banned from driving
           adult_motoring_fine: A court gave you a fine that was not a fixed penalty notice (FPN)
+          adult_penalty_notice: You were given a fine ‘on the spot’ or by post
           adult_penalty_points: You were given a number of penalty points for a driving offence
           # youth motoring
           youth_disqualification: You were banned from driving
           youth_motoring_fine: A court gave you a fine that was not a fixed penalty notice (FPN)
+          youth_penalty_notice: You were given a fine ‘on the spot’ or by post
           youth_penalty_points: You were given a number of penalty points for a driving offence
           # adult_discharge
           adult_bind_over: Your sentence was postponed as long as you kept to certain conditions
@@ -329,9 +333,11 @@ en:
         adult_service_detention: When were you given the detention?
         adult_disqualification: When did the ban start?
         adult_motoring_fine: When were you given the fine?
+        adult_penalty_notice: When was the endorsement given?
         adult_penalty_points: When were you given the penalty points?
         youth_disqualification: When did the ban start?
         youth_motoring_fine: When were you given the fine?
+        youth_penalty_notice: When was the endorsement given?
         youth_penalty_points: When were you given the penalty points?
       steps_conviction_conviction_type_form:
         conviction_type: What type of conviction did you get?

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -67,10 +67,12 @@ en:
       # adult_motoring
       adult_disqualification: Disqualification
       adult_motoring_fine: Fine
+      adult_penalty_notice: Fixed Penalty notice (FPN)
       adult_penalty_points: Penalty points
       # youth_motoring
       youth_disqualification: Disqualification
       youth_motoring_fine: Fine
+      youth_penalty_notice: Fixed Penalty notice (FPN)
       youth_penalty_points: Penalty points
       # adult_discharge
       adult_bind_over: Bind over
@@ -105,6 +107,8 @@ en:
       title_html: This %{kind} is spent on the day you receive it
     indefinite:
       title_html: This %{kind} is not spent and will stay in place until another order is made to change or end it
+    no_record:
+      title_html: This fixed penalty notice (FPN) was not a conviction
 
   results/shared/date_format:
     exact: '%{date}'

--- a/features/adults/conviction_motoring.feature
+++ b/features/adults/conviction_motoring.feature
@@ -72,6 +72,7 @@ Feature: Adult Conviction
       | subtype                    | endorsement | known_date_header                        | result               | spent_date                                      |
       | Fine                       | Yes         | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 January 2025 |
       | Fine                       | No          | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 January 2021 |
+      | Fixed Penalty notice (FPN) | Yes         | When was the endorsement given?          | /steps/check/results | This conviction will be spent on 1 January 2025 |
 
   @happy_path @date_travel
   Scenario Outline: Motoring penalty points
@@ -87,3 +88,13 @@ Feature: Adult Conviction
     Examples:
       | subtype                    | known_date_header                        | result               | spent_date                      |
       | Penalty points             | When were you given the penalty points?  | /steps/check/results | will be spent on 1 January 2025 |
+
+  @happy_path
+  Scenario: Fixed Penalty notice (FPN) convictions without endorsement
+    When I choose "Fixed Penalty notice (FPN)"
+
+    Then I should see "Did you get an endorsement?"
+    And I choose "No"
+
+    Then I should be on "/steps/check/results"
+    And I should see "This fixed penalty notice (FPN) was not a conviction"

--- a/features/youth/conviction_motoring.feature
+++ b/features/youth/conviction_motoring.feature
@@ -73,6 +73,7 @@ Feature: Youth Conviction
       | subtype                    | endorsement | known_date_header                        | result               | spent_date                                      |
       | Fine                       | Yes         | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 July 2022    |
       | Fine                       | No          | When were you given the fine?            | /steps/check/results | This conviction was spent on 1 July 2020        |
+      | Fixed Penalty notice (FPN) | Yes         | When was the endorsement given?          | /steps/check/results | This conviction will be spent on 1 July 2022    |
 
   @happy_path @date_travel
   Scenario Outline: Motoring penalty points
@@ -88,3 +89,13 @@ Feature: Youth Conviction
     Examples:
       | subtype        | known_date_header                        | result               | spent_date                                      |
       | Penalty points | When were you given the penalty points?  | /steps/check/results | This conviction will be spent on 1 January 2023 |
+
+  @happy_path
+  Scenario: Fixed Penalty notice (FPN) convictions without endorsement
+    When I choose "Fixed Penalty notice (FPN)"
+
+    Then I should see "Did you get an endorsement?"
+    And I choose "No"
+
+    Then I should be on "/steps/check/results"
+    And I should see "This fixed penalty notice (FPN) was not a conviction"

--- a/spec/decorators/conviction_decorator_spec.rb
+++ b/spec/decorators/conviction_decorator_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe ConvictionDecorator do
     end
   end
 
+  describe '#motoring_penalty_notice?' do
+    context 'for an adult `ADULT_PENALTY_NOTICE` conviction type' do
+      subject { ConvictionType::ADULT_PENALTY_NOTICE }
+      it { expect(subject.motoring_penalty_notice?).to eq(true) }
+    end
+
+    context 'for a youth `YOUTH_PENALTY_NOTICE` conviction type' do
+      subject { ConvictionType::YOUTH_PENALTY_NOTICE }
+      it { expect(subject.motoring_penalty_notice?).to eq(true) }
+    end
+  end
+
   describe '#bailable_offense?' do
     context 'for a youth `DETENTION` conviction type' do
       subject { ConvictionType::DETENTION }

--- a/spec/services/calculators/motoring/adult/penalty_notice_spec.rb
+++ b/spec/services/calculators/motoring/adult/penalty_notice_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Motoring::Adult::PenaltyNotice do
+  subject { described_class.new(disclosure_check) }
+
+  let(:disclosure_check) { build(:disclosure_check,
+                                 under_age: under_age,
+                                 known_date: known_date,
+                                 motoring_endorsement: motoring_endorsement) }
+
+  let(:under_age) { GenericYesNo::NO }
+  let(:known_date) { Date.new(2018, 10, 31) }
+  let(:motoring_endorsement) { GenericYesNo::NO }
+
+  describe '#expiry_date' do
+    context 'with a motoring endorsement' do
+      let(:motoring_endorsement) { GenericYesNo::YES }
+      it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
+    end
+
+    context 'without a motoring endorsement' do
+      it { expect(subject.expiry_date).to eq(:no_record) }
+    end
+  end
+end

--- a/spec/services/calculators/motoring/youth/penalty_notice_spec.rb
+++ b/spec/services/calculators/motoring/youth/penalty_notice_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Calculators::Motoring::Youth::PenaltyNotice do
+  subject { described_class.new(disclosure_check) }
+
+  let(:disclosure_check) { build(:disclosure_check,
+                                 under_age: under_age,
+                                 known_date: known_date,
+                                 motoring_endorsement: motoring_endorsement) }
+
+  let(:under_age) { GenericYesNo::YES }
+  let(:known_date) { Date.new(2020, 1, 1) }
+  let(:motoring_endorsement) { GenericYesNo::NO }
+
+  describe '#expiry_date' do
+    context 'with a motoring endorsement' do
+      let(:motoring_endorsement) { GenericYesNo::YES }
+
+      it { expect(subject.expiry_date.to_s).to eq('2022-07-01') }
+    end
+
+    context 'without a motoring endorsement' do
+      it { expect(subject.expiry_date).to eq(:no_record) }
+    end
+  end
+end

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe ConvictionDecisionTree do
         it { is_expected.to have_destination(:motoring_endorsement, :edit) }
       end
 
+      context 'when subtype equal youth_penalty_notice' do
+        let(:conviction_subtype) { :youth_penalty_notice }
+        it { is_expected.to have_destination(:motoring_endorsement, :edit) }
+      end
+
       context 'when subtype equal youth_penalty_points' do
         let(:conviction_subtype) { :youth_penalty_points }
         it { is_expected.to have_destination(:known_date, :edit) }
@@ -66,6 +71,11 @@ RSpec.describe ConvictionDecisionTree do
 
       context 'when subtype equal adult_motoring_fine' do
         let(:conviction_subtype) { :adult_motoring_fine }
+        it { is_expected.to have_destination(:motoring_endorsement, :edit) }
+      end
+
+      context 'when subtype equal adult_penalty_notice' do
+        let(:conviction_subtype) { :adult_penalty_notice }
         it { is_expected.to have_destination(:motoring_endorsement, :edit) }
       end
 
@@ -184,21 +194,31 @@ RSpec.describe ConvictionDecisionTree do
   end
 
   context 'when the step is `motoring_endorsement`' do
-    let(:motoring_endorsement) { GenericYesNo::YES }
+    let(:motoring_endorsement) {GenericYesNo::YES }
     let(:step_params) { { motoring_endorsement:  motoring_endorsement } }
 
-    %i(adult_disqualification adult_motoring_fine adult_penalty_points).each do |subtype|
-      context "when subtype is '#{subtype}'" do
-        let(:conviction_subtype) { subtype }
+    context 'when subtype is equal adult_penalty_notice' do
+      let(:conviction_subtype) { :adult_penalty_notice }
+      context 'with a endorsement' do
+        it { is_expected.to have_destination(:known_date, :edit) }
+      end
 
-        context 'with a endorsement' do
-          it { is_expected.to have_destination(:known_date, :edit) }
-        end
+      context ' without a endorsement' do
+        let(:motoring_endorsement) {GenericYesNo::NO }
+        it { is_expected.to complete_the_check_and_show_results }
+      end
+    end
 
-        context 'without a endorsement' do
-          let(:motoring_endorsement) { GenericYesNo::NO }
-          it { is_expected.to have_destination(:known_date, :edit) }
-        end
+    context 'when subtype is not equal to adult_penalty_notice sub types' do
+      let(:conviction_subtype) { :adult_disqualification }
+
+      context 'with a endorsement' do
+        it { is_expected.to have_destination(:known_date, :edit) }
+      end
+
+      context 'without a endorsement' do
+        let(:motoring_endorsement) {GenericYesNo::NO }
+        it { is_expected.to have_destination(:known_date, :edit) }
       end
     end
   end

--- a/spec/services/conviction_length_choices_spec.rb
+++ b/spec/services/conviction_length_choices_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ConvictionLengthChoices do
       ConvictionType.values.size - described_class::SUBTYPES_HIDE_NO_LENGTH_CHOICE.size
     }
 
-    it { expect(total).to eq(51) }
+    it { expect(total).to eq(53) }
   end
 
   describe '.choices' do

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe ConvictionType do
         expect(values).to eq(%w(
           adult_disqualification
           adult_motoring_fine
+          adult_penalty_notice
           adult_penalty_points
         ))
       end
@@ -466,6 +467,14 @@ RSpec.describe ConvictionType do
       it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Youth::Fine) }
     end
 
+    context 'YOUTH_PENALTY_NOTICE' do
+      let(:subtype) { 'youth_penalty_notice' }
+
+      it { expect(conviction_type.skip_length?).to eq(true) }
+      it { expect(conviction_type.relevant_order?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Youth::PenaltyNotice) }
+    end
+
     context 'YOUTH_PENALTY_POINTS' do
       let(:subtype) { 'youth_penalty_points' }
 
@@ -490,6 +499,14 @@ RSpec.describe ConvictionType do
       it { expect(conviction_type.skip_length?).to eq(true) }
       it { expect(conviction_type.relevant_order?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Adult::Fine) }
+    end
+
+    context 'ADULT_PENALTY_NOTICE' do
+      let(:subtype) { 'adult_penalty_notice' }
+
+      it { expect(conviction_type.skip_length?).to eq(true) }
+      it { expect(conviction_type.relevant_order?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::Motoring::Adult::PenaltyNotice) }
     end
 
     context 'ADULT_PENALTY_POINTS' do


### PR DESCRIPTION
This reverts commit ef87968bdfc518fd624b96e3a3de1748dad18d3c, reversing
changes made to bfa55a8d517e23a3ce8907053f1d0b000cfcaa7a.

Ticket: https://trello.com/c/Vcpqhlqr

As per policy and legal decision, instead of removing completely from
the service FPNs, we are going to maintain them but only when they are
given an endorsement and thus they become a conviction.

In order to do this as clean as possible, first I'm reverting the PR
where the FPNs were removed, fixing any conflicts, so it works as it
was before for `singles`.

It will not work for `multiples` as the work/refactors we did in the
multiples calculator was under the assumption we didn't have FPNs.

In a follow-up PR I will adapt the code so we only leave in the service
FPNs with endorsement, and this will work with multiples too.