### PR TITLE
Check Your Answers Page

### DIFF
--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -25,9 +25,8 @@ class StepController < ApplicationController
         # (and usually only) attribute in the form.
         as:            opts[:as],
         next_step:     @next_step,
-        # TODO: following is only for the multiples MVP while it is behind a feature flag.
-        # We propagate this to the decision trees as they don't have access to the session.
-        multiples_enabled: multiples_enabled?
+        # Through the following, decision trees can have access to the session.
+        controller:    self
       ).destination
 
       redirect_to destination

--- a/app/controllers/steps/check/caution_or_conviction_controller.rb
+++ b/app/controllers/steps/check/caution_or_conviction_controller.rb
@@ -1,0 +1,13 @@
+module Steps
+  module Check
+    class CautionOrConvictionController < Steps::CheckStepController
+      def edit
+        @form_object = CautionOrConvictionForm.build(current_disclosure_check)
+      end
+
+      def update
+        update_and_advance(CautionOrConvictionForm)
+      end
+    end
+  end
+end

--- a/app/controllers/steps/check/results_controller.rb
+++ b/app/controllers/steps/check/results_controller.rb
@@ -8,7 +8,7 @@ module Steps
 
       def show
         @presenter = if show_multiple_results?
-                       CheckAnswersPresenter.new(current_disclosure_report)
+                       MultipleResultsPresenter.new(current_disclosure_report)
                      else
                        ResultsPresenter.build(current_disclosure_check)
                      end

--- a/app/forms/steps/check/caution_or_conviction_form.rb
+++ b/app/forms/steps/check/caution_or_conviction_form.rb
@@ -1,0 +1,16 @@
+module Steps
+  module Check
+    class CautionOrConvictionForm < BaseForm
+      include SingleQuestionForm
+
+      yes_no_attribute :add_caution_or_conviction
+
+      # There is no DB attribute for this form-object so we just return `true`
+      def persist!
+        raise DisclosureCheckNotFound unless disclosure_check
+
+        true
+      end
+    end
+  end
+end

--- a/app/presenters/check_group_presenter.rb
+++ b/app/presenters/check_group_presenter.rb
@@ -1,16 +1,19 @@
 class CheckGroupPresenter
   attr_reader :number, :check_group, :spent_date, :scope
 
-  def initialize(number, check_group, spent_date:, scope:)
+  def initialize(number, check_group, spent_date:, scope:, results_page: false)
     @number = number
     @check_group = check_group
     @spent_date = spent_date
     @scope = scope
+    @results_page = results_page
   end
 
   def summary
-    completed_checks.map do |disclosure_check|
-      CheckPresenter.new(disclosure_check)
+    sentences = completed_checks.size
+
+    completed_checks.map.with_index(1) do |disclosure_check, i|
+      CheckPresenter.new(disclosure_check, number: i, sentences: sentences, results_page: @results_page)
     end
   end
 
@@ -22,7 +25,11 @@ class CheckGroupPresenter
   end
 
   def to_partial_path
-    'check_your_answers/shared/check'
+    if @results_page
+      'results/multiples/check'
+    else
+      'check_your_answers/shared/check'
+    end
   end
 
   def add_another_sentence_button?

--- a/app/presenters/check_presenter.rb
+++ b/app/presenters/check_presenter.rb
@@ -1,18 +1,30 @@
 class CheckPresenter
-  attr_reader :disclosure_check
+  attr_reader :disclosure_check, :number
 
-  def initialize(disclosure_check)
+  def initialize(disclosure_check, number:, sentences:, results_page: false)
     @disclosure_check = disclosure_check
+    @results_page = results_page
+    @number = number
+    @sentences = sentences
+  end
+
+  def show_sentence_header?
+    @sentences > 1
   end
 
   def summary
     CheckRow.new(
       ResultsPresenter.build(disclosure_check).summary,
-      scope: to_partial_path
+      scope: to_partial_path,
+      results_page: @results_page
     )
   end
 
   def to_partial_path
-    'check_your_answers/shared/check_row'
+    if @results_page
+      'results/multiples/check_row'
+    else
+      'check_your_answers/shared/check_row'
+    end
   end
 end

