### PR TITLE
Add new catch-all requirement order option

### DIFF
--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -78,13 +78,13 @@ class ConvictionType < ValueObject
     ######################
 
     ADULT_ATTENDANCE_CENTRE_ORDER       = new(:adult_attendance_centre_order,      parent: ADULT_COMMUNITY_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
-    ADULT_COMMUNITY_ORDER               = new(:adult_community_order,              parent: ADULT_COMMUNITY_REPARATION, relevant_order: false, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
-
+    ADULT_COMMUNITY_ORDER               = new(:adult_community_order,              parent: ADULT_COMMUNITY_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
     ADULT_CRIMINAL_BEHAVIOUR            = new(:adult_criminal_behaviour,           parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_REPARATION_ORDER              = new(:adult_reparation_order,             parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
     ADULT_RESTRAINING_ORDER             = new(:adult_restraining_order,            parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_SERIOUS_CRIME_PREVENTION      = new(:adult_serious_crime_prevention,     parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_SEXUAL_HARM_PREVENTION_ORDER  = new(:adult_sexual_harm_prevention_order, parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
+    ADULT_OTHER_REQUIREMENT_ORDER       = new(:adult_other_requirement_order,      parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
 
     ADULT_BIND_OVER                     = new(:adult_bind_over,                    parent: ADULT_DISCHARGE, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_ABSOLUTE_DISCHARGE            = new(:adult_absolute_discharge,           parent: ADULT_DISCHARGE, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -1,6 +1,6 @@
 ---
 en:
-  dictionary:
+  helpers/dictionary:
     date_hint_text: &date_hint_text |
       If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
       <p>For example, 23 9 2018</p>
@@ -80,6 +80,7 @@ en:
       adult_restraining_order: Restraining order
       adult_serious_crime_prevention: Serious crime prevention order
       adult_sexual_harm_prevention_order: Sexual harm prevention order
+      adult_other_requirement_order: Order with a requirement
       # adult_financial
       adult_fine: A fine
       adult_compensation_to_a_victim: Compensation to a victim
@@ -223,6 +224,7 @@ en:
           adult_restraining_order: You were ordered not to do something, such as approach or contact a certain person
           adult_serious_crime_prevention: A court ruled that you had been involved in a serious crime, such as money laundering, drug trafficking or armed robbery
           adult_sexual_harm_prevention_order: A court ruled that you pose a risk of causing a sexual offence or sexual harm
+          adult_other_requirement_order: Includes all orders that disqualify you, prohibit certain things or impose a penalty of some kind
           # adult_motoring
           adult_disqualification: You were banned from driving
           adult_motoring_fine: A court gave you a fine that was not a fixed penalty notice (FPN)
@@ -272,6 +274,7 @@ en:
       steps_conviction_conviction_subtype_form:
         conviction_subtype_options:
           <<: *CONVICTION_SUBTYPES
+          adult_other_requirement_order: Any other order with a requirement
       steps_conviction_conviction_length_type_form:
         conviction_length_type_options:
           weeks: Weeks

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -1,6 +1,6 @@
 ---
 en:
-  dictionary:
+  results/dictionary:
     CAUTION_TYPES: &CAUTION_TYPES
       youth_simple_caution: Youth caution
       youth_conditional_caution: Youth conditional caution
@@ -56,6 +56,7 @@ en:
       adult_restraining_order: Restraining order
       adult_serious_crime_prevention: Serious crime prevention order
       adult_sexual_harm_prevention_order: Sexual harm prevention order
+      adult_other_requirement_order: Order with a requirement
       # adult_financial
       adult_fine: A fine
       adult_compensation_to_a_victim: Compensation to a victim

--- a/docs/relevant_orders.md
+++ b/docs/relevant_orders.md
@@ -2,18 +2,19 @@
 
 ## Adults
 
-| Category                                  | Conviction                       | Subject to drag through? |
-|------------------------------------------ |--------------------------------- | ------------------------ |
-| Discharge                                 | Bind over                        | Yes                      |
-| Discharge                                 | Conditional discharge            | Yes                      |
-| Motoring                                  | Disqualification                 | No                       |
-| Financial penalty                         | Compensation to a victim         | Yes                      |
-| Custody or hospital order                 | Hospital order                   | Yes                      |
-| Community, Prevention or reparation order | Criminal behaviour order         | No                       |
-| Community, Prevention or reparation order | Reparation order                 | No                       |
-| Community, Prevention or reparation order | Restraining order                | No                       |
-| Community, Prevention or reparation order | Serious crime prevention order   | No                       |
-| Community, Prevention or reparation order | Sexual harm prevention order     | No                       |
+| Category                                               | Conviction                         | Subject to drag through? |
+|------------------------------------------------------- |----------------------------------- | ------------------------ |
+| Discharge                                              | Bind over                          | Yes                      |
+| Discharge                                              | Conditional discharge              | Yes                      |
+| Motoring                                               | Disqualification                   | No                       |
+| Financial penalty                                      | Compensation to a victim           | Yes                      |
+| Custody or hospital order                              | Hospital order                     | Yes                      |
+| Community, reparation or other order with requirements | Criminal behaviour order           | No                       |
+| Community, reparation or other order with requirements | Reparation order                   | No                       |
+| Community, reparation or other order with requirements | Restraining order                  | No                       |
+| Community, reparation or other order with requirements | Serious crime prevention order     | No                       |
+| Community, reparation or other order with requirements | Sexual harm prevention order       | No                       |
+| Community, reparation or other order with requirements | Any other order with a requirement | No                       |
 
 ## Youths
 

--- a/features/adults/conviction_community_prevention_reparation.feature
+++ b/features/adults/conviction_community_prevention_reparation.feature
@@ -25,6 +25,7 @@ Feature: Conviction
       | Restraining order              | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
       | Serious crime prevention order | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
       | Sexual harm prevention order   | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
+      | Any other order with a requirement | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
 
   Scenario: Adult community, reparation or other order with requirements - Reparation order
     Given I am completing a basic 18 or over "Community, reparation or other order with requirements" conviction

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -11,21 +11,21 @@ RSpec.describe 'I18n' do
   end
 
   # Note: The following sanity checks will ensure we have the same keys and values in both places,
-  # so we don't inadvertently update just once place and not the other.
+  # so we don't inadvertently update just one place but not the other.
   # It doesn't matter the order of the keys in the locales, what matters is the content.
   #
   context 'shared dictionaries sanity checks' do
-    it 'caution types in `helpers.yml` matches caution types in `results.yml`' do
+    it 'caution types in `helpers.yml` match caution types in `results.yml`' do
       expect(
-        i18n.tree('en.helpers.label.steps_caution_caution_type_form.caution_type_options').to_hash
+        i18n.tree('en.helpers/dictionary.CAUTION_TYPES').to_hash
       ).to eq(
         i18n.tree('en.results/caution.caution_type.answers').to_hash
       )
     end
 
-    it 'convictions subtypes in `helpers.yml` matches convictions subtypes in `results.yml`' do
+    it 'convictions subtypes in `helpers.yml` match convictions subtypes in `results.yml`' do
       expect(
-        i18n.tree('en.helpers.label.steps_conviction_conviction_subtype_form.conviction_subtype_options').to_hash
+        i18n.tree('en.helpers/dictionary.CONVICTION_SUBTYPES').to_hash
       ).to eq(
         i18n.tree('en.results/conviction.conviction_subtype.answers').to_hash
       )

--- a/spec/services/conviction_length_choices_spec.rb
+++ b/spec/services/conviction_length_choices_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ConvictionLengthChoices do
       ConvictionType.values.size - described_class::SUBTYPES_HIDE_NO_LENGTH_CHOICE.size
     }
 
-    it { expect(total).to eq(53) }
+    it { expect(total).to eq(54) }
   end
 
   describe '.choices' do

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -123,6 +123,7 @@ RSpec.describe ConvictionType do
           adult_restraining_order
           adult_serious_crime_prevention
           adult_sexual_harm_prevention_order
+          adult_other_requirement_order
         ))
       end
     end
@@ -421,6 +422,15 @@ RSpec.describe ConvictionType do
       it { expect(conviction_type.relevant_order?).to eq(true) }
       it { expect(conviction_type.drag_through?).to eq(true) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusZeroMonths) }
+    end
+
+    context 'ADULT_OTHER_REQUIREMENT_ORDER' do
+      let(:subtype) { 'adult_other_requirement_order' }
+
+      it { expect(conviction_type.skip_length?).to eq(false) }
+      it { expect(conviction_type.relevant_order?).to eq(true) }
+      it { expect(conviction_type.drag_through?).to eq(false) }
+      it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusTwelveMonths) }
     end
 
     # ADULT FINANCIAL


### PR DESCRIPTION
Ticket: https://trello.com/c/7SK4PLNz

This is the 2nd part of the work requested in the above ticket.

A new catch-all radio option in the "Community, prevention or reparation order" (note this bucket will be renamed once the PR #485 is merged) has been added, named "Any other order with a requirement".

At the moment this is a relevant order, with no drag through, and the calculation rules are the same as in the community order conviction.

However we need confirmation if these rules are correct before merging. Other than that the rest of the work is done.

<img width="720" alt="Screenshot 2021-04-20 at 15 32 52" src="https://user-images.githubusercontent.com/687910/115414128-b0c5b480-a1ed-11eb-815d-fce23dbb08c9.png">

---

<img width="683" alt="Screenshot 2021-04-20 at 15 33 09" src="https://user-images.githubusercontent.com/687910/115414170-ba4f1c80-a1ed-11eb-8cb4-f1a1b3087b80.png">
