### PR TITLE
Results page new design

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -16,6 +16,10 @@
   padding: govuk-spacing(3);
 }
 
+.app-tag-middle {
+  vertical-align: middle;
+}
+
 dl.multiple-checks-summary:not(:only-child) {
   &:not(:last-of-type) { padding-bottom: 0.5em; }
 }

--- a/app/presenters/check_group_presenter.rb
+++ b/app/presenters/check_group_presenter.rb
@@ -23,8 +23,7 @@ class CheckGroupPresenter
   def spent_date_panel
     SpentDatePanel.new(
       kind: first_check_kind,
-      spent_date: spent_date,
-      conviction_date: conviction_date
+      spent_date: spent_date
     )
   end
 
@@ -42,10 +41,6 @@ class CheckGroupPresenter
   end
 
   private
-
-  def conviction_date
-    @_conviction_date ||= completed_checks.first.conviction_date
-  end
 
   def first_check_kind
     @_first_check_kind ||= completed_checks.first.kind

--- a/app/presenters/check_group_presenter.rb
+++ b/app/presenters/check_group_presenter.rb
@@ -16,8 +16,9 @@ class CheckGroupPresenter
 
   def spent_date_panel
     SpentDatePanel.new(
+      kind: first_check_kind,
       spent_date: spent_date,
-      kind: first_check_kind
+      conviction_date: conviction_date
     )
   end
 
@@ -35,6 +36,10 @@ class CheckGroupPresenter
   end
 
   private
+
+  def conviction_date
+    @_conviction_date ||= completed_checks.first.conviction_date
+  end
 
   def first_check_kind
     @_first_check_kind ||= completed_checks.first.kind

--- a/app/presenters/check_group_presenter.rb
+++ b/app/presenters/check_group_presenter.rb
@@ -14,6 +14,12 @@ class CheckGroupPresenter
     end
   end
 
