### PR TITLE
Add explanatory copy for consecutive/concurrent sentences

### DIFF
--- a/app/views/steps/conviction/conviction_length/edit.html.erb
+++ b/app/views/steps/conviction/conviction_length/edit.html.erb
@@ -1,17 +1,27 @@
 <% title t('.page_title') %>
 <% step_header %>
 
-<%
-  heading = t(".heading.#{@form_object.conviction_subtype}", default: t('.heading.default'))
-  explanation = t(".explanation.#{@form_object.conviction_subtype}_html", default: '')
-%>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_fieldset legend: { text: heading }, caption: { text: f.i18n_caption } do %>
+      <%= f.govuk_fieldset legend: { text: t(".heading.#{@form_object.conviction_subtype}", default: t('.heading.default')) },
+                           caption: { text: f.i18n_caption } do %>
+
+        <% if @form_object.conviction_type.custodial_sentence? %>
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text" data-ga-category="explanations" data-ga-label="consecutive sentences">
+                <%=t '.sentence_details.title' %>
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <%=t '.sentence_details.body_html' %>
+            </div>
+          </details>
+        <% end %>
+
         <%= f.govuk_text_field :conviction_length, label: { text: f.i18n_legend }, width: 3, pattern: "[0-9]*", inputmode: "numeric" %>
       <% end %>
 

--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -1,30 +1,5 @@
 ---
 en:
-  dictionary:
-    sentence_info: &sentence_info |
-      <p class="govuk-body">
-        Enter the whole length of the sentence you were given in court, even if you were released:
-      </p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>early</li>
-        <li>on temporary license</li>
-        <li>on parole</li>
-        <li>under supervision</li>
-      </ul>
-    sentence_info_with_callout: &sentence_info_with_callout |
-      <p class="govuk-body">
-        Enter the whole length of the sentence you were given in court, even if you were released:
-      </p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>early</li>
-        <li>on temporary license</li>
-        <li>on parole</li>
-        <li>under supervision</li>
-      </ul>
-      <div class="govuk-inset-text">
-        If your sentence was extended, the number you enter must include both the original sentence length and the length it was extended by.
-      </div>
-
   steps:
     conviction:
       known_date:
@@ -58,11 +33,12 @@ en:
             youth_disqualification: What was the length of the disqualification?
             adult_service_detention: What was the length of the detention?
             service_detention: What was the length of the detention?
-          explanation:
-            detention_html: *sentence_info_with_callout
-            detention_training_order_html: *sentence_info
-            adult_prison_sentence_html: *sentence_info_with_callout
-            adult_suspended_prison_sentence_html: *sentence_info_with_callout
+          sentence_details:
+            title: If you got more than one sentence at the same time
+            body_html: |
+              <p>If you served one sentence after the other (consecutively), enter the total sentence length.</p>
+              <p>For example, if you got a 5 month and a 3 month sentence to serve consecutively, enter 8 months.</p>
+              <p>If you served more than one sentence at the same time (concurrently), enter them as separate sentences.</p>
       compensation_paid:
         edit:
           page_title: Compensation paid

--- a/features/adults/conviction_custodial_sentence.feature
+++ b/features/adults/conviction_custodial_sentence.feature
@@ -21,6 +21,7 @@ Feature: Conviction
 
     And  I choose "Months"
     Then I should see "<length_header>"
+    And I should see "If you got more than one sentence at the same time"
     And I fill in "Number of months" with "22"
 
     Then I click the "Continue" button
@@ -46,6 +47,7 @@ Feature: Conviction
 
     And  I choose "Years"
     Then I should see "<length_header>"
+    And I should see "If you got more than one sentence at the same time"
     And I fill in "Number of years" with "2"
 
     Then I click the "Continue" button

--- a/features/youth/conviction_custodial_sentence.feature
+++ b/features/youth/conviction_custodial_sentence.feature
@@ -21,6 +21,7 @@ Feature: Conviction
 
     And  I choose "Months"
     Then I should see "<length_header>"
+    And I should see "If you got more than one sentence at the same time"
     And I fill in "Number of months" with "24"
 
     Then I click the "Continue" button
@@ -45,6 +46,7 @@ Feature: Conviction
 
     And  I choose "Years"
     Then I should see "<length_header>"
+    And I should see "If you got more than one sentence at the same time"
     And I fill in "Number of years" with "2"
 
     Then I click the "Continue" button


### PR DESCRIPTION
Ticket: https://trello.com/c/nJnRENsS
Slack thread: https://mojdt.slack.com/archives/CKZT0MY1G/p1617784023002500

Add an explanatory copy, hidden behind a revealing link, for how to enter the sentence length depending if there are consecutive or concurrent sentences.

Cleaned up some unused code and locales from a previous version of the page.

<img width="656" alt="Screenshot 2021-04-08 at 14 35 14" src="https://user-images.githubusercontent.com/687910/114036871-57b66200-9878-11eb-86e3-4639305ab3ed.png">