--- a/app/presenters/check_row.rb
+++ b/app/presenters/check_row.rb
@@ -1,12 +1,17 @@
 class CheckRow
   attr_reader :question_answers, :scope
 
-  def initialize(question_answers, scope:)
+  def initialize(question_answers, scope:, results_page: false)
     @question_answers = question_answers
     @scope = scope
+    @results_page = results_page
   end
 
   def to_partial_path
-    'check_your_answers/shared/check_row'
+    if @results_page
+      'results/multiples/check_row'
+    else
+      'check_your_answers/shared/check_row'
+    end
   end
 end

--- a/app/presenters/multiple_results_presenter.rb
+++ b/app/presenters/multiple_results_presenter.rb
@@ -1,0 +1,31 @@
+class MultipleResultsPresenter
+  attr_reader :disclosure_report
+
+  def initialize(disclosure_report)
+    @disclosure_report = disclosure_report
+  end
+
+  def summary
+    calculator.proceedings.map.with_index(1) do |proceeding, i|
+      CheckGroupPresenter.new(
+        i,
+        proceeding.check_group,
+        spent_date: calculator.spent_date_for(proceeding),
+        scope: to_partial_path,
+        results_page: true
+      )
+    end
+  end
+
+  def calculator
+    @_calculator ||= Calculators::Multiples::MultipleOffensesCalculator.new(disclosure_report)
+  end
+
+  def variant
+    :multiples
+  end
+
+  def to_partial_path
+    'results/multiples/check'
+  end
+end

--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -4,7 +4,7 @@ class BaseDecisionTree
   include ApplicationHelper
 
   attr_reader :disclosure_check, :record, :step_params,
-              :as, :next_step, :multiples_enabled
+              :as, :next_step, :controller
 
   def initialize(disclosure_check:, record: nil, step_params: {}, **options)
     @disclosure_check = disclosure_check
@@ -12,13 +12,13 @@ class BaseDecisionTree
     @step_params = step_params
     @as = options[:as]
     @next_step = options[:next_step]
-    @multiples_enabled = options[:multiples_enabled]
+    @controller = options[:controller]
   end
 
   private
 
   def multiples_enabled?
-    @multiples_enabled
+    controller.multiples_enabled?
   end
 
   def step_value(attribute_name)
@@ -29,8 +29,8 @@ class BaseDecisionTree
     (as || step_params.keys.first).to_sym
   end
 
-  def show(step_controller)
-    { controller: step_controller, action: :show }
+  def show(step_controller, params = {})
+    {controller: step_controller, action: :show}.merge(params)
   end
 
   def edit(step_controller, params = {})

--- a/app/services/check_decision_tree.rb
+++ b/app/services/check_decision_tree.rb
@@ -7,6 +7,8 @@ class CheckDecisionTree < BaseDecisionTree
       edit(:under_age)
     when :under_age
       after_under_age
+    when :add_caution_or_conviction
+      after_add_caution_or_conviction
     else
       raise InvalidStep, "Invalid step '#{as || step_params}'"
     end
@@ -23,5 +25,16 @@ class CheckDecisionTree < BaseDecisionTree
 
       edit('/steps/conviction/conviction_type')
     end
+  end
+
+  def after_add_caution_or_conviction
+    return show(:results, show_results: true) if GenericYesNo.new(step_params[:add_caution_or_conviction]).no?
+
+    controller.send(
+      :initialize_disclosure_check,
+      disclosure_report: disclosure_check.disclosure_report
+    )
+
+    edit(:kind)
   end
 end

--- a/app/views/steps/check/caution_or_conviction/edit.html.erb
+++ b/app/views/steps/check/caution_or_conviction/edit.html.erb
@@ -1,0 +1,16 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+
+    <!-- The header is part of the radios legend by default, but can be configured -->
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :add_caution_or_conviction,
+            GenericYesNo.values, :value, nil, inline: true %>
+        <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/check/check_your_answers/shared/_check.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check.html.erb
@@ -1,17 +1,17 @@
-<h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+<h2 class="govuk-heading-l govuk-!-margin-bottom-3">
   <%= "#{check.number}. #{t("kind.#{check.check_group_name}", scope: check.scope)}"%>
