### PR TITLE
Avoid jumping from h1 to h3 in results page

### DIFF
--- a/app/views/steps/check/results/shared/_meaning.en.html.erb
+++ b/app/views/steps/check/results/shared/_meaning.en.html.erb
@@ -1,6 +1,6 @@
-<h3 class="govuk-heading-s">
+<h2 class="govuk-heading-m">
   If a basic criminal record check is requested
-</h3>
+</h2>
 
 <p class="govuk-body">
   When a caution or conviction is spent you do not need to tell people about it, or the offence that led to it, if
@@ -9,9 +9,9 @@
     criminal record check</a>.
 </p>
 
-<h3 class="govuk-heading-s">
+<h2 class="govuk-heading-m">
   If a standard or enhanced criminal record check is requested
-</h3>
+</h2>
 
 <p class="govuk-body">
   You will need to tell people about spent cautions or convictions if they request a

--- a/app/views/steps/check/results/shared/_meaning_cautions.en.html.erb
+++ b/app/views/steps/check/results/shared/_meaning_cautions.en.html.erb
@@ -1,8 +1,8 @@
 <% if caution_type.youth? %>
 
-  <h3 class="govuk-heading-s">
+  <h2 class="govuk-heading-m">
     If a basic or standard criminal record check is requested
-  </h3>
+  </h2>
 
   <p class="govuk-body">
     You don’t need to tell people about this caution, reprimand or warning once it is spent, as you were under 18 when
@@ -11,9 +11,9 @@
       or standard criminal record check</a>.
   </p>
 
-  <h3 class="govuk-heading-s">
+  <h2 class="govuk-heading-m">
     If an enhanced criminal record check is requested
-  </h3>
+  </h2>
 
   <p class="govuk-body">
     You probably won’t need to tell people about this caution, reprimand or warning once it is spent, as you were under


### PR DESCRIPTION
Ticket: https://trello.com/c/18AS69LI

Feedback from GDS:

Currently the first 2 headings appear to be h3s:
‘If a basic criminal record check is requested’
‘If a standard or enhanced criminal record check is requested’

These then skip to an h2:
‘How this result has been worked out’

Our internal accessibility guidance states:

'Each page should get one H1 (the title), followed by H2s and H3s. Don’t skip from an h1 to an h3. Nest headings appropriately so that screen reader users, who can navigate using a list of headings, don’t think they’ve missed one which doesn’t exist.'