### PR TITLE
Small cleanup and code reorganisation

### DIFF
--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -1,21 +1,24 @@
 class ConvictionType < ValueObject
   include ConvictionDecorator
 
-  attr_reader :parent, :skip_length, :calculator_class, :relevant_order, :drag_through
+  attr_reader :parent, :calculator_class,
+              :skip_length, :relevant_order, :drag_through
+
+  alias skip_length? skip_length
+  alias relevant_order? relevant_order
+  alias drag_through? drag_through
 
   def initialize(raw_value, params = {})
     @parent = params.fetch(:parent, nil)
-    @skip_length = params.fetch(:skip_length, false)
     @calculator_class = params.fetch(:calculator_class, nil)
+
+    # Customise journey or calculations
+    @skip_length = params.fetch(:skip_length, false)
     @relevant_order = params.fetch(:relevant_order, false)
     @drag_through = params.fetch(:drag_through, false)
 
     super(raw_value)
   end
-
-  alias skip_length? skip_length
-  alias relevant_order? relevant_order
-  alias drag_through? drag_through
 
   VALUES = [
     YOUTH_PARENT_TYPES = [
@@ -37,29 +40,24 @@ class ConvictionType < ValueObject
       ADULT_FINANCIAL             = new(:adult_financial),
     ].freeze,
 
-    # Quick way of enabling/disabling convictions. These will not show in the interface to users.
-    # If there are cucumber test, tag the affected scenarios with `@skip`.
-    #
-    DISABLED_PARENT_TYPES = [].freeze,
-
     #####################
     # Youth convictions #
     #####################
     #
-    REFERRAL_ORDER                     = new(:referral_order,                   parent: REFERRAL_SUPERVISION_YRO, relevant_order: true, drag_through: false, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    REFERRAL_ORDER                     = new(:referral_order,                   parent: REFERRAL_SUPERVISION_YRO, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     SUPERVISION_ORDER                  = new(:supervision_order,                parent: REFERRAL_SUPERVISION_YRO, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
     YOUTH_REHABILITATION_ORDER         = new(:youth_rehabilitation_order,       parent: REFERRAL_SUPERVISION_YRO, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
 
     DETENTION_TRAINING_ORDER           = new(:detention_training_order,         parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::DetentionTraining),
     DETENTION                          = new(:detention,                        parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::Detention),
-    HOSPITAL_ORDER                     = new(:hospital_order,                   parent: CUSTODIAL_SENTENCE, relevant_order: true, drag_through: false, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    HOSPITAL_ORDER                     = new(:hospital_order,                   parent: CUSTODIAL_SENTENCE, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 
-    BIND_OVER                          = new(:bind_over,                        parent: DISCHARGE, relevant_order: true, drag_through: false, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    BIND_OVER                          = new(:bind_over,                        parent: DISCHARGE, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ABSOLUTE_DISCHARGE                 = new(:absolute_discharge,               parent: DISCHARGE, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
-    CONDITIONAL_DISCHARGE              = new(:conditional_discharge,            parent: DISCHARGE, relevant_order: true, drag_through: false, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    CONDITIONAL_DISCHARGE              = new(:conditional_discharge,            parent: DISCHARGE, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 
     FINE                               = new(:fine,                             parent: FINANCIAL, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
-    COMPENSATION_TO_A_VICTIM           = new(:compensation_to_a_victim,         parent: FINANCIAL, relevant_order: true, drag_through: false, calculator_class: Calculators::CompensationCalculator),
+    COMPENSATION_TO_A_VICTIM           = new(:compensation_to_a_victim,         parent: FINANCIAL, relevant_order: true, calculator_class: Calculators::CompensationCalculator),
 
     DISMISSAL                          = new(:dismissal,                        parent: MILITARY, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusSixMonths),
     OVERSEAS_COMMUNITY_ORDER           = new(:overseas_community_order,         parent: MILITARY, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
@@ -80,19 +78,19 @@ class ConvictionType < ValueObject
     ######################
 
     ADULT_ATTENDANCE_CENTRE_ORDER       = new(:adult_attendance_centre_order,      parent: ADULT_COMMUNITY_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
-    ADULT_COMMUNITY_ORDER               = new(:adult_community_order,              parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: false, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
+    ADULT_COMMUNITY_ORDER               = new(:adult_community_order,              parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
     ADULT_CRIMINAL_BEHAVIOUR            = new(:adult_criminal_behaviour,           parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_REPARATION_ORDER              = new(:adult_reparation_order,             parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
     ADULT_RESTRAINING_ORDER             = new(:adult_restraining_order,            parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_SERIOUS_CRIME_PREVENTION      = new(:adult_serious_crime_prevention,     parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_SEXUAL_HARM_PREVENTION_ORDER  = new(:adult_sexual_harm_prevention_order, parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 
-    ADULT_BIND_OVER                     = new(:adult_bind_over,                    parent: ADULT_DISCHARGE, relevant_order: true, drag_through: false, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    ADULT_BIND_OVER                     = new(:adult_bind_over,                    parent: ADULT_DISCHARGE, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_ABSOLUTE_DISCHARGE            = new(:adult_absolute_discharge,           parent: ADULT_DISCHARGE, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
-    ADULT_CONDITIONAL_DISCHARGE         = new(:adult_conditional_discharge,        parent: ADULT_DISCHARGE, relevant_order: true, drag_through: false, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    ADULT_CONDITIONAL_DISCHARGE         = new(:adult_conditional_discharge,        parent: ADULT_DISCHARGE, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
 
     ADULT_FINE                          = new(:adult_fine,                         parent: ADULT_FINANCIAL, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusTwelveMonths),
-    ADULT_COMPENSATION_TO_A_VICTIM      = new(:adult_compensation_to_a_victim,     parent: ADULT_FINANCIAL, relevant_order: true, drag_through: false, calculator_class: Calculators::CompensationCalculator),
+    ADULT_COMPENSATION_TO_A_VICTIM      = new(:adult_compensation_to_a_victim,     parent: ADULT_FINANCIAL, relevant_order: true, calculator_class: Calculators::CompensationCalculator),
 
     ADULT_DISMISSAL                     = new(:adult_dismissal,                    parent: ADULT_MILITARY, skip_length: true, calculator_class: Calculators::AdditionCalculator::StartPlusTwelveMonths),
     ADULT_OVERSEAS_COMMUNITY_ORDER      = new(:adult_overseas_community_order,     parent: ADULT_MILITARY, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
@@ -104,7 +102,7 @@ class ConvictionType < ValueObject
     ADULT_PENALTY_NOTICE                = new(:adult_penalty_notice,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Adult::PenaltyNotice),
     ADULT_PENALTY_POINTS                = new(:adult_penalty_points,               parent: ADULT_MOTORING, skip_length: true, calculator_class: Calculators::Motoring::Adult::PenaltyPoints),
 
-    ADULT_HOSPITAL_ORDER                = new(:adult_hospital_order,               parent: ADULT_CUSTODIAL_SENTENCE, relevant_order: true, drag_through: false, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    ADULT_HOSPITAL_ORDER                = new(:adult_hospital_order,               parent: ADULT_CUSTODIAL_SENTENCE, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_PRISON_SENTENCE               = new(:adult_prison_sentence,              parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::Prison),
     ADULT_SUSPENDED_PRISON_SENTENCE     = new(:adult_suspended_prison_sentence,    parent: ADULT_CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::SuspendedPrison),
   ].flatten.freeze

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ConvictionType do
   describe 'YOUTH_PARENT_TYPES' do
     let(:values) {
-      (described_class::YOUTH_PARENT_TYPES - described_class::DISABLED_PARENT_TYPES).map(&:to_s)
+      described_class::YOUTH_PARENT_TYPES.map(&:to_s)
     }
 
     it 'returns top level youth convictions' do
@@ -21,7 +21,7 @@ RSpec.describe ConvictionType do
 
   describe 'ADULT_PARENT_TYPES' do
     let(:values) {
-      (described_class::ADULT_PARENT_TYPES.map(&:to_s) - described_class::DISABLED_PARENT_TYPES).map(&:to_s)
+      described_class::ADULT_PARENT_TYPES.map(&:to_s)
     }
 
     it 'returns top level adult convictions' do


### PR DESCRIPTION
Just some small cleanup of a functionality no longer in use (DISABLED_PARENT_TYPES) as well as code reorganisation.

Also removal of the hardcoded `drag_through: false` because the default is already false so no need to specify it, so it is easier to find the ones that are `drag_through: true` as these are just a handful.

Functionality is the same, this is only shuffling around some code.