### PR TITLE
Update journey to only have endorsed FPN

### DIFF
--- a/app/forms/steps/conviction/conviction_subtype_form.rb
+++ b/app/forms/steps/conviction/conviction_subtype_form.rb
@@ -27,6 +27,19 @@ module Steps
         disclosure_check.conviction_subtype != conviction_subtype
       end
 
+      def motoring_endorsement
+        return GenericYesNo::YES if motoring_penalty_notice?
+
+        nil
+      end
+
+      def motoring_penalty_notice?
+        [
+          ConvictionType::ADULT_PENALTY_NOTICE,
+          ConvictionType::YOUTH_PENALTY_NOTICE,
+        ].map(&:to_s).include?(conviction_subtype)
+      end
+
       def persist!
         raise DisclosureCheckNotFound unless disclosure_check
         return true unless changed?
@@ -41,7 +54,7 @@ module Steps
           conviction_length_type: nil,
           compensation_paid: nil,
           compensation_payment_date: nil,
-          motoring_endorsement: nil
+          motoring_endorsement: motoring_endorsement
         )
       end
     end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -53,9 +53,11 @@ class ConvictionDecisionTree < BaseDecisionTree
   end
 
   def after_motoring_conviction
-    return edit(:motoring_endorsement) unless conviction_subtype.motoring_penalty_points?
-
-    known_date_question
+    if conviction_subtype.motoring_penalty_points? || conviction_subtype.motoring_penalty_notice?
+      known_date_question
+    else
+      edit(:motoring_endorsement)
+    end
   end
 
   def after_known_date

--- a/app/views/steps/conviction/conviction_subtype/edit.html.erb
+++ b/app/views/steps/conviction/conviction_subtype/edit.html.erb
@@ -7,7 +7,7 @@
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :conviction_subtype, @form_object.values, :value, nil,
-            legend: { text: f.i18n_legend } %>
+            legend: { text: f.i18n_legend }, hint: { text: f.i18n_hint } %>
 
       <%= f.continue_button %>
     <% end %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -91,12 +91,12 @@ en:
       # adult_motoring
       adult_disqualification: Disqualification
       adult_motoring_fine: Fine
-      adult_penalty_notice: Fixed Penalty notice (FPN)
+      adult_penalty_notice: Fixed Penalty notice (FPN) with penalty points (endorsement)
       adult_penalty_points: Penalty points
       # adult_motoring
       youth_disqualification: Disqualification
       youth_motoring_fine: Fine
-      youth_penalty_notice: Fixed Penalty notice (FPN)
+      youth_penalty_notice: Fixed Penalty notice (FPN) with penalty points (endorsement)
       youth_penalty_points: Penalty points
       # adult_discharge
       adult_bind_over: Bind over
@@ -223,12 +223,12 @@ en:
           # adult_motoring
           adult_disqualification: You were banned from driving
           adult_motoring_fine: A court gave you a fine that was not a fixed penalty notice (FPN)
-          adult_penalty_notice: You were given a fine ‘on the spot’ or by post
+          adult_penalty_notice: You were given a fine ‘on the spot’ or by post that is recorded on your driving licence
           adult_penalty_points: You were given a number of penalty points for a driving offence
           # youth motoring
           youth_disqualification: You were banned from driving
           youth_motoring_fine: A court gave you a fine that was not a fixed penalty notice (FPN)
-          youth_penalty_notice: You were given a fine ‘on the spot’ or by post
+          youth_penalty_notice: You were given a fine ‘on the spot’ or by post that is recorded on your driving licence
           youth_penalty_points: You were given a number of penalty points for a driving offence
           # adult_discharge
           adult_bind_over: Your sentence was postponed as long as you kept to certain conditions

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -195,6 +195,9 @@ en:
       steps_conviction_conviction_bail_days_form:
         conviction_bail_days: This is decided by the court. If you do not know the exact number of days you can enter an approximate number or leave this blank, but it might affect the accuracy of your result.
       steps_conviction_conviction_subtype_form:
+        default_html: ''
+        adult_motoring_html: A fixed penalty notice (FPN) with no penalty points is a fine for a minor driving offence. It will not appear on your criminal record unless a court gives you a conviction because of one.
+        youth_motoring_html: A fixed penalty notice (FPN) with no penalty points is a fine for a minor driving offence. It will not appear on your criminal record unless a court gives you a conviction because of one.
         conviction_subtype_options:
           # referral_supervision_yro
           referral_order: You were referred to community volunteers and the youth offending team (YOT)

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -67,12 +67,12 @@ en:
       # adult_motoring
       adult_disqualification: Disqualification
       adult_motoring_fine: Fine
