### PR TITLE
Fix under reporting of proceedings in GA

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -2,6 +2,7 @@ module AnalyticsHelper
   CUSTOM_DIMENSIONS_MAP = {
     spent: :dimension1,
     proceedings: :dimension2,
+    orders: :dimension3,
   }.freeze
 
   # Because transactions can be triggered more than once for the same report,

--- a/app/presenters/check_answers_presenter.rb
+++ b/app/presenters/check_answers_presenter.rb
@@ -21,7 +21,7 @@ class CheckAnswersPresenter
   end
 
   def proceedings_size
-    calculator.proceedings.size
+    disclosure_report.disclosure_checks.completed.size
   end
 
   def variant

--- a/app/presenters/check_answers_presenter.rb
+++ b/app/presenters/check_answers_presenter.rb
@@ -20,8 +20,16 @@ class CheckAnswersPresenter
     @_calculator ||= Calculators::Multiples::MultipleOffensesCalculator.new(disclosure_report)
   end
 
+  # This is how many cautions or convictions are in this report, meaning
+  # 1 caution and 1 conviction with 3 sentences will return 2.
   def proceedings_size
-    disclosure_report.disclosure_checks.completed.size
+    calculator.proceedings.size
+  end
+
+  # This is how many individual "checks" are in this report, meaning
+  # 1 caution and 1 conviction with 3 sentences will return 4.
+  def orders_size
+    calculator.proceedings.sum(&:size)
   end
 
   def variant

--- a/app/services/calculators/multiples/proceedings.rb
+++ b/app/services/calculators/multiples/proceedings.rb
@@ -3,6 +3,8 @@ module Calculators
     class Proceedings
       attr_reader :check_group
 
+      delegate :size, to: :disclosure_checks
+
       def initialize(check_group)
         @check_group = check_group
       end

--- a/app/views/steps/check/results/show.en.html+multiples.erb
+++ b/app/views/steps/check/results/show.en.html+multiples.erb
@@ -2,7 +2,7 @@
 
 <% track_transaction name: 'Multiple check completed', category: 'Completed checks', sku: 'multiples',
                      id: current_disclosure_report.id,
-                     dimensions: { proceedings: @presenter.proceedings_size } %>
+                     dimensions: { proceedings: @presenter.proceedings_size, orders: @presenter.orders_size } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -97,6 +97,16 @@ RSpec.describe AnalyticsHelper, type: :helper do
           ).to match(/"dimension2":3/)
         end
       end
+
+      context 'orders' do
+        it 'sets the transaction attributes to track' do
+          helper.track_transaction(name: 'whatever', dimensions: { orders: 5 })
+
+          expect(
+              helper.content_for(:transaction_data)
+          ).to match(/"dimension3":5/)
+        end
+      end
     end
   end
 

--- a/spec/presenters/check_answers_presenter_spec.rb
+++ b/spec/presenters/check_answers_presenter_spec.rb
@@ -56,4 +56,10 @@ RSpec.describe CheckAnswersPresenter do
       expect(subject.proceedings_size).to eq(1)
     end
   end
+
+  describe '#orders_size' do
+    it 'returns the sum of each proceedings size' do
+      expect(subject.orders_size).to eq(1)
+    end
+  end
 end

--- a/spec/services/calculators/multiples/proceedings_spec.rb
+++ b/spec/services/calculators/multiples/proceedings_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Calculators::Multiples::Proceedings do
   let(:kind) { 'conviction' }
   let(:conviction_date) { Date.new(2018, 1, 1) }
 
+  describe '#size' do
+    it { expect(subject.size).to eq(3) }
+  end
+
   describe '#kind' do
     context 'for a caution' do
       let(:kind) { 'caution' }


### PR DESCRIPTION
We were reporting only cautions or convictions, but not the sentences/orders inside a conviction, which means a conviction with 3 sentences was reported just as 1 proceedings to google analytics, and in reality we want to know how many "multiples" checks are done and having more than 1 sentence qualify as "multiples".