### PR TITLE
Check we have a completed report before results page

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -10,6 +10,8 @@ module ErrorHandling
         redirect_to results_not_found_errors_path
       when Errors::ReportCompleted
         redirect_to report_completed_errors_path
+      when Errors::ReportNotCompleted
+        redirect_to report_not_completed_errors_path
       else
         raise if Rails.application.config.consider_all_requests_local
 
@@ -27,5 +29,9 @@ module ErrorHandling
 
   def check_disclosure_report_not_completed
     raise Errors::ReportCompleted if current_disclosure_report.completed?
+  end
+
+  def check_disclosure_report_completed
+    raise Errors::ReportNotCompleted unless current_disclosure_report.completed?
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -17,6 +17,10 @@ class ErrorsController < ApplicationController
     respond_with_status(:unprocessable_entity)
   end
 
+  def report_not_completed
+    respond_with_status(:unprocessable_entity)
+  end
+
   def unhandled
     respond_with_status(:internal_server_error)
   end

--- a/app/controllers/steps/check/results_controller.rb
+++ b/app/controllers/steps/check/results_controller.rb
@@ -1,6 +1,8 @@
 module Steps
   module Check
     class ResultsController < Steps::CheckStepController
+      before_action :check_disclosure_report_completed
+
       def show
         @presenter = ResultsPresenter.new(current_disclosure_report)
       end

--- a/app/errors/errors.rb
+++ b/app/errors/errors.rb
@@ -4,4 +4,6 @@ module Errors
   class InvalidSession < StandardError; end
 
   class ReportCompleted < StandardError; end
+
+  class ReportNotCompleted < StandardError; end
 end

--- a/app/views/errors/report_not_completed.html.erb
+++ b/app/views/errors/report_not_completed.html.erb
@@ -1,0 +1,11 @@
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
+
+    <p class="govuk-body"><%=t '.lead_text' %></p>
+
+    <%= render partial: 'steps/shared/kickout_buttons' %>
+  </div>
+</div>

--- a/app/views/steps/shared/_kickout_buttons.html.erb
+++ b/app/views/steps/shared/_kickout_buttons.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-button-group govuk-!-margin-top-6">
   <% if any_completed_checks? %>
-    <%= link_button :cancel_check, steps_check_check_your_answers_path %>
+    <%= link_button :check_your_answers, steps_check_check_your_answers_path %>
   <% else %>
     <%= link_button :restart_check, root_path(new: 'y') %>
   <% end %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -100,6 +100,10 @@ en:
       heading: You have already completed this report
       lead_text: If you want to make changes you will need to start again.
       results_page: Go to results page
+    report_not_completed:
+      page_title: Report not completed
+      heading: You have not completed this report
+      lead_text: You need to add cautions or convictions to check their spent dates.
     invalid_session:
       page_title: Sorry, you'll have to start again
       heading: Sorry, you'll have to start again

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -116,7 +116,7 @@ en:
       start_again: New check
       resume_check: Resume check
       restart_check: Start a new check
-      cancel_check: Go back to check your answers
+      check_your_answers: Go back to check your answers
       results_page: Continue to your results
 
     caption:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
     get :not_found
     get :results_not_found
     get :report_completed
+    get :report_not_completed
   end
 
   # Health and ping endpoints (`status` and `health` are alias)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ApplicationController do
     def invalid_session; raise Errors::InvalidSession; end
     def results_not_found; raise Errors::ResultsNotFound; end
     def report_completed; raise Errors::ReportCompleted; end
+    def report_not_completed; raise Errors::ReportNotCompleted; end
     def another_exception; raise Exception; end
   end
 
@@ -45,6 +46,17 @@ RSpec.describe ApplicationController do
 
         get :report_completed
         expect(response).to redirect_to(report_completed_errors_path)
+      end
+    end
+
+    context 'Errors::ReportNotCompleted' do
+      it 'should not report the exception, and redirect to the error page' do
+        routes.draw { get 'report_not_completed' => 'anonymous#report_not_completed' }
+
+        expect(Raven).not_to receive(:capture_exception)
+
+        get :report_not_completed
+        expect(response).to redirect_to(report_not_completed_errors_path)
       end
     end
 

--- a/spec/controllers/steps/check/results_controller_spec.rb
+++ b/spec/controllers/steps/check/results_controller_spec.rb
@@ -19,23 +19,25 @@ RSpec.describe Steps::Check::ResultsController, type: :controller do
       end
     end
 
-    context 'when the disclosure report is completed' do
+    context 'when there is a disclosure report in the session' do
       let(:disclosure_check) { DisclosureCheck.create(status: :in_progress) }
 
-      before do
-        disclosure_check.disclosure_report.completed!
+      context 'when the disclosure report is completed' do
+        before do
+          disclosure_check.disclosure_report.completed!
+        end
+
+        it 'does not return an error, and renders the template' do
+          get :show, session: { disclosure_check_id: disclosure_check.id }
+          expect(response).to render_template(:show)
+        end
       end
 
-      it 'does not return an error, and renders the template' do
-        get :show, session: { disclosure_check_id: disclosure_check.id }
-        expect(response).to render_template(:show)
-      end
-    end
-
-    context 'when there is a valid disclosure check' do
-      it 'render template' do
-        get :show
-        expect(response).to render_template(:show)
+      context 'when the disclosure report is not yet completed' do
+        it 'does redirects to the error page' do
+          get :show, session: { disclosure_check_id: disclosure_check.id }
+          expect(response).to redirect_to(report_not_completed_errors_path)
+        end
       end
     end
   end


### PR DESCRIPTION
There was a missing validation in the results page.

If a user, for whatever reason bookmarks the result page, next time they come back to the service they might not complete any check or leave midway a check and then jump straight to the results page.

It would show an empty page (as in no items: cautions or convictions in the basket) which would be weird.

With this validation we ensure we show the results page only if we have a "completed" report. If not we show an error message and let them either get back to the CYA page if they had something in the basket, or to start a new check.