-      adult_penalty_notice: Fixed Penalty notice (FPN)
+      adult_penalty_notice: Fixed Penalty notice (FPN) with penalty points (endorsement)
       adult_penalty_points: Penalty points
       # youth_motoring
       youth_disqualification: Disqualification
       youth_motoring_fine: Fine
-      youth_penalty_notice: Fixed Penalty notice (FPN)
+      youth_penalty_notice: Fixed Penalty notice (FPN) with penalty points (endorsement)
       youth_penalty_points: Penalty points
       # adult_discharge
       adult_bind_over: Bind over

--- a/features/adults/conviction_motoring.feature
+++ b/features/adults/conviction_motoring.feature
@@ -72,7 +72,26 @@ Feature: Adult Conviction
       | subtype                    | endorsement | known_date_header                        | result               | spent_date                                      |
       | Fine                       | Yes         | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 January 2025 |
       | Fine                       | No          | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 January 2021 |
-      | Fixed Penalty notice (FPN) | Yes         | When was the endorsement given?          | /steps/check/results | This conviction will be spent on 1 January 2025 |
+
+  @happy_path  @date_travel
+  Scenario: Motoring endorsed FPN
+    Given The current date is 03-07-2020
+    When I choose "Fixed Penalty notice (FPN) with penalty points (endorsement)"
+
+    Then I should see "When was the endorsement given?"
+    And I enter the following date 01-01-2020
+    Then I should be on "/steps/check/results"
+    And I should see "This conviction will be spent on 1 January 2025"
+
+  @happy_path  @date_travel
+  Scenario: Motoring endorsed FPN
+    Given The current date is 03-07-2020
+    When I choose "Fixed Penalty notice (FPN) with penalty points (endorsement)"
+
+    Then I should see "When was the endorsement given?"
+    And I enter the following date 01-01-2020
+    Then I should be on "/steps/check/results"
+    And I should see "This conviction will be spent on 1 January 2025"
 
   @happy_path @date_travel
   Scenario Outline: Motoring penalty points
@@ -88,13 +107,3 @@ Feature: Adult Conviction
     Examples:
       | subtype                    | known_date_header                        | result               | spent_date                      |
       | Penalty points             | When were you given the penalty points?  | /steps/check/results | will be spent on 1 January 2025 |
-
-  @happy_path
-  Scenario: Fixed Penalty notice (FPN) convictions without endorsement
-    When I choose "Fixed Penalty notice (FPN)"
-
-    Then I should see "Did you get an endorsement?"
-    And I choose "No"
-
-    Then I should be on "/steps/check/results"
-    And I should see "This fixed penalty notice (FPN) was not a conviction"

--- a/features/youth/conviction_motoring.feature
+++ b/features/youth/conviction_motoring.feature
@@ -73,7 +73,18 @@ Feature: Youth Conviction
       | subtype                    | endorsement | known_date_header                        | result               | spent_date                                      |
       | Fine                       | Yes         | When were you given the fine?            | /steps/check/results | This conviction will be spent on 1 July 2022    |
       | Fine                       | No          | When were you given the fine?            | /steps/check/results | This conviction was spent on 1 July 2020        |
-      | Fixed Penalty notice (FPN) | Yes         | When was the endorsement given?          | /steps/check/results | This conviction will be spent on 1 July 2022    |
+
+  @happy_path @date_travel
+  Scenario: Motoring endorsed FPN
+    Given The current date is 03-07-2020
+    When I choose "Fixed Penalty notice (FPN) with penalty points (endorsement)"
+
+    Then I should see "When was the endorsement given?"
+    And I enter the following date 01-01-2020
+
+    Then I should be on "/steps/check/results"
+    And I should see "This conviction will be spent on 1 July 2022"
+
 
   @happy_path @date_travel
   Scenario Outline: Motoring penalty points
@@ -89,13 +100,3 @@ Feature: Youth Conviction
     Examples:
       | subtype        | known_date_header                        | result               | spent_date                                      |
       | Penalty points | When were you given the penalty points?  | /steps/check/results | This conviction will be spent on 1 January 2023 |