-</h3>
+</h2>
 
-<div class="govuk-inset-text govuk-!-margin-top-2">
-  <%= render check.spent_date_panel if check.spent_date %>
+<%= render check.summary %>
 
-  <%= render check.summary %>
+<% if check.add_another_sentence_button? %>
+  <p class="govuk-body">
+    If you were given more than one sentence as part of this conviction you must add it now.
+  </p>
 
-  <% if check.add_another_sentence_button? %>
-    <div class="govuk-!-margin-top-1">
-      <%= button_to 'Add another sentence to this conviction', check_group_path(check.check_group),
-                          class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
-                          data: { module: 'govuk-button', 'prevent-double-click': true } %>
-    </div>
-  <% end %>
-</div>
+  <div class="govuk-button-group govuk-!-margin-bottom-6">
+    <%= button_to 'Add another sentence', check_group_path(check.check_group),
+                        class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
+                        data: { module: 'govuk-button', 'prevent-double-click': true } %>
+  </div>
+<% end %>

--- a/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
@@ -1,3 +1,9 @@
+<% if check_row.show_sentence_header? %>
+  <h3 class="govuk-heading-m govuk-!-margin-bottom-1">
+    Sentence <%= check_row.number %>
+  </h3>
+<% end %>
+
 <dl class="govuk-summary-list multiple-checks-summary">
   <%= render check_row.summary.question_answers %>
 </dl>

--- a/app/views/steps/check/check_your_answers/show.html.erb
+++ b/app/views/steps/check/check_your_answers/show.html.erb
@@ -2,17 +2,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">What you've told us</h1>
+    <h1 class="govuk-heading-xl">Check your answers</h1>
 
-    <p class="govuk-body">Here’s what you’ve told us so far. You can check the information you’ve entered is correct before choosing to:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>add a sentence to an existing conviction – for example, if you were given a community order and a fine for a single offence)</li>
-      <li>enter a separate caution or conviction – for example, if you were convicted for an unrelated offence</li>
-      <li>continue to the results page, if you have no more cautions, convictions or sentences to check</li>
-    </ul>
-
-    <p class="govuk-heading-m">Your cautions or convictions</p>
+    <p class="govuk-body">
+      You can add more sentences to the convictions you’ve told us about on this page. You will be able to add more convictions later.
+    </p>
 
     <%= render @presenter.summary %>
 

--- a/app/views/steps/check/check_your_answers/show.html.erb
+++ b/app/views/steps/check/check_your_answers/show.html.erb
@@ -10,12 +10,6 @@
 
     <%= render @presenter.summary %>
 
-    <h2 class="govuk-heading-m">Add a separate caution or conviction</h2>
-
-    <%= button_to 'Enter a new caution or conviction', checks_path,
-                  class: 'govuk-button govuk-button--secondary',
-                  data: { module: 'govuk-button', 'prevent-double-click': true } %>
-
-    <%= link_button :results_page, steps_check_results_path(show_results: true), class: 'govuk-button govuk-!-margin-top-5' %>
+    <%= link_to t('helpers.buttons.continue'), edit_steps_check_caution_or_conviction_path, class: 'govuk-button govuk-!-margin-top-5' %>
   </div>
 </div>

--- a/app/views/steps/check/results/multiples/_check.html.erb
+++ b/app/views/steps/check/results/multiples/_check.html.erb
@@ -1,0 +1,17 @@
+<h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+  <%= "#{check.number}. #{t("kind.#{check.check_group_name}", scope: check.scope)}"%>
+</h3>
+
+<div class="govuk-inset-text govuk-!-margin-top-2">
+  <%= render check.spent_date_panel if check.spent_date %>
+
+  <%= render check.summary %>
+
+  <% if check.add_another_sentence_button? %>
+    <div class="govuk-!-margin-top-1">
+      <%= button_to 'Add another sentence to this conviction', check_group_path(check.check_group),
+                          class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
+                          data: { module: 'govuk-button', 'prevent-double-click': true } %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/steps/check/results/multiples/_check_row.html.erb
+++ b/app/views/steps/check/results/multiples/_check_row.html.erb
@@ -1,0 +1,3 @@
+<dl class="govuk-summary-list multiple-checks-summary">
+  <%= render check_row.summary.question_answers %>
+</dl>

