### PR TITLE
Ensure we start a new session in some links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,7 +60,7 @@ module ApplicationHelper
     }.merge(attributes)
   end
 
-  def allow_to_cancel_check?
+  def any_completed_checks?
     current_disclosure_report.disclosure_checks.completed.any?
   end
 

--- a/app/views/errors/report_completed.html.erb
+++ b/app/views/errors/report_completed.html.erb
@@ -5,8 +5,13 @@
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
     <p class="govuk-body"><%=t '.lead_text' %></p>
-    <p class="govuk-body"><%= link_to t('.results_page'), steps_check_results_path, class: 'govuk-link govuk-link--no-visited-state' %></p>
 
-    <%= link_button :start_again, root_path %>
+    <% if any_completed_checks? %>
+      <p class="govuk-body">
+        <%= link_to t('.results_page'), steps_check_results_path, class: 'govuk-link govuk-link--no-visited-state' %>
+      </p>
+    <% end %>
+
+    <%= link_button :start_again, root_path(new: 'y') %>
   </div>
 </div>

--- a/app/views/steps/check/results/shared/_feedback.en.html.erb
+++ b/app/views/steps/check/results/shared/_feedback.en.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <%
-  survey_file = if current_disclosure_check.under_age.inquiry.yes?
+  survey_file = if current_disclosure_check.under_age.to_s.inquiry.yes?
                   'tRaiETqnLgj758hTBazgd_2Bo7LRXsbd1AcAFHQu4ukGzukG3bvIXELhbfUTio3i90'
                 else
                   'tRaiETqnLgj758hTBazgd6NBO_2By7HeCVIjOSkE2u6sDH2S6srYblwb6DaI4Zc9w5'

--- a/app/views/steps/check/results/show.en.html.erb
+++ b/app/views/steps/check/results/show.en.html.erb
@@ -44,7 +44,7 @@
 
     <p class="govuk-body">
       If you need to change any information, or if you have another caution or conviction you’d like to
-      check, <%= link_to 'start a new check', root_path, class: 'govuk-link govuk-link--no-visited-state ga-pageLink', data: { ga_category: 'results', ga_label: 'new check' } %>.
+      check, <%= link_to 'start a new check', root_path(new: 'y'), class: 'govuk-link govuk-link--no-visited-state ga-pageLink', data: { ga_category: 'results', ga_label: 'new check' } %>.
     </p>
 
     <h2 class="govuk-heading-l" id="telling-people-section">

--- a/app/views/steps/shared/_kickout_buttons.html.erb
+++ b/app/views/steps/shared/_kickout_buttons.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-button-group govuk-!-margin-top-6">
-  <% if allow_to_cancel_check? %>
+  <% if any_completed_checks? %>
     <%= link_button :cancel_check, steps_check_check_your_answers_path %>
   <% else %>
     <%= link_button :restart_check, root_path(new: 'y') %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#allow_to_cancel_check?' do
+  describe '#any_completed_checks?' do
     let(:disclosure_report) { instance_double(DisclosureReport) }
     let(:disclosure_checks) { double('result_set', completed: checks) }
 
@@ -159,12 +159,12 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context 'for no checks completed' do
       let(:checks) { [] }
-      it { expect(helper.allow_to_cancel_check?).to eq(false) }
+      it { expect(helper.any_completed_checks?).to eq(false) }
     end
 
     context 'for at least one check completed' do
       let(:checks) { [1] }
-      it { expect(helper.allow_to_cancel_check?).to eq(true) }
+      it { expect(helper.any_completed_checks?).to eq(true) }
     end
   end
 


### PR DESCRIPTION
A very minor fix.

There were some edge cases where the links to start a new check would still show the message "you have a check in progress" which is not what we wanted.

This is because they were missing the "magic" parameter that indicates to not show that message and instead reset/start a new session.

Similarly, in the completed report error page, do not link to the results page if there are no completed checks as that makes no sense.

Renamed the helper method to make more clear what it does.