### PR TITLE
Update GA transactions to cope with multiples

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,6 +1,7 @@
 module AnalyticsHelper
   CUSTOM_DIMENSIONS_MAP = {
     spent: :dimension1,
+    proceedings: :dimension2,
   }.freeze
 
   def analytics_tracking_id
@@ -16,6 +17,7 @@ module AnalyticsHelper
 
     content_for :transaction_data, {
       id: current_disclosure_check.id,
+      name: current_disclosure_check.kind,
       sku: transaction_sku,
       quantity: 1,
     }.merge(

--- a/app/presenters/check_answers_presenter.rb
+++ b/app/presenters/check_answers_presenter.rb
@@ -20,6 +20,10 @@ class CheckAnswersPresenter
     @_calculator ||= Calculators::Multiples::MultipleOffensesCalculator.new(disclosure_report)
   end
 
+  def proceedings_size
+    calculator.proceedings.size
+  end
+
   def variant
     :multiples
   end

--- a/app/views/steps/check/check_your_answers/show.html.erb
+++ b/app/views/steps/check/check_your_answers/show.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction category: 'CYA Basket' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/steps/check/results/show.en.html+multiples.erb
+++ b/app/views/steps/check/results/show.en.html+multiples.erb
@@ -1,5 +1,8 @@
 <% title 'When your cautions or convictions are spent' %>
-<% track_transaction name: 'Multiple check completed', category: 'Completed checks' %>
+
+<% track_transaction name: 'Multiple check completed', category: 'Completed checks', sku: 'multiples',
+                     id: current_disclosure_report.id,
+                     dimensions: { proceedings: @presenter.proceedings_size } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -27,16 +27,36 @@ RSpec.describe AnalyticsHelper, type: :helper do
 
       expect(
         helper.content_for(:transaction_data)
-      ).to eq("{\"id\":\"12345\",\"sku\":\"caution\",\"quantity\":1,\"name\":\"whatever\"}")
+      ).to eq("{\"id\":\"12345\",\"name\":\"whatever\",\"sku\":\"caution\",\"quantity\":1}")
+    end
+
+    it 'defaults transaction attributes if not present' do
+      helper.track_transaction({})
+
+      expect(
+        helper.content_for(:transaction_data)
+      ).to eq("{\"id\":\"12345\",\"name\":\"caution\",\"sku\":\"caution\",\"quantity\":1}")
     end
 
     context 'custom dimensions' do
-      it 'sets the transaction attributes to track' do
-        helper.track_transaction(name: 'whatever', dimensions: { spent: 'yes' } )
+      context 'spent' do
+        it 'sets the transaction attributes to track' do
+          helper.track_transaction(name: 'whatever', dimensions: { spent: 'yes' })
 
-        expect(
-          helper.content_for(:transaction_data)
-        ).to match(/"name":"whatever","dimension1":"yes"/)
+          expect(
+            helper.content_for(:transaction_data)
+          ).to match(/"dimension1":"yes"/)
+        end
+      end
+
+      context 'proceedings' do
+        it 'sets the transaction attributes to track' do
+          helper.track_transaction(name: 'whatever', dimensions: { proceedings: 3 })
+
+          expect(
+            helper.content_for(:transaction_data)
+          ).to match(/"dimension2":3/)
+        end
       end
     end
   end

--- a/spec/presenters/check_answers_presenter_spec.rb
+++ b/spec/presenters/check_answers_presenter_spec.rb
@@ -50,4 +50,10 @@ RSpec.describe CheckAnswersPresenter do
       end
     end
   end
+
+  describe '#proceedings_size' do
+    it 'returns the calculator proceedings size' do
+      expect(subject.proceedings_size).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://trello.com/c/KF3PYWfT

Up until now we only had "single checks", as 1 check equals to just 1 caution or 1 conviction transaction on GA.

However going forward with multiples this needs to change, as 1 check (as in all the way to the results page) can equal to X number of convictions or cautions (added previously to a "basket").

As a first step so our current analytics don't start to get too skewed after the release of multiples we did in PR #473, we are adding a new transaction to the "CYA - Check your answer page" that triggers each time a new caution or conviction is added.

In addition, we modify the results page transaction so it contains information about how many proceedings it had and identify it by their report ID.

This is a first step and will be improved as we iterate and implement the new design and flow.