### PR TITLE
Do not track analytics for completed reports again

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -4,7 +4,21 @@ module AnalyticsHelper
     proceedings: :dimension2,
   }.freeze
 
+  # Because transactions can be triggered more than once for the same report,
+  # we try to limit this by only triggering GA events and transactions for
+  # reports not completed, or completed recently. But not old ones.
+  #
+  # This is specially important in the results page as it can be reloaded
+  # multiple times or accessed to "replay" the results at a later date.
+  #
   def analytics_tracking_id
+    if current_disclosure_report.try(:completed?)
+      # legacy reports do not have the `completed_at` date
+      return if current_disclosure_report.completed_at.nil?
+
+      return if current_disclosure_report.completed_at <= 15.minutes.ago
+    end
+
     ENV['GA_TRACKING_ID']
   end
 

--- a/app/models/disclosure_report.rb
+++ b/app/models/disclosure_report.rb
@@ -10,4 +10,8 @@ class DisclosureReport < ApplicationRecord
   def self.purge!(date)
     where('created_at <= :date', date: date).destroy_all
   end
+
+  def completed!
+    update!(status: :completed, completed_at: Time.current)
+  end
 end

--- a/db/migrate/20210419110220_add_completed_at_to_disclosure_reports.rb
+++ b/db/migrate/20210419110220_add_completed_at_to_disclosure_reports.rb
@@ -1,0 +1,5 @@
+class AddCompletedAtToDisclosureReports < ActiveRecord::Migration[6.1]
+  def change
+    add_column :disclosure_reports, :completed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_01_114508) do
+ActiveRecord::Schema.define(version: 2021_04_19_110220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2021_02_01_114508) do
     t.integer "status", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "completed_at"
     t.index ["status"], name: "index_disclosure_reports_on_status"
   end
 

--- a/spec/models/disclosure_report_spec.rb
+++ b/spec/models/disclosure_report_spec.rb
@@ -27,4 +27,20 @@ RSpec.describe DisclosureReport, type: :model do
       described_class.purge!(28.days.ago)
     end
   end
+
+  describe '#completed!' do
+    before do
+      travel_to Time.at(123)
+    end
+
+    it 'marks the application as completed' do
+      expect(
+        subject
+      ).to receive(:update!).with(
+        status: :completed, completed_at: Time.at(123)
+      ).and_return(true)
+
+      subject.completed!
+    end
+  end
 end


### PR DESCRIPTION
This is an improvement over a piece of work we did some time ago.

In essence, so we can use the "replay" functionality where we can see the results page at a later moment for a completed check, we need to avoid triggering some of the transactions and analytics otherwise it gets super skewed.

In order to do that, we add an extra attribute to the `disclosure_report` records, `completed_at` which is filled when the report is completed and then we can use this date later on to make decisions.

This will make it possible to replay old checks without tracking anything to GA.