### PR TITLE
More design tweaks to CYA/results

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -10,6 +10,12 @@
   margin-bottom: 1em;
 }
 
+.app-proceeding-box {
+  border: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(5);
+  padding: govuk-spacing(3);
+}
+
 dl.multiple-checks-summary:not(:only-child) {
   &:not(:last-of-type) { padding-bottom: 0.5em; }
 }

--- a/app/views/steps/check/check_your_answers/shared/_check.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check.html.erb
@@ -1,17 +1,17 @@
-<h2 class="govuk-heading-l">
-  <%=t "#{check.check_group_kind}.heading", scope: check.scope, index: check.number %>
-</h2>
+<div class="app-proceeding-box">
+  <h2 class="govuk-heading-l">
+    <%=t "#{check.check_group_kind}.heading", scope: check.scope, index: check.number %>
+  </h2>
 
-<%= render check.summary %>
+  <%= render check.summary %>
 
-<% if check.add_another_sentence_button? %>
-  <p class="govuk-body">
-    If you were given more than one sentence as part of this conviction you must add it now.
-  </p>
+  <% if check.add_another_sentence_button? %>
+    <p class="govuk-body">
+      If you were given more than one sentence as part of this conviction you must add it now.
+    </p>
 
-  <div class="govuk-!-margin-top-1">
     <%= button_to 'Add another sentence', check_group_path(check.check_group),
-                  class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-8',
-                  data: {module: 'govuk-button', 'prevent-double-click': true } %>
-  </div>
-<% end %>
+                  class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-3',
+                  data: { module: 'govuk-button', 'prevent-double-click': true } %>
+  <% end %>
+</div>

--- a/app/views/steps/check/check_your_answers/show.en.html.erb
+++ b/app/views/steps/check/check_your_answers/show.en.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Check your answers</h1>
 
-    <p class="govuk-body">You can enter additional cautions and convictions if you need to.</p>
+    <p class="govuk-body">You can add additional cautions and convictions if you need to.</p>
 
     <%= render @presenter.summary %>
 

--- a/app/views/steps/check/results/shared/_check.html.erb
+++ b/app/views/steps/check/results/shared/_check.html.erb
@@ -1,8 +1,8 @@
-<h2 class="govuk-heading-l">
-  <%=t "#{check.check_group_kind}.heading", scope: check.scope, index: check.number %>
-</h2>
+<div class="app-proceeding-box">
+  <h2 class="govuk-heading-l">
+    <%=t "#{check.check_group_kind}.heading", scope: check.scope, index: check.number %>
+  </h2>
 
-<div class="govuk-inset-text govuk-!-margin-top-2">
   <%= render check.spent_date_panel if check.spent_date %>
   <%= render check.summary %>
 </div>


### PR DESCRIPTION
Just adding the nice boxes around each of the proceedings (cautions or convictions) as I think this really makes a difference to clarify each of them.

Although the results page needs to change dramatically, I've added the box there too for consistency as it looks nicer.

This is following some of the latest changes to the prototype, so still WIP but starting to take form.

<img width="379" alt="Screenshot 2021-04-27 at 15 45 02" src="https://user-images.githubusercontent.com/687910/116262001-170f8180-a770-11eb-9aff-66995c6f6ba3.png">

--- 

<img width="365" alt="Screenshot 2021-04-27 at 15 45 16" src="https://user-images.githubusercontent.com/687910/116262024-1bd43580-a770-11eb-9706-b36bc47106e3.png">