--- a/config/locales/en/check.yml
+++ b/config/locales/en/check.yml
@@ -11,3 +11,6 @@ en:
       check_your_answers:
         show:
           page_title: Check your answers
+      caution_or_conviction:
+        edit:
+          page_title: Add a new caution or conviction

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -71,6 +71,10 @@ en:
           attributes:
             motoring_endorsement:
               inclusion: Select yes if you have received an endorsement
+        steps/check/caution_or_conviction_form:
+          attributes:
+            add_caution_or_conviction:
+              inclusion: Select yes if you have another caution on conviction to check
 
   errors:
     format: "%{message}"

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -173,6 +173,8 @@ en:
         kind_options:
           caution: You were given an official warning by the police
           conviction: You were found guilty of a crime in court
+      steps_check_caution_or_conviction_form:
+        add_caution_or_conviction_html: You must enter details of all cautious or convictions if you have received more than one.
       steps_caution_known_date_form:
         known_date_html: *date_hint_text
       steps_check_under_age_form:
@@ -251,6 +253,8 @@ en:
         under_age_options:
           'yes': Under 18
           'no': 18 or over
+      steps_check_caution_or_conviction_form:
+        add_caution_or_conviction_options: *YESNO
       steps_caution_known_date_form:
         approximate_known_date_options:
           'true': *approximate_date_checkbox
@@ -307,6 +311,8 @@ en:
       steps_check_under_age_form:
         caution: How old were you when you got cautioned?
         conviction: How old were you when you got convicted?
+      steps_check_caution_or_conviction_form:
+        add_caution_or_conviction: Do you have another caution on conviction you'd like to check?
       steps_caution_known_date_form:
         known_date: When did you get the caution?
         approximate_known_date: *approximate_date_legend

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -87,6 +87,10 @@ en:
     kind:
       caution: Caution
       conviction: Conviction
+  results/multiples/check:
+    kind:
+      caution: Caution
+      conviction: Conviction
 
   steps:
     check:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
       edit_step :under_age
       show_step :results
       show_step :check_your_answers
+      edit_step :caution_or_conviction
     end
 
     namespace :caution do

--- a/spec/controllers/steps/check/caution_or_conviction_controller_spec.rb
+++ b/spec/controllers/steps/check/caution_or_conviction_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Check::CautionOrConvictionController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Check::CautionOrConvictionForm, CheckDecisionTree
+end

--- a/spec/controllers/steps/check/results_controller_spec.rb
+++ b/spec/controllers/steps/check/results_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Steps::Check::ResultsController, type: :controller do
           get :show, params: { show_results: true }
 
           expect(response).to render_template(:show)
-          expect(assigns[:presenter]).to be_a_kind_of(CheckAnswersPresenter)
+          expect(assigns[:presenter]).to be_a_kind_of(MultipleResultsPresenter)
         end
       end
 

