### PR TITLE
Check your answers page

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,19 @@ For more details on the ENV variables needed for CircleCI, refer to the [deploy 
 [c100-application]: https://github.com/ministryofjustice/c100-application
 [deploy-repo]: https://github.com/ministryofjustice/disclosure-checker-deploy
 [k8s-staging]: https://disclosure-checker-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+
+
+## This version of ChromeDriver only supports Chrome version...
+
+When you are running your cucumber features and suddenly you are presented with failing features,
+where the error message is related with ChromeDriver, as such
+
+`This version of ChromeDriver only supports Chrome version 80`
+
+The solution on MacOS is to use [Homebrew](http://brew.sh) and upgrade ChromeDriver
+
+```
+brew upgrade chromedriver
+```
+
+This happens because Chrome updates it's version automatically, this may happen once in a while.

--- a/app/presenters/caution_result_presenter.rb
+++ b/app/presenters/caution_result_presenter.rb
@@ -7,7 +7,6 @@ class CautionResultPresenter < ResultsPresenter
 
   def question_attributes
     [
-      :caution_type,
       :under_age,
       :known_date,
       :conditional_end_date,

--- a/app/presenters/check_presenter.rb
+++ b/app/presenters/check_presenter.rb
@@ -12,6 +12,10 @@ class CheckPresenter
     )
   end
 
+  def type
+    CheckTypePresenter.new(disclosure_check).type
+  end
+
   def to_partial_path
     'check_your_answers/shared/check_row'
   end

--- a/app/presenters/check_type_presenter.rb
+++ b/app/presenters/check_type_presenter.rb
@@ -1,0 +1,22 @@
+class CheckTypePresenter
+  attr_reader :disclosure_check
+
+  def initialize(disclosure_check)
+    @disclosure_check = disclosure_check
+  end
+
+  def type
+    kind.humanize
+  end
+
+  private
+
+  def kind
+    case CheckKind.new(disclosure_check.kind)
+    when CheckKind::CAUTION
+      disclosure_check.caution_type
+    when CheckKind::CONVICTION
+      disclosure_check.conviction_subtype
+    end
+  end
+end

--- a/app/presenters/conviction_result_presenter.rb
+++ b/app/presenters/conviction_result_presenter.rb
@@ -7,7 +7,6 @@ class ConvictionResultPresenter < ResultsPresenter
 
   def question_attributes
     [
-      :conviction_subtype,
       :under_age,
       :conviction_bail_days,
       :known_date,

--- a/app/views/steps/check/check_your_answers/shared/_check.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check.html.erb
@@ -1,8 +1,8 @@
-<h3 class="govuk-heading-s govuk-!-margin-bottom-1">
-  <%= "#{check.number}. #{t("kind.#{check.check_group_name}", scope: check.scope)}"%>
-</h3>
+<h2 class="govuk-heading-l">
+  <%= "#{t("kind.#{check.check_group_name}", scope: check.scope)} #{check.number}"%>
+</h2>
 
-<div class="govuk-inset-text govuk-!-margin-top-2">
+<div class="govuk-body">
   <%= render check.spent_date_panel if check.spent_date %>
 
   <%= render check.summary %>

--- a/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
@@ -1,3 +1,5 @@
+<h3><%= check_row.type %></h3>
+
 <dl class="govuk-summary-list multiple-checks-summary">
   <%= render check_row.summary.question_answers %>
 </dl>

--- a/app/views/steps/check/check_your_answers/show.html.erb
+++ b/app/views/steps/check/check_your_answers/show.html.erb
@@ -2,17 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">What you've told us</h1>
-
-    <p class="govuk-body">Here’s what you’ve told us so far. You can check the information you’ve entered is correct before choosing to:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>add a sentence to an existing conviction – for example, if you were given a community order and a fine for a single offence)</li>
-      <li>enter a separate caution or conviction – for example, if you were convicted for an unrelated offence</li>
-      <li>continue to the results page, if you have no more cautions, convictions or sentences to check</li>
-    </ul>
-
-    <p class="govuk-heading-m">Your cautions or convictions</p>
+    <h1 class="govuk-heading-xl">Check your answers</h1>
 
     <%= render @presenter.summary %>
 

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -142,7 +142,7 @@ en:
     conviction_bail_days:
       question: Days on bail
     known_date:
-      question: Start date
+      question: Date of sentence
     conviction_length:
       question: Length of conviction
       answers:

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -36,16 +36,13 @@ RSpec.describe CautionResultPresenter do
 
     context 'for a youth simple caution' do
       it 'returns the correct question-answer pairs' do
-        expect(summary.size).to eq(3)
+        expect(summary.size).to eq(2)
 
-        expect(summary[0].question).to eql(:caution_type)
-        expect(summary[0].answer).to eql('youth_simple_caution')
+        expect(summary[0].question).to eql(:under_age)
+        expect(summary[0].answer).to eql('yes')
 
-        expect(summary[1].question).to eql(:under_age)
-        expect(summary[1].answer).to eql('yes')
-
-        expect(summary[2].question).to eql(:known_date)
-        expect(summary[2].answer).to eq('31 October 2018')
+        expect(summary[1].question).to eql(:known_date)
+        expect(summary[1].answer).to eq('31 October 2018')
       end
     end
 
@@ -53,19 +50,16 @@ RSpec.describe CautionResultPresenter do
       let(:disclosure_check) { build(:disclosure_check, :youth_conditional_caution) }
 
       it 'returns the correct question-answer pairs' do
-        expect(summary.size).to eq(4)
+        expect(summary.size).to eq(3)
 
-        expect(summary[0].question).to eql(:caution_type)
-        expect(summary[0].answer).to eql('youth_conditional_caution')
+        expect(summary[0].question).to eql(:under_age)
+        expect(summary[0].answer).to eql('yes')
 
-        expect(summary[1].question).to eql(:under_age)
-        expect(summary[1].answer).to eql('yes')
+        expect(summary[1].question).to eql(:known_date)
+        expect(summary[1].answer).to eq('31 October 2018')
 
-        expect(summary[2].question).to eql(:known_date)
-        expect(summary[2].answer).to eq('31 October 2018')
-
-        expect(summary[3].question).to eql(:conditional_end_date)
-        expect(summary[3].answer).to eq('25 December 2018')
+        expect(summary[2].question).to eql(:conditional_end_date)
+        expect(summary[2].answer).to eq('25 December 2018')
       end
     end
 
@@ -73,11 +67,11 @@ RSpec.describe CautionResultPresenter do
       let(:disclosure_check) { build(:disclosure_check, :youth_conditional_caution, approximate_known_date: true) }
 
       it 'formats the date to indicate it is approximate' do
-        expect(summary[2].question).to eql(:known_date)
-        expect(summary[2].answer).to eq('31 October 2018 (approximate)')
+        expect(summary[1].question).to eql(:known_date)
+        expect(summary[1].answer).to eq('31 October 2018 (approximate)')
 
-        expect(summary[3].question).to eql(:conditional_end_date)
-        expect(summary[3].answer).to eq('25 December 2018')
+        expect(summary[2].question).to eql(:conditional_end_date)
+        expect(summary[2].answer).to eq('25 December 2018')
       end
     end
   end

--- a/spec/presenters/check_presenter_spec.rb
+++ b/spec/presenters/check_presenter_spec.rb
@@ -13,7 +13,25 @@ RSpec.describe CheckPresenter do
     context 'for a single youth caution' do
       it 'returns CheckRow' do
         expect(summary).to be_an_instance_of(CheckRow)
-        expect(summary.question_answers.size).to eq(3)
+        expect(summary.question_answers.size).to eq(2)
+      end
+    end
+  end
+
+  describe '#type' do
+    let(:type) { subject.type }
+
+    context 'for a caution' do
+      it 'returns a caution type' do
+        expect(type).to eq('Youth simple caution')
+      end
+    end
+
+    context 'for a conviction' do
+      let(:disclosure_check) { create(:disclosure_check, :with_fine, :completed) }
+
+      it 'returns a caution type' do
+        expect(type).to eq('Fine')
       end
     end
   end

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -37,19 +37,16 @@ RSpec.describe ConvictionResultPresenter do
     let(:summary) { subject.summary }
 
     it 'returns the correct question-answer pairs' do
-      expect(summary.size).to eq(4)
+      expect(summary.size).to eq(3)
 
-      expect(summary[0].question).to eql(:conviction_subtype)
-      expect(summary[0].answer).to eql('detention_training_order')
+      expect(summary[0].question).to eql(:under_age)
+      expect(summary[0].answer).to eql('yes')
 
-      expect(summary[1].question).to eql(:under_age)
-      expect(summary[1].answer).to eql('yes')
+      expect(summary[1].question).to eql(:known_date)
+      expect(summary[1].answer).to eq('31 October 2018')
 
-      expect(summary[2].question).to eql(:known_date)
-      expect(summary[2].answer).to eq('31 October 2018')
-
-      expect(summary[3].question).to eql(:conviction_length)
-      expect(summary[3].answer).to eq('9 weeks')
+      expect(summary[2].question).to eql(:conviction_length)
+      expect(summary[2].answer).to eq('9 weeks')
     end
 
     context 'when no length given' do
@@ -58,10 +55,10 @@ RSpec.describe ConvictionResultPresenter do
       }
 
       it 'returns the correct question-answer pairs' do
-        expect(summary.size).to eq(4)
+        expect(summary.size).to eq(3)
 
-        expect(summary[3].question).to eql(:conviction_length)
-        expect(summary[3].answer).to eq('No length was given')
+        expect(summary[2].question).to eql(:conviction_length)
+        expect(summary[2].answer).to eq('No length was given')
       end
     end
 
@@ -69,19 +66,16 @@ RSpec.describe ConvictionResultPresenter do
       let(:disclosure_check) { build(:disclosure_check, :compensation) }
 
       it 'returns the correct question-answer pairs' do
-        expect(summary.size).to eq(4)
+        expect(summary.size).to eq(3)
 
-        expect(summary[0].question).to eql(:conviction_subtype)
-        expect(summary[0].answer).to eql('compensation_to_a_victim')
+        expect(summary[0].question).to eql(:under_age)
+        expect(summary[0].answer).to eql('yes')
 
-        expect(summary[1].question).to eql(:under_age)
-        expect(summary[1].answer).to eql('yes')
+        expect(summary[1].question).to eql(:known_date)
+        expect(summary[1].answer).to eq('31 October 2018')
 
-        expect(summary[2].question).to eql(:known_date)
-        expect(summary[2].answer).to eq('31 October 2018')
-
-        expect(summary[3].question).to eql(:compensation_payment_date)
-        expect(summary[3].answer).to eq('31 October 2019')
+        expect(summary[2].question).to eql(:compensation_payment_date)
+        expect(summary[2].answer).to eq('31 October 2019')
       end
     end
 
@@ -89,11 +83,11 @@ RSpec.describe ConvictionResultPresenter do
       let(:disclosure_check) { build(:disclosure_check, :compensation, approximate_compensation_payment_date: true) }
 
       it 'formats the date to indicate it is approximate' do
-        expect(summary[2].question).to eql(:known_date)
-        expect(summary[2].answer).to eq('31 October 2018')
+        expect(summary[1].question).to eql(:known_date)
+        expect(summary[1].answer).to eq('31 October 2018')
 
-        expect(summary[3].question).to eql(:compensation_payment_date)
-        expect(summary[3].answer).to eq('31 October 2019 (approximate)')
+        expect(summary[2].question).to eql(:compensation_payment_date)
+        expect(summary[2].answer).to eq('31 October 2019 (approximate)')
       end
     end
 
@@ -101,19 +95,16 @@ RSpec.describe ConvictionResultPresenter do
       let(:disclosure_check) { build(:disclosure_check, :dto_conviction, conviction_bail_days: 15) }
 
       it 'returns the correct question-answer pairs' do
-        expect(summary.size).to eq(5)
+        expect(summary.size).to eq(4)
 
-        expect(summary[0].question).to eql(:conviction_subtype)
-        expect(summary[0].answer).to eql('detention_training_order')
+        expect(summary[0].question).to eql(:under_age)
+        expect(summary[0].answer).to eql('yes')
 
-        expect(summary[1].question).to eql(:under_age)
-        expect(summary[1].answer).to eql('yes')
+        expect(summary[1].question).to eql(:conviction_bail_days)
+        expect(summary[1].answer).to eq(15)
 
-        expect(summary[2].question).to eql(:conviction_bail_days)
-        expect(summary[2].answer).to eq(15)
-
-        expect(summary[3].question).to eql(:known_date)
-        expect(summary[3].answer).to eq('31 October 2018')
+        expect(summary[2].question).to eql(:known_date)
+        expect(summary[2].answer).to eq('31 October 2018')
 
         # ignoring following rows as they are the same as in other tests
       end


### PR DESCRIPTION
Story: https://trello.com/c/eLQkrUGd/203-dc-work-on-check-your-answers-page

This is a close implementation of [this page in the prototype](https://moj-disclosure-checker.herokuapp.com/prototype-2/check-your-answers/check-your-answers)

Except it will have the buttons to add another sentence or another conviction until [this story is completed](https://trello.com/c/krAsstbg/204-dc-question-page-to-new-caution-conviction)


### After

![image](https://user-images.githubusercontent.com/136777/111342946-d7cf1a80-8672-11eb-9f4e-eec82b282f27.png)
