### PR TITLE
Remove reference to non endorsed FPN

### DIFF
--- a/app/services/calculators/motoring/adult/penalty_notice.rb
+++ b/app/services/calculators/motoring/adult/penalty_notice.rb
@@ -3,16 +3,11 @@ module Calculators
     module Adult
       # If an endorsement was received
       # start_date + 5 years
-
-      # If an endorsement was not received
-      # Go to different result page: https://moj-disclosure-checker.herokuapp.com/motoring/v3/fpn-no-conviction
       class PenaltyNotice < BaseCalculator
         REHABILITATION_1 = { months: 60 }.freeze
 
         def expiry_date
-          return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
-
-          :no_record
+          conviction_start_date.advance(REHABILITATION_1)
         end
       end
     end

--- a/app/services/calculators/motoring/youth/penalty_notice.rb
+++ b/app/services/calculators/motoring/youth/penalty_notice.rb
@@ -3,16 +3,11 @@ module Calculators
     module Youth
       # If an endorsement was received
       # start_date + 2.5 years
-
-      # If an endorsement was not received
-      # Go to different result page: https://moj-disclosure-checker.herokuapp.com/motoring/v3/fpn-no-conviction
       class PenaltyNotice < BaseCalculator
         REHABILITATION_1 = { months: 30 }.freeze
 
         def expiry_date
-          return conviction_start_date.advance(REHABILITATION_1) if motoring_endorsement?
-
-          :no_record
+          conviction_start_date.advance(REHABILITATION_1)
         end
       end
     end

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -126,8 +126,6 @@ en:
       title_html: This %{kind} is spent on the day you receive it
     indefinite:
       title_html: This %{kind} is not spent and will stay in place until another order is made to change or end it
-    no_record:
-      title_html: This fixed penalty notice (FPN) was not a conviction
 
   results/shared/date_format:
     exact: '%{date}'

--- a/spec/services/calculators/motoring/adult/penalty_notice_spec.rb
+++ b/spec/services/calculators/motoring/adult/penalty_notice_spec.rb
@@ -6,20 +6,12 @@ RSpec.describe Calculators::Motoring::Adult::PenaltyNotice do
   let(:disclosure_check) { build(:disclosure_check,
                                  under_age: under_age,
                                  known_date: known_date,
-                                 motoring_endorsement: motoring_endorsement) }
+                                 motoring_endorsement: GenericYesNo::YES) }
 
   let(:under_age) { GenericYesNo::NO }
   let(:known_date) { Date.new(2018, 10, 31) }
-  let(:motoring_endorsement) { GenericYesNo::NO }
 
   describe '#expiry_date' do
-    context 'with a motoring endorsement' do
-      let(:motoring_endorsement) { GenericYesNo::YES }
-      it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
-    end
-
-    context 'without a motoring endorsement' do
-      it { expect(subject.expiry_date).to eq(:no_record) }
-    end
+    it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
   end
 end

--- a/spec/services/calculators/motoring/youth/penalty_notice_spec.rb
+++ b/spec/services/calculators/motoring/youth/penalty_notice_spec.rb
@@ -6,21 +6,12 @@ RSpec.describe Calculators::Motoring::Youth::PenaltyNotice do
   let(:disclosure_check) { build(:disclosure_check,
                                  under_age: under_age,
                                  known_date: known_date,
-                                 motoring_endorsement: motoring_endorsement) }
+                                 motoring_endorsement: GenericYesNo::YES) }
 
   let(:under_age) { GenericYesNo::YES }
   let(:known_date) { Date.new(2020, 1, 1) }
-  let(:motoring_endorsement) { GenericYesNo::NO }
 
   describe '#expiry_date' do
-    context 'with a motoring endorsement' do
-      let(:motoring_endorsement) { GenericYesNo::YES }
-
-      it { expect(subject.expiry_date.to_s).to eq('2022-07-01') }
-    end
-
-    context 'without a motoring endorsement' do
-      it { expect(subject.expiry_date).to eq(:no_record) }
-    end
+    it { expect(subject.expiry_date.to_s).to eq('2022-07-01') }
   end
 end


### PR DESCRIPTION
Back in PR #466 we have agreed to only have endorsed FPN's in the 
service - this is due to non endorsed FPN not being considered a 
conviction. 

Now that we have the possibility to calculate multiple convictions, we 
no longer support non endorsed FPN's as they are not a conviction.

This is more of a follow up cleanup on #466