### PR TITLE
Fix legal scenario 9

### DIFF
--- a/app/services/calculators/multiples/multiple_offenses_calculator.rb
+++ b/app/services/calculators/multiples/multiple_offenses_calculator.rb
@@ -51,12 +51,10 @@ module Calculators
           next if other_spent_date.nil?
           next if spent_date_without_relevant_order.nil?
 
-          # the comparison to know if there's an overlap in conviction dates
+          # The comparison to know if there's an overlap in conviction dates
           # should be done without the relevant order
           # because relevant orders do not dictacte the spent_date of another conviction.
-          next unless spent_date_without_relevant_order.to_date.in?(
-            other_conviction_date..other_spent_date.to_date
-          )
+          next unless within_other_conviction_date_and_spent_date?(proceeding, spent_date, other_conviction_date, other_spent_date)
 
           next if conviction_date > other_conviction_date
 
@@ -82,6 +80,22 @@ module Calculators
       end
 
       private
+
+      def within_other_conviction_date_and_spent_date?(proceeding, spent_date, other_conviction_date, other_spent_date)
+        # We should first check wether the proceeding spent date has been affected
+        # by previous comparisons, if so, we should use the value assigned to _spent_date_
+        # otherwise we continue to compare spent dates with _spent_date_without_relevant_orders_
+
+        if spent_date == proceeding.spent_date
+          proceeding.spent_date_without_relevant_orders.to_date.in?(
+            other_conviction_date..other_spent_date.to_date
+          )
+        else
+          spent_date.to_date.in?(
+            other_conviction_date..other_spent_date.to_date
+          )
+        end
+      end
 
       def dates_memory
         @_dates_memory ||= {}

--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -78,7 +78,8 @@ class ConvictionType < ValueObject
     ######################
 
     ADULT_ATTENDANCE_CENTRE_ORDER       = new(:adult_attendance_centre_order,      parent: ADULT_COMMUNITY_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
-    ADULT_COMMUNITY_ORDER               = new(:adult_community_order,              parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
+    ADULT_COMMUNITY_ORDER               = new(:adult_community_order,              parent: ADULT_COMMUNITY_REPARATION, relevant_order: false, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
+
     ADULT_CRIMINAL_BEHAVIOUR            = new(:adult_criminal_behaviour,           parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_REPARATION_ORDER              = new(:adult_reparation_order,             parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
     ADULT_RESTRAINING_ORDER             = new(:adult_restraining_order,            parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -59,6 +59,20 @@ FactoryBot.define do
       conditional_end_date { Date.new(2018, 12, 25) }
     end
 
+    trait :with_youth_rehabilitation_order do
+      conviction_with_known_date
+      youth
+      conviction_type { ConvictionType::REFERRAL_SUPERVISION_YRO }
+      conviction_subtype { ConvictionType::YOUTH_REHABILITATION_ORDER }
+    end
+
+    trait :with_referral_order do
+      conviction_with_known_date
+      youth
+      conviction_type { ConvictionType::REFERRAL_SUPERVISION_YRO }
+      conviction_subtype { ConvictionType::REFERRAL_ORDER }
+    end
+
     trait :suspended_prison_sentence do
       conviction_with_known_date
       adult

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe ConvictionType do
       let(:subtype) { 'adult_community_order' }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.relevant_order?).to eq(true) }
+      it { expect(conviction_type.relevant_order?).to eq(false) }
       it { expect(conviction_type.drag_through?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusTwelveMonths) }
     end


### PR DESCRIPTION
This PR does two things:

1. Addresses the observation done by Legal that a Community Order shouldn't be a relevant order
> Youth rehab orders and Community orders are not relevant orders so are subject to the drag on effect. 

2. Fixes the scenario given by Legal by using the modified date (spent_date) as the comparison point between dates when this variable is modified from the initial assigned value.

> YRO is shown as spent on until 1 July 2016 but it should be showing as spent on 29 June 2021 along with the community order and custodial sentence.


This PR does not address the following quote:

> Also, it is not clear to me why the Referral order is prompting me to include the date that person attended first panel meeting. 
> My understanding is that referral orders like all other offences that do not have buffer periods run from date of conviction; and would be treated as running from date of conviction on basic checks. 

I'm not really sure what this means, but doesn't a breaking point right now (unlike point 1 and 2).

Further comment on commit e0ebe84.


Story: https://trello.com/c/r3BsvxQC
