### PR TITLE
Bump govuk_design_system_formbuilder gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # This gem complies with the GOV.UK Design System
 # https://design-system.service.gov.uk
 # https://govuk-form-builder.netlify.app
-gem 'govuk_design_system_formbuilder', '~> 2.1.8'
+gem 'govuk_design_system_formbuilder', '~> 2.5.0'
 
 gem 'jquery-rails'
 gem 'pg'
@@ -49,7 +49,7 @@ end
 group :test do
   gem 'brakeman'
   gem 'capybara'
-  gem 'cucumber'
+  gem 'cucumber', '< 6.0.0'
   gem 'cucumber-rails', require: false
   gem 'rails-controller-testing'
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.8)
+    connection_pool (2.2.5)
     crass (1.0.6)
     cucumber (5.3.0)
       builder (~> 3.2, >= 3.2.4)
@@ -131,6 +132,7 @@ GEM
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
     debug_inspector (1.1.0)
+    deep_merge (1.2.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.4.4)
@@ -141,24 +143,32 @@ GEM
       railties (>= 3.2)
     equalizer (0.0.11)
     erubi (1.10.0)
+    excon (0.80.1)
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    faraday (1.3.0)
+    faraday (1.4.0)
+      faraday-excon (~> 1.0)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
+    faraday-excon (1.0.0)
+      excon (>= 0.27.4)
     faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.0.3)
+      net-http-persistent (>= 3.1)
     ffi (1.15.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_design_system_formbuilder (2.1.9)
-      actionview (>= 5.2)
-      activemodel (>= 5.2)
-      activesupport (>= 5.2)
+    govuk_design_system_formbuilder (2.5.0)
+      actionview (>= 6.0)
+      activemodel (>= 6.0)
+      activesupport (>= 6.0)
+      deep_merge (~> 1.2.1)
     highline (2.0.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -208,6 +218,8 @@ GEM
     msgpack (1.4.2)
     multi_test (0.1.2)
     multipart-post (2.1.1)
+    net-http-persistent (4.0.1)
+      connection_pool (~> 2.2)
     nio4r (2.5.7)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
@@ -384,11 +396,11 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   brakeman
   capybara
-  cucumber
+  cucumber (< 6.0.0)
   cucumber-rails
   dotenv-rails
   factory_bot_rails
-  govuk_design_system_formbuilder (~> 2.1.8)
+  govuk_design_system_formbuilder (~> 2.5.0)
   i18n-debug
   i18n-tasks
   jquery-rails

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CustomFormHelpers, type: :helper do
     it 'outputs the govuk continue button' do
       expect(
         builder.continue_button
-      ).to eq('<input type="submit" name="commit" value="Continue" class="govuk-button" formnovalidate="formnovalidate" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" />')
+      ).to eq('<input type="submit" name="commit" value="Continue" formnovalidate="formnovalidate" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" />')
     end
   end
 


### PR DESCRIPTION
Updates the `govuk_design_system_formbuilder` gem to the latest version as the one we were using was a bit outdated.

There are several changes but nothing breaking. Our tests and cukes continue to pass and I did some manual testing as well with no obvious regressions.

Also starting with v2.2.0 the gem dropped support for Rails 5.2.4 so good thing we've upgraded to Rails 6.2 already.

Note: I had to lock `cucumber` to < 6.0.0 otherwise we would start getting an error, I suppose this is because some of the other gems are not yet updated to support cucumber > 6.0

We can test further on staging before releasing to production.