-
-  @happy_path
-  Scenario: Fixed Penalty notice (FPN) convictions without endorsement
-    When I choose "Fixed Penalty notice (FPN)"
-
-    Then I should see "Did you get an endorsement?"
-    And I choose "No"
-
-    Then I should be on "/steps/check/results"
-    And I should see "This fixed penalty notice (FPN) was not a conviction"

--- a/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
@@ -38,6 +38,74 @@ RSpec.describe Steps::Conviction::ConvictionSubtypeForm do
   describe '#save' do
     it_behaves_like 'a value object form', attribute_name: :conviction_subtype, example_value: 'referral_order'
 
+    context 'when conviction type is motoring' do
+      context 'and conviction subtype is youth_penalty_notice' do
+        let(:conviction_type) { 'youth_motoring' }
+        let(:conviction_subtype) { 'youth_penalty_notice' }
+
+        it 'saves the record with motoring endorsement saved with `yes` value' do
+          expect(disclosure_check).to receive(:update).with(
+            conviction_subtype: conviction_subtype,
+            # Dependent attributes to be reset
+            known_date: nil,
+            conviction_bail: nil,
+            conviction_bail_days: nil,
+            conviction_length: nil,
+            conviction_length_type: nil,
+            compensation_paid: nil,
+            compensation_payment_date: nil,
+            motoring_endorsement: GenericYesNo::YES,
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+
+        context 'when conviction_subtype is already the same on the model' do
+          let(:disclosure_check) {
+            instance_double(DisclosureCheck, conviction_type: conviction_type, conviction_subtype: conviction_subtype)
+          }
+
+          it 'does not save the record but returns true' do
+            expect(disclosure_check).to_not receive(:update)
+            expect(subject.save).to be(true)
+          end
+        end
+      end
+
+      context 'and conviction subtype is adult_penalty_notice' do
+        let(:conviction_type) { 'adult_motoring' }
+        let(:conviction_subtype) { 'adult_penalty_notice' }
+
+        it 'saves the record with motoring endorsement saved with `yes` value' do
+          expect(disclosure_check).to receive(:update).with(
+            conviction_subtype: conviction_subtype,
+            # Dependent attributes to be reset
+            known_date: nil,
+            conviction_bail: nil,
+            conviction_bail_days: nil,
+            conviction_length: nil,
+            conviction_length_type: nil,
+            compensation_paid: nil,
+            compensation_payment_date: nil,
+            motoring_endorsement: GenericYesNo::YES,
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+
+        context 'when conviction_subtype is already the same on the model' do
+          let(:disclosure_check) {
+            instance_double(DisclosureCheck, conviction_type: conviction_type, conviction_subtype: conviction_subtype)
+          }
+
+          it 'does not save the record but returns true' do
+            expect(disclosure_check).to_not receive(:update)
+            expect(subject.save).to be(true)
+          end
+        end
+      end
+    end
+
     context 'when form is valid' do
       let(:conviction_subtype) { 'referral_order' }
 
@@ -62,7 +130,6 @@ RSpec.describe Steps::Conviction::ConvictionSubtypeForm do
         let(:disclosure_check) {
           instance_double(DisclosureCheck, conviction_type: conviction_type, conviction_subtype: conviction_subtype)
         }
-        let(:conviction_subtype) { 'referral_order' }
 
         it 'does not save the record but returns true' do
           expect(disclosure_check).to_not receive(:update)

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ConvictionDecisionTree do
 
       context 'when subtype equal youth_penalty_notice' do
         let(:conviction_subtype) { :youth_penalty_notice }
-        it { is_expected.to have_destination(:motoring_endorsement, :edit) }
+        it { is_expected.to have_destination(:known_date, :edit) }
       end
 
       context 'when subtype equal youth_penalty_points' do
@@ -76,7 +76,7 @@ RSpec.describe ConvictionDecisionTree do
 
       context 'when subtype equal adult_penalty_notice' do
         let(:conviction_subtype) { :adult_penalty_notice }
-        it { is_expected.to have_destination(:motoring_endorsement, :edit) }
+        it { is_expected.to have_destination(:known_date, :edit) }
       end
 
       context 'when subtype equal adult_penalty_points' do


### PR DESCRIPTION
Story: https://trello.com/c/jdhA6rjb/64-dc-endorsed-fpns-journey

We are not removing the page that questions users about endorsement, we are just removing non-endorsed FPN from the journey.

