### PR TITLE
Change back link to GOV.UK page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,9 @@
 class HomeController < ApplicationController
   before_action :existing_disclosure_check_warning, :reset_disclosure_check_session
 
-  def index; end
+  def index
+    redirect_to steps_check_kind_path
+  end
 
   private
 

--- a/app/services/external_url.rb
+++ b/app/services/external_url.rb
@@ -1,0 +1,9 @@
+class ExternalUrl
+  GOVUK_TELL_EMPLOYER_EXTERNAL_URL = 'https://www.gov.uk/tell-employer-or-college-about-criminal-record/check-your-conviction-caution'.freeze
+
+  class << self
+    def govuk_check_your_conviction_caution_url
+      GOVUK_TELL_EMPLOYER_EXTERNAL_URL
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <% content_for(:service_name) do %>
-  <%= link_to service_name, '/', class: 'govuk-header__link govuk-header__link--service-name ga-pageLink', data: {ga_category: 'header', ga_label: 'service name'} %>
+  <%= link_to service_name, root_path, class: 'govuk-header__link govuk-header__link--service-name ga-pageLink', data: {ga_category: 'header', ga_label: 'service name'} %>
 <% end %>
 
 <% content_for(:phase_banner) do %>

--- a/app/views/steps/check/kind/edit.html.erb
+++ b/app/views/steps/check/kind/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% step_header %>
+<% step_header(path: ExternalUrl.govuk_check_your_conviction_caution_url) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/check/results/shared/_disclaimer.en.html.erb
+++ b/app/views/steps/check/results/shared/_disclaimer.en.html.erb
@@ -25,5 +25,5 @@
   start a new check.
 </p>
 
-<%= link_button :restart_check, root_path, class: 'govuk-button ga-pageLink govuk-!-margin-top-2',
+<%= link_button :restart_check, root_path(new: 'y'), class: 'govuk-button ga-pageLink govuk-!-margin-top-2',
                 data: { module: 'govuk-button', ga_category: 'results', ga_label: 'new check' } %>

--- a/features/adults/caution.feature
+++ b/features/adults/caution.feature
@@ -1,7 +1,6 @@
 Feature: Caution
   Background:
     When I visit "/"
-    And I click the "Start now" link
     Then I should see "Were you cautioned or convicted?"
     When I choose "Cautioned"
     Then I should see "How old were you when you got cautioned?"

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -89,7 +89,6 @@ end
 
 When(/^I have started a check$/) do
   step %[I visit "/"]
-  step %[I click the "Start now" link]
 end
 
 When(/^I am in the conviction known date step$/) do

--- a/features/youth/caution.feature
+++ b/features/youth/caution.feature
@@ -1,7 +1,6 @@
 Feature: Caution
   Background:
     When I visit "/"
-    And I click the "Start now" link
     Then I should see "Were you cautioned or convicted?"
     When I choose "Cautioned"
     Then I should see "How old were you when you got cautioned?"

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe HomeController, type: :controller do
         let(:navigation_stack) { %w(/1 /2 /3) }
 
         context 'and user bypass the warning' do
-          it 'responds with HTTP success' do
+          it 'redirects to /steps/check/kind' do
             get :index, session: { disclosure_check_id: existing_disclosure_check.id }, params: {new: 'y'}
-            expect(response).to be_successful
+            expect(response).to redirect_to('/steps/check/kind')
           end
 
           it 'resets the disclosure_check session data' do
@@ -53,9 +53,9 @@ RSpec.describe HomeController, type: :controller do
       context 'with not enough steps advanced' do
         let(:navigation_stack) { %w(/1) }
 
-        it 'responds with HTTP success' do
+        it 'redirects to /steps/check/kind' do
           get :index, session: { disclosure_check_id: existing_disclosure_check.id }
-          expect(response).to be_successful
+          expect(response).to redirect_to('/steps/check/kind')
         end
 
         it 'resets the disclosure check session data' do
@@ -71,9 +71,9 @@ RSpec.describe HomeController, type: :controller do
       let!(:existing_disclosure_check) { nil }
       let(:navigation_stack) { [] }
 
-      it 'responds with HTTP success' do
+      it 'redirects to /steps/check/kind' do
         get :index
-        expect(response).to be_successful
+        expect(response).to redirect_to('/steps/check/kind')
       end
 
       it 'resets the disclosure_checker session data' do

--- a/spec/services/external_url_spec.rb
+++ b/spec/services/external_url_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe ExternalUrl do
+  describe '.govuk_check_your_conviction_caution_url' do
+    it 'has the correct url' do
+      expect(described_class.govuk_check_your_conviction_caution_url).to eq(
+        'https://www.gov.uk/tell-employer-or-college-about-criminal-record/check-your-conviction-caution'
+      )
+    end
+  end
+end


### PR DESCRIPTION
### ⚠️ This is to be deployed tomorrow 1pm ⚠️ 

This is a requirement to be able to send users back to the
GOV.UK page that will be live tomorrow (25th February 2021, at 1pm).

The intention is to make the user feel it never left to a different platform.

Technically I decided to use a new class, to identify external URLs given that
we may have other external urls around, it would become easier to find and change them
in the future.

Story: https://trello.com/c/HPTKJ7Dp