+  def spent_tag
+    SpentTag.new(
+      spent_date: spent_date
+    )
+  end
+
   def spent_date_panel
     SpentDatePanel.new(
       kind: first_check_kind,

--- a/app/presenters/spent_date_panel.rb
+++ b/app/presenters/spent_date_panel.rb
@@ -1,10 +1,9 @@
 class SpentDatePanel
-  attr_reader :kind, :spent_date, :conviction_date
+  attr_reader :kind, :spent_date
 
-  def initialize(kind:, spent_date:, conviction_date:)
+  def initialize(kind:, spent_date:)
     @kind = kind
     @spent_date = spent_date
-    @conviction_date = conviction_date
   end
 
   def to_partial_path
@@ -17,10 +16,6 @@ class SpentDatePanel
 
   def date
     I18n.l(spent_date) if spent_date.instance_of?(Date)
-  end
-
-  def given_date
-    I18n.l(conviction_date) if conviction_date.instance_of?(Date)
   end
 
   private

--- a/app/presenters/spent_date_panel.rb
+++ b/app/presenters/spent_date_panel.rb
@@ -1,9 +1,10 @@
 class SpentDatePanel
-  attr_reader :spent_date, :kind
+  attr_reader :kind, :spent_date, :conviction_date
 
-  def initialize(spent_date:, kind:)
-    @spent_date = spent_date
+  def initialize(kind:, spent_date:, conviction_date:)
     @kind = kind
+    @spent_date = spent_date
+    @conviction_date = conviction_date
   end
 
   def to_partial_path
@@ -16,6 +17,10 @@ class SpentDatePanel
 
   def date
     I18n.l(spent_date) if spent_date.instance_of?(Date)
+  end
+
+  def given_date
+    I18n.l(conviction_date) if conviction_date.instance_of?(Date)
   end
 
   private

--- a/app/presenters/spent_tag.rb
+++ b/app/presenters/spent_tag.rb
@@ -1,0 +1,34 @@
+class SpentTag
+  GREEN = 'green'.freeze
+  RED = 'red'.freeze
+
+  COLORS = {
+    ResultsVariant::SPENT => GREEN,
+    ResultsVariant::NOT_SPENT => RED,
+    ResultsVariant::NEVER_SPENT => RED,
+    ResultsVariant::SPENT_SIMPLE => GREEN,
+    ResultsVariant::INDEFINITE => RED,
+  }.freeze
+
+  attr_reader :spent_date
+
+  def initialize(spent_date:)
+    @spent_date = spent_date
+  end
+
+  def color
+    COLORS[variant]
+  end
+
+  def variant
+    if spent_date.instance_of?(Date)
+      spent_date.past? ? ResultsVariant::SPENT : ResultsVariant::NOT_SPENT
+    else
+      spent_date
+    end
+  end
+
+  def scope
+    'results/spent_tag'
+  end
+end

--- a/app/views/steps/check/results/shared/_check.html.erb
+++ b/app/views/steps/check/results/shared/_check.html.erb
@@ -1,8 +1,12 @@
 <div class="app-proceeding-box">
   <h2 class="govuk-heading-l">
     <%=t "#{check.check_group_kind}.heading", scope: check.scope, index: check.number %>
+
+    <strong class="govuk-tag govuk-tag--<%= check.spent_tag.color %> govuk-!-margin-left-3 app-tag-middle">
+      <%= t check.spent_tag.variant, scope: check.spent_tag.scope %>
+    </strong>
   </h2>
 
-  <%= render check.spent_date_panel if check.spent_date %>
+  <%= render check.spent_date_panel %>
   <%= render check.summary %>
 </div>

--- a/app/views/steps/check/results/shared/_spent_date_panel.html.erb
+++ b/app/views/steps/check/results/shared/_spent_date_panel.html.erb
@@ -1,6 +1,8 @@
-<div class="govuk-panel govuk-panel--confirmation">
-  <h3 class="govuk-panel__title govuk-!-font-size-27">
-    <%=t('title_html', scope: spent_date_panel.scope,
-         kind: spent_date_panel.kind, date: spent_date_panel.date) %>
-  </h3>
-</div>
+<p class="govuk-body">
+  <%= t(
+        'title_html',
+        scope: spent_date_panel.scope,
+        kind: spent_date_panel.kind,
+        date: spent_date_panel.date,
+        given_date: spent_date_panel.given_date) %>
+</p>

--- a/app/views/steps/check/results/shared/_spent_date_panel.html.erb
+++ b/app/views/steps/check/results/shared/_spent_date_panel.html.erb
@@ -1,8 +1,3 @@
 <p class="govuk-body">
-  <%= t(
-        'title_html',
-        scope: spent_date_panel.scope,
-        kind: spent_date_panel.kind,
-        date: spent_date_panel.date,
-        given_date: spent_date_panel.given_date) %>
+  <%= t('title_html', scope: spent_date_panel.scope, kind: spent_date_panel.kind, date: spent_date_panel.date) %>
 </p>

--- a/app/views/steps/check/results/show.en.html.erb
+++ b/app/views/steps/check/results/show.en.html.erb
@@ -9,7 +9,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
     <h1 class="govuk-heading-xl">
       <% if @presenter.calculator.all_spent? %>
         Your cautions or convictions are spent
@@ -18,83 +17,60 @@
       <% end %>
     </h1>
 
-    <div class="govuk-inset-text">
-      The result you’ve been given is for guidance only. Find out
-      <a class="govuk-link govuk-link--no-visited-state" href="#next-steps-section">how to use this information</a>
-      before deciding whether or not to tell people about your caution or conviction.
-    </div>
-
-    <h2 class="govuk-heading-l">Contents</h2>
-
-    <ol class="govuk-list govuk-list--number">
-      <li><a class="govuk-link govuk-link--no-visited-state" href="#spent-section">When your cautions or convictions become spent</a></li>
-      <li><a class="govuk-link govuk-link--no-visited-state" href="#telling-people-section">Telling people about your cautions or convictions</a></li>
-      <li><a class="govuk-link govuk-link--no-visited-state" href="#next-steps-section">How to use this information</a></li>
-    </ol>
-
-    <h2 class="govuk-heading-l" id="spent-section">
-      1. When your cautions or convictions become spent
-    </h2>
-
-    <p class="govuk-body">The spent dates you’ve been given are based on:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>what you’ve told us about your cautions or convictions</li>
-      <li>the current law on <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/guidance/rehabilitation-periods">rehabilitation periods</a></li>
-    </ul>
+    <p class="govuk-body">
+      Your results are calculated using the information you have given and the current law.
+      Read more about
+      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/tell-employer-or-college-about-criminal-record/what-information-you-need-to-give">
+        what a spent caution or conviction is</a>
+      on GOV.UK.
+    </p>
 
     <%= render @presenter.summary %>
 
+    <h2 class="govuk-heading-l">Using your results</h2>
+
     <p class="govuk-body">
-      If you need to change any information, or if you have another caution or conviction you’d like to
-      check, <%= link_to 'start a new check', root_path(new: 'y'), class: 'govuk-link govuk-link--no-visited-state ga-pageLink', data: { ga_category: 'results', ga_label: 'new check' } %>.
+      Your results are correct if you served your sentence in full as the court ordered you to.
+      The conviction might not be spent if you did not stick to the terms of your sentence.
     </p>
 
-    <h2 class="govuk-heading-l" id="telling-people-section">
-      2. Telling people about your cautions or convictions
-    </h2>
-
-    <h3 class="govuk-heading-s">If a basic criminal record check is requested</h3>
-
     <p class="govuk-body">
-      When a caution or conviction is spent you do not need to tell people about it, or the offence that led to it,
-      if they’re carrying out a
-      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#basic-dbs-checks">basic
-        criminal record check</a>.
+      You do not have to tell anyone about spent cautions or convictions unless you are asked.
+      And employers and other organisations can only ask if they have a good reason.
+      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/tell-employer-or-college-about-criminal-record/what-information-you-need-to-give">
+        Read more about this on GOV.UK</a>.
     </p>
 
-    <h3 class="govuk-heading-s">If a standard or enhanced criminal record check is requested</h3>
+    <h3 class="govuk-heading-m">Disclosure and Barring Service (DBS) checks</h3>
 
     <p class="govuk-body">
-      You will usually need to tell people about spent cautions or convictions if they’re carrying out a
-      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/guidance/telling-people-about-your-criminal-record#standard-dbs">standard or
-        enhanced criminal record check</a>.
+      DBS checks are criminal record checks.
+      If you’re applying for a job, university, college or insurance, you may be told a DBS check is needed.
+      You should also be told what type of check will be done.
     </p>
 
-    <h2 class="govuk-heading-l" id="next-steps-section">
-      3. How to use this information
-    </h2>
+    <p class="govuk-body">
+      Criminal record checks are usually done through the Disclosure and Barring Service (DBS).
+    </p>
 
     <p class="govuk-body">
-      As you’ve not given specific details about your caution or conviction, this service can only give you
-      general guidance about when it becomes spent.
-    <p>
+      Some spent cautions and convictions are
+      ‘<a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/publications/dbs-filtering-guidance">protected</a>’
+      and will not show on a DBS certificate.
+    </p>
 
     <p class="govuk-body">
-      The result you’ve been given might be wrong if you:
+      Criminal record checks are usually done through the
+      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/publications/dbs-filtering-guidance">Disclosure and Barring Service (DBS)</a>.
+      The 4 types of DBS checks are:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>entered any incorrect information, such as approximate dates</li>
-      <li>did not serve your sentence in full as the court ordered you to, or</li>
-      <li>did not stick to the conditions of your sentence</li>
+      <li>Basic - shows only cautions and convictions that are not spent.</li>
+      <li>Standard - shows all convictions, cautions, reprimands and final warnings, even if they’re spent</li>
+      <li>Enhanced - shows the same information as a standard check but also includes any information held by the police that they think is relevant to your application.</li>
+      <li>Enhanced with barred list - shows the same information as an enhanced check but also tells employers if you’ve been barred from doing the role you’re applying for.</li>
     </ul>
-
-    <div class="govuk-inset-text">
-      Some spent cautions and convictions are
-      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/publications/dbs-filtering-guidance">’protected’ or ‘filtered’</a> and
-      will not show up on a standard or enhanced criminal record check.
-    </div>
 
     <%= render partial: 'steps/check/results/shared/feedback' %>
   </div>

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -117,15 +117,15 @@ en:
   # Ensure all the values declared in `ResultsVariant` have their corresponding locale here.
   results/shared/spent_date_panel:
     spent:
-      title_html: This %{kind} was spent on <span class="nowrap">%{date}</span>
+      title_html: This %{kind} was given on %{given_date} and was spent on <span class="nowrap">%{date}</span>
     not_spent:
-      title_html: This %{kind} will be spent on <span class="nowrap">%{date}</span>
+      title_html: This %{kind} was given on %{given_date} and will be spent on <span class="nowrap">%{date}</span>
     never_spent:
-      title_html: This %{kind} will never be spent
+      title_html: This %{kind} was given on %{given_date} and will never be spent
     spent_simple:
-      title_html: This %{kind} is spent on the day you receive it
+      title_html: This %{kind} was given on %{given_date} and is spent on the day you receive it
     indefinite:
-      title_html: This %{kind} is not spent and will stay in place until another order is made to change or end it
+      title_html: This %{kind} was given on %{given_date} and is not spent and will stay in place until another order is made to change or end it
 
   results/shared/date_format:
     exact: '%{date}'

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -117,15 +117,22 @@ en:
   # Ensure all the values declared in `ResultsVariant` have their corresponding locale here.
   results/shared/spent_date_panel:
     spent:
-      title_html: This %{kind} was given on %{given_date} and was spent on <span class="nowrap">%{date}</span>
+      title_html: This %{kind} was spent on <span class="nowrap">%{date}</span>
     not_spent:
-      title_html: This %{kind} was given on %{given_date} and will be spent on <span class="nowrap">%{date}</span>
+      title_html: This %{kind} will be spent on <span class="nowrap">%{date}</span>
     never_spent:
-      title_html: This %{kind} was given on %{given_date} and will never be spent
+      title_html: This %{kind} will never be spent
     spent_simple:
-      title_html: This %{kind} was given on %{given_date} and is spent on the day you receive it
+      title_html: This %{kind} is spent on the day you receive it
     indefinite:
-      title_html: This %{kind} was given on %{given_date} and is not spent and will stay in place until another order is made to change or end it
+      title_html: This %{kind} is not spent and will stay in place until another order is made to change or end it
+
+  results/spent_tag:
+    spent: Spent
+    not_spent: Unspent
+    never_spent: Never Spent
+    spent_simple: Spent
+    indefinite: Indefinite
 
   results/shared/date_format:
     exact: '%{date}'

--- a/spec/presenters/check_group_presenter_spec.rb
+++ b/spec/presenters/check_group_presenter_spec.rb
@@ -27,6 +27,22 @@ RSpec.describe CheckGroupPresenter do
     end
   end
 
+  describe '#spent_tag' do
+    let(:spent_date) { Date.yesterday }
+
+    before do
+      allow(subject).to receive(:first_check_kind).and_return('caution')
+    end
+
+    it 'builds a SpentTag instance with the correct attributes' do
+      tag = subject.spent_tag
+
+      expect(tag).to be_an_instance_of(SpentTag)
+      expect(tag.color).to eq(SpentTag::GREEN)
+      expect(tag.variant).to eq(ResultsVariant::SPENT)
+    end
+  end
+
   describe '#spent_date_panel' do
     let(:spent_date) { 'date' }
 
@@ -48,6 +64,7 @@ RSpec.describe CheckGroupPresenter do
       let!(:disclosure_check) { create(:disclosure_check, :caution, :completed) }
       it { expect(subject.check_group_kind).to eq('caution') }
     end
+
     context 'conviction' do
       let!(:disclosure_check) { create(:disclosure_check, :conviction,  :completed) }
       it { expect(subject.check_group_kind).to eq('conviction') }

--- a/spec/presenters/spent_date_panel_spec.rb
+++ b/spec/presenters/spent_date_panel_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe SpentDatePanel do
-  subject { described_class.new(spent_date: spent_date, kind: 'caution') }
+  subject { described_class.new(kind: 'caution', spent_date: spent_date, conviction_date: conviction_date) }
 
   let(:spent_date) { nil }
+  let(:conviction_date) { nil }
   let(:partial_path) { 'results/shared/spent_date_panel' }
 
   describe '#to_partial_path' do
@@ -34,6 +35,18 @@ RSpec.describe SpentDatePanel do
     context 'it is not a date instance' do
       let(:spent_date) { :foobar }
       it { expect(subject.date).to be_nil }
+    end
+  end
+
+  describe '#given_date' do
+    context 'it is a date instance' do
+      let(:conviction_date) { Date.new(2018, 10, 31) }
+      it { expect(subject.given_date).to eq('31 October 2018') }
+    end
+
+    context 'it is not a date instance' do
+      let(:conviction_date) { :foobar }
+      it { expect(subject.given_date).to be_nil }
     end
   end
 end

--- a/spec/presenters/spent_date_panel_spec.rb
+++ b/spec/presenters/spent_date_panel_spec.rb
@@ -1,8 +1,7 @@
 RSpec.describe SpentDatePanel do
-  subject { described_class.new(kind: 'caution', spent_date: spent_date, conviction_date: conviction_date) }
+  subject { described_class.new(kind: 'caution', spent_date: spent_date) }
 
   let(:spent_date) { nil }
-  let(:conviction_date) { nil }
   let(:partial_path) { 'results/shared/spent_date_panel' }
 
   describe '#to_partial_path' do
@@ -35,18 +34,6 @@ RSpec.describe SpentDatePanel do
     context 'it is not a date instance' do
       let(:spent_date) { :foobar }
       it { expect(subject.date).to be_nil }
-    end
-  end
-
-  describe '#given_date' do
-    context 'it is a date instance' do
-      let(:conviction_date) { Date.new(2018, 10, 31) }
-      it { expect(subject.given_date).to eq('31 October 2018') }
-    end
-
-    context 'it is not a date instance' do
-      let(:conviction_date) { :foobar }
-      it { expect(subject.given_date).to be_nil }
     end
   end
 end

--- a/spec/presenters/spent_tag_spec.rb
+++ b/spec/presenters/spent_tag_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe SpentTag do
+  subject { described_class.new(spent_date: spent_date) }
+
+  let(:spent_date) { nil }
+
+  describe '#color' do
+    context 'when spent date is in the past' do
+      let(:spent_date) { Date.yesterday }
+
+      it { expect(subject.color).to eq(SpentTag::GREEN) }
+    end
+
+    context 'when spent date is in the future' do
+      let(:spent_date) { Date.tomorrow }
+
+      it { expect(subject.color).to eq(SpentTag::RED) }
+    end
+
+    context 'when spent date is NEVER_SPENT' do
+      let(:spent_date) { ResultsVariant::NEVER_SPENT }
+
+      it { expect(subject.color).to eq(SpentTag::RED) }
+    end
+
+    context 'when spent date is SPENT_SIMPLE' do
+      let(:spent_date) { ResultsVariant::SPENT_SIMPLE }
+
+      it { expect(subject.color).to eq(SpentTag::GREEN) }
+    end
+
+    context 'when spent date is INDEFINITE' do
+      let(:spent_date) { ResultsVariant::INDEFINITE }
+
+      it { expect(subject.color).to eq(SpentTag::RED) }
+    end
+  end
+
+  describe '#variant' do
+    context 'when spent date is a date' do
+      context 'when is a past date' do
+        let(:spent_date) { Date.yesterday }
+
+        it { expect(subject.variant).to eq(ResultsVariant::SPENT) }
+      end
+
+      context 'when is a future date' do
+        let(:spent_date) { Date.tomorrow }
+
+        it { expect(subject.variant).to eq(ResultsVariant::NOT_SPENT) }
+      end
+    end
+
+    context 'when spent date is INDEFINITE' do
+      let(:spent_date) { ResultsVariant::INDEFINITE }
+
+      it { expect(subject.variant).to eq(ResultsVariant::INDEFINITE) }
+    end
+
+    context 'when spent date is SPENT_SIMPLE' do
+      let(:spent_date) { ResultsVariant::SPENT_SIMPLE }
+
+      it { expect(subject.variant).to eq(ResultsVariant::SPENT_SIMPLE) }
+    end
+
+    context 'when spent date is NEVER_SPENT' do
+      let(:spent_date) { ResultsVariant::NEVER_SPENT }
+
+      it { expect(subject.variant).to eq(ResultsVariant::NEVER_SPENT) }
+    end
+  end
+
+  describe '#scope' do
+    it { expect(subject.scope).to eq('results/spent_tag') }
+  end
+end


### PR DESCRIPTION
Story: https://trello.com/c/QmITv0Rd

I've reconsiders the addition of the conviction date within the paragraph and found that it adds too much code for a minimal gain, because cautions do not have "conviction_date" but a "known_date". We already have that information on the table underneath so I think it's not worth the extra code for repeated information.

I'm also considering changing the name of "SpentDatePanel" but right now I don't have a better naming for it.

### Never spent
![image](https://user-images.githubusercontent.com/136777/117675233-4b3d6600-b1a4-11eb-9f4a-1bbae7ffb412.png)

### Spent
![image](https://user-images.githubusercontent.com/136777/117675280-555f6480-b1a4-11eb-8b51-1d5894d3a2ea.png)

### Unspent
![image](https://user-images.githubusercontent.com/136777/117675331-614b2680-b1a4-11eb-9c04-c5541fa292ef.png)