--- a/spec/forms/steps/check/caution_or_conviction_form_spec.rb
+++ b/spec/forms/steps/check/caution_or_conviction_form_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Check::CautionOrConvictionForm do
+  # NOTE: not using the shared examples for 'a yes-no question form' because
+  # we are performing a custom override of the `#persist!` method.
+
+  let(:question_attribute) { :add_caution_or_conviction }
+  let(:answer_value) { 'yes' }
+
+  let(:arguments) {
+    {
+      disclosure_check: disclosure_check,
+      question_attribute => answer_value
+    }
+  }
+
+  let(:disclosure_check) { instance_double(DisclosureCheck) }
+
+  subject { described_class.new(arguments) }
+
+  describe 'validations on field presence' do
+    it { should validate_presence_of(question_attribute, :inclusion) }
+  end
+
+  describe '#save' do
+    context 'when no disclosure_check is associated with the form' do
+      let(:disclosure_check) { nil }
+
+      it 'raises an error' do
+        expect { described_class.new(arguments).save }.to raise_error(BaseForm::DisclosureCheckNotFound)
+      end
+    end
+
+    context 'when answer is `yes`' do
+      let(:answer_value) { 'yes' }
+
+      it 'saves the record' do
+        expect(disclosure_check).not_to receive(:update)
+        expect(described_class.new(arguments).save).to be(true)
+      end
+    end
+
+    context 'when answer is `no`' do
+      let(:answer_value) { 'no' }
+
+      it 'saves the record' do
+        expect(disclosure_check).not_to receive(:update)
+        expect(described_class.new(arguments).save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/presenters/check_group_presenter_spec.rb
+++ b/spec/presenters/check_group_presenter_spec.rb
@@ -2,18 +2,26 @@ RSpec.describe CheckGroupPresenter do
   let!(:disclosure_check) { create(:disclosure_check, :completed) }
   let(:number) { 1 }
   let(:spent_date) { nil }
+  let(:results_page) { false }
 
   subject {
     described_class.new(
       number,
       disclosure_check.check_group,
       spent_date: spent_date,
-      scope: 'some/path'
+      scope: 'some/path',
+      results_page: results_page
     )
   }
 
   describe '#to_partial_path' do
     it { expect(subject.to_partial_path).to eq('check_your_answers/shared/check') }
+
+    context 'when results page' do
+      let(:results_page) { true }
+
+      it { expect(subject.to_partial_path).to eq('results/multiples/check') }
+    end
   end
 
   describe '#summary' do

--- a/spec/presenters/check_presenter_spec.rb
+++ b/spec/presenters/check_presenter_spec.rb
@@ -1,10 +1,33 @@
 RSpec.describe CheckPresenter do
   let(:disclosure_check) { create(:disclosure_check, :completed) }
+  let(:number) { 1 }
+  let(:sentences) { 1 }
+  let(:results_page) { false }
 
-  subject { described_class.new(disclosure_check) }
+  subject { described_class.new(disclosure_check, number: number, sentences: sentences, results_page: results_page) }
+
+  describe '#number' do
+    it { expect(subject.number).to eq(1) }
+  end
+
+  describe '#show_sentence_header?' do
+    it { expect(subject.show_sentence_header?).to be(false) }
+
+    context 'when there are more than 1 sentence' do
+      let(:sentences) { 2 }
+
+      it { expect(subject.show_sentence_header?).to be(true) }
+    end
+  end
 
   describe '#to_partial_path' do
     it { expect(subject.to_partial_path).to eq('check_your_answers/shared/check_row') }
+
+    context 'when results page' do
+      let(:results_page) { true }
+
+      it { expect(subject.to_partial_path).to eq('results/multiples/check_row') }
+    end
   end
 
   describe '#summary' do

--- a/spec/presenters/check_row_spec.rb
+++ b/spec/presenters/check_row_spec.rb
@@ -4,10 +4,18 @@ RSpec.describe CheckRow do
   let(:number) { 1 }
   let(:name) { 'name' }
   let(:question_answers) { 'question_rows' }
-  subject { described_class.new(question_answers, scope: 'path/to/locales') }
+  let(:results_page) { false }
+
+  subject { described_class.new(question_answers, scope: 'path/to/locales', results_page: results_page) }
 
   describe '#to_partial_path' do
     it { expect(subject.to_partial_path).to eq('check_your_answers/shared/check_row') }
+
+    context 'when results page' do
+      let(:results_page) { true }
+
+      it { expect(subject.to_partial_path).to eq('results/multiples/check_row') }
+    end
   end
 
   describe '#question_answers' do

--- a/spec/presenters/multiple_results_presenter_spec.rb
+++ b/spec/presenters/multiple_results_presenter_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe MultipleResultsPresenter do
+  let(:disclosure_check) { create(:disclosure_check, :dto_conviction, :completed) }
+  let(:disclosure_report) { disclosure_check.disclosure_report }
+
+  subject { described_class.new(disclosure_report) }
+
+  describe '.initialize' do
+    it 'processes the check groups (proceedings) for later use' do
+      expect(subject.calculator.proceedings).not_to be_empty
+    end
+  end
+
+  describe '#to_partial_path' do
+    it { expect(subject.to_partial_path).to eq('results/multiples/check') }
+  end
+
+  describe '#variant' do
+    it { expect(subject.variant).to eq(:multiples) }
+  end
+
+  describe '#summary' do
+    let(:summary) { subject.summary }
+    let(:spent_date) { 'date' }
+
+    context 'when the report is completed' do
+      before do
+        disclosure_report.completed!
+      end
+
+      it 'returns CheckGroupPresenter with spent dates' do
+        expect(summary.size).to eq(1)
+        expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
+        expect(summary[0].number).to eql(1)
+        expect(summary[0].check_group).to eql(disclosure_check.check_group)
+        expect(summary[0].spent_date).to eq(Date.new(2020, 7, 1))
+      end
+    end
+
+    context 'when the report is not yet completed' do
+      before do
+        disclosure_report.in_progress!
+      end
+
+      it 'returns CheckGroupPresenter without spent dates' do
+        expect(summary.size).to eq(1)
+        expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
+        expect(summary[0].number).to eql(1)
+        expect(summary[0].check_group).to eql(disclosure_check.check_group)
+        expect(summary[0].spent_date).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/services/check_decision_tree_spec.rb
+++ b/spec/services/check_decision_tree_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe CheckDecisionTree do
     )
   end
 
