### PR TITLE
Update mimemagic to 0.3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk --no-cache add --virtual build-deps \
   curl \
 && apk --no-cache add \
   postgresql-client \
+  shared-mime-info \
   linux-headers \
   xz-libs \
   tzdata \

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'sass-rails', '< 6.0.0'
 gem 'sentry-raven', '~> 3.0'
 gem 'uglifier'
 gem 'virtus'
+gem 'mimemagic', '~> 0.3.7'
 
 group :production do
   gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
@@ -375,6 +377,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   logstash-event
+  mimemagic (~> 0.3.7)
   pg (~> 1.1)
   pry-byebug
   pry-rails

--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ environments (kubernetes cluster). But the general ideal is the same (nginx reve
 
 ## Getting Started
 
+You will need to install [Homebrew](https://brew.sh), to enable the `brew` command.
+
 * Copy `.env.example` to `.env` and replace with suitable values.
 
+* `brew install shared-mime-info`
 * `bundle install`
 * `bundle exec rails db:setup`
 * `bundle exec rails db:migrate`


### PR DESCRIPTION
Following long discussions we have an intermediate solution to upgrade 
mimemagic.

This also updates Docker to have the package.

It requires each individual to have a copy of `shared-mime-info`. 

More details here:
https://github.com/mimemagicrb/mimemagic/blob/master/README.md#dependencies