### PR TITLE
Rename adults community orders conviction group

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -40,7 +40,7 @@ en:
       financial: Financial penalty (not including motoring fines)
 
       # adults
-      adult_community_reparation: Community, prevention or reparation order
+      adult_community_reparation: Community, reparation or other order with requirements
       adult_discharge: Discharge
       adult_motoring: Motoring (including motoring fines)
       adult_military: Military
@@ -357,7 +357,7 @@ en:
         adult_military: What was your military conviction?
         adult_motoring: What was your motoring conviction?
         youth_motoring: What was your motoring conviction?
-        adult_community_reparation: What was your community, prevention or reparation order?
+        adult_community_reparation: What was your community, reparation or other order with requirements?
         adult_discharge: What discharge were you given?
         adult_custodial_sentence: What sentence were you given?
       steps_conviction_compensation_payment_date_form:

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -16,7 +16,7 @@ en:
       military: Military
       prevention_reparation: Prevention or reparation order
       # adults
-      adult_community_reparation: Community, prevention or reparation order
+      adult_community_reparation: Community, reparation or other order with requirements
       adult_custodial_sentence: Custody or hospital order
       adult_discharge: Discharge
       adult_financial: Financial penalty

--- a/features/adults/conviction_community_prevention_reparation.feature
+++ b/features/adults/conviction_community_prevention_reparation.feature
@@ -1,8 +1,8 @@
 Feature: Conviction
 
-  Scenario Outline: Adult community, prevention or reparation order
-    Given I am completing a basic 18 or over "Community, prevention or reparation order" conviction
-    Then I should see "What was your community, prevention or reparation order?"
+  Scenario Outline: Adult community, reparation or other order with requirements
+    Given I am completing a basic 18 or over "Community, reparation or other order with requirements" conviction
+    Then I should see "What was your community, reparation or other order with requirements?"
 
     When I choose "<subtype>"
     Then I should see "<known_date_header>"
@@ -26,9 +26,9 @@ Feature: Conviction
       | Serious crime prevention order | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
       | Sexual harm prevention order   | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
 
-  Scenario: Adult community, prevention or reparation order - Reparation order
-    Given I am completing a basic 18 or over "Community, prevention or reparation order" conviction
-    Then I should see "What was your community, prevention or reparation order?"
+  Scenario: Adult community, reparation or other order with requirements - Reparation order
+    Given I am completing a basic 18 or over "Community, reparation or other order with requirements" conviction
+    Then I should see "What was your community, reparation or other order with requirements?"
 
     When I choose "Reparation order"
     Then I should see "When were you given the order?"


### PR DESCRIPTION
Ticket: https://trello.com/c/7SK4PLNz

The work in the above ticket will be split into 2 parts. This PR is the first part.

Renaming of the `Community, prevention or reparation order` conviction group to `Community, reparation or other order with requirements`.