+  let(:controller)       { double('controller', multiples_enabled?: multiples_enabled) }
   let(:step_params)      { double('Step') }
   let(:next_step)        { nil }
   let(:as)               { nil }
@@ -19,7 +20,7 @@ RSpec.describe CheckDecisionTree do
 
   subject {
     described_class.new(
-      disclosure_check: disclosure_check, step_params: step_params, as: as, next_step: next_step, multiples_enabled: multiples_enabled
+      disclosure_check: disclosure_check, step_params: step_params, as: as, next_step: next_step, controller: controller
     )
   }
 
@@ -67,6 +68,27 @@ RSpec.describe CheckDecisionTree do
         let(:kind) { 'conviction' }
         it { is_expected.to have_destination('/steps/conviction/conviction_type', :edit) }
       end
+    end
+  end
+
+  describe 'when the step is `add_caution_or_conviction`' do
+    let(:step_params) { { add_caution_or_conviction: add_caution_or_conviction } }
+
+    context 'and answer is `yes`' do
+      let(:add_caution_or_conviction) { GenericYesNo::YES }
+
+      before do
+        allow(disclosure_check).to receive(:disclosure_report).and_return('disclosure_report')
+        allow(controller).to receive(:initialize_disclosure_check).with(disclosure_report: 'disclosure_report')
+      end
+
+      it {is_expected.to have_destination(:kind, :edit) }
+    end
+
+    context 'and answer is `no`' do
+      let(:add_caution_or_conviction) { GenericYesNo::NO }
+
+      it { expect(subject.destination).to eq({controller: :results, action: :show, show_results: true}) }
     end
   end
 end


### PR DESCRIPTION


https://user-images.githubusercontent.com/136777/112176182-c8f6e380-8bef-11eb-925d-801ed0607e7a.mov



I've done a soft separation from CheckYourAnswers, which was being shared
between the results page and the Check Your Answers page.

Having MultipleResultsPresenter enable us to separate both pages, althought for now,
the only thing that is different is the `results_page` attribute that is passed
down the chain of existing classes.

I don't want to commit to fully separate both right now, it's not clear to me
at this moment what we will need once we start working on the results page, so
I rather have a soft transition here.

-----

I've also requested a decision to show number before the word "Conviction" (or "Caution"),
as this felt misleading to have the number after the word.

Prototype suggested

Conviction 1
Conviction 2

The problem emerged when a caution is added after a conviction, like so:

Conviction 1
Conviction 2
Caution 3

It could make the user think that they have a 3rd caution when they only inserted 1 caution.
So we have agreed to have the number before as if it was a numbered bullet point list.

1. Conviction
2. Conviction
3. Caution

-----

Header logic for sentence numeration

When a conviction has 1 sentence, do not show the header ("Sentence 1")
When a conviction has more than 1 sentence, show the header with numeration

Story: https://trello.com/c/eLQkrUGd