### PR TITLE
Show DBS information on results page (feature-flagged)

### DIFF
--- a/app/presenters/check_group_presenter.rb
+++ b/app/presenters/check_group_presenter.rb
@@ -28,6 +28,14 @@ class CheckGroupPresenter
     )
   end
 
+  def dbs_visibility
+    DbsVisibility.new(
+      kind: first_check_kind,
+      variant: variant,
+      completed_checks: completed_checks
+    )
+  end
+
   def to_partial_path
     [scope, 'shared', 'check'].join('/')
   end

--- a/app/presenters/dbs_visibility.rb
+++ b/app/presenters/dbs_visibility.rb
@@ -1,0 +1,51 @@
+class DbsVisibility
+  attr_reader :kind, :variant, :completed_checks
+
+  delegate :spent?, to: :variant
+
+  def initialize(kind:, variant:, completed_checks:)
+    @kind = kind
+    @variant = variant
+    @completed_checks = completed_checks
+  end
+
+  # Basic check rules:
+  #
+  #   - If caution/conviction is spent: will not appear on a basic DBS check.
+  #   - If caution/conviction is unspent: will appear on a basic DBS check.
+  #
+  def basic
+    return :will_not if spent?
+
+    :will
+  end
+
+  # Enhanced check rules:
+  #
+  #   - Youth cautions will not appear on enhanced checks regardless spent/unspent.
+  #   - Unspent cautions/convictions: will appear on enhanced checks.
+  #   - TODO: Spent cautions/convictions: TBD, for now we say 'may appear'.
+  #
+  def enhanced
+    return :will_not if youth_caution?
+    return :will unless spent?
+
+    :maybe
+  end
+
+  def to_partial_path
+    'results/shared/dbs_visibility'
+  end
+
+  private
+
+  def youth_caution?
+    return false unless CheckKind.new(kind).inquiry.caution?
+
+    # `completed_checks` refers to this caution or conviction orders or sentences.
+    # For cautions, we always have just one thing, so we pick the first one.
+    caution = completed_checks.first
+
+    CautionType.new(caution.caution_type).youth?
+  end
+end

--- a/app/views/steps/check/results/shared/_check.html.erb
+++ b/app/views/steps/check/results/shared/_check.html.erb
@@ -8,5 +8,7 @@
   </h2>
 
   <%= render check.spent_date_panel %>
+  <%= render check.dbs_visibility if dev_tools_enabled? %>
+
   <%= render check.summary %>
 </div>

--- a/app/views/steps/check/results/shared/_dbs_visibility.html.erb
+++ b/app/views/steps/check/results/shared/_dbs_visibility.html.erb
@@ -1,0 +1,5 @@
+<div class="govuk-inset-text govuk-!-padding-top-1 govuk-!-padding-bottom-1">
+  <%= t([dbs_visibility.basic, 'html'].join('_'), scope: [dbs_visibility.to_partial_path, :basic_dbs], kind: dbs_visibility.kind) %>
+  <br/>
+  <%= t([dbs_visibility.enhanced, 'html'].join('_'), scope: [dbs_visibility.to_partial_path, :enhanced_dbs], kind: dbs_visibility.kind) %>
+</div>

--- a/app/views/steps/check/results/show.en.html.erb
+++ b/app/views/steps/check/results/show.en.html.erb
@@ -41,7 +41,7 @@
         Read more about this on GOV.UK</a>.
     </p>
 
-    <h3 class="govuk-heading-m">Disclosure and Barring Service (DBS) checks</h3>
+    <h3 class="govuk-heading-m" id="disclosure-and-barring-service">Disclosure and Barring Service (DBS) checks</h3>
 
     <p class="govuk-body">
       DBS checks are criminal record checks.

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -127,6 +127,16 @@ en:
     indefinite:
       title_html: This %{kind} is not spent and will stay in place until another order is made to change or end it
 
+  results/shared/dbs_visibility:
+    basic_dbs:
+      will_html: This %{kind} <strong>will</strong> appear on a <a class="govuk-link" href="#disclosure-and-barring-service">basic DBS check</a>.
+      will_not_html: This %{kind} <strong>will not</strong> appear on a <a class="govuk-link" href="#disclosure-and-barring-service">basic DBS check</a>.
+      maybe_html: This %{kind} <strong>may</strong> appear on a <a class="govuk-link" href="#disclosure-and-barring-service">basic DBS check</a>.
+    enhanced_dbs:
+      will_html: This %{kind} <strong>will</strong> appear on a <a class="govuk-link" href="#disclosure-and-barring-service">standard or enhanced DBS check</a>.
+      will_not_html: This %{kind} <strong>will not</strong> appear on a <a class="govuk-link" href="#disclosure-and-barring-service">standard or enhanced DBS check</a>.
+      maybe_html: This %{kind} <strong>may</strong> appear on a <a class="govuk-link" href="#disclosure-and-barring-service">standard or enhanced DBS check</a>.
+
   results/spent_tag:
     spent: Spent
     not_spent: Unspent

--- a/spec/presenters/check_group_presenter_spec.rb
+++ b/spec/presenters/check_group_presenter_spec.rb
@@ -55,6 +55,22 @@ RSpec.describe CheckGroupPresenter do
     end
   end
 
+  describe '#dbs_visibility' do
+    let(:spent_date) { Date.yesterday }
+
+    before do
+      allow(subject).to receive(:first_check_kind).and_return('caution')
+    end
+
+    it 'builds a DbsVisibility instance with the correct attributes' do
+      panel = subject.dbs_visibility
+
+      expect(panel).to be_an_instance_of(DbsVisibility)
+      expect(panel.kind).to eq('caution')
+      expect(panel.variant).to eq(ResultsVariant::SPENT)
+    end
+  end
+
   describe '#check_group_kind' do
     context 'caution' do
       let!(:disclosure_check) { create(:disclosure_check, :caution, :completed) }

--- a/spec/presenters/dbs_visibility_spec.rb
+++ b/spec/presenters/dbs_visibility_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe DbsVisibility do
+  subject { described_class.new(kind: kind, variant: variant, completed_checks: [disclosure_check]) }
+
+  let(:kind) { nil }
+  let(:variant) { nil }
+  let(:disclosure_check) { nil }
+
+  describe '#to_partial_path' do
+    it { expect(subject.to_partial_path).to eq('results/shared/dbs_visibility') }
+  end
+
+  # Note: for basic checks it does not matter if it is a caution or a conviction
+  describe '#basic' do
+    let(:kind) { 'foobar' }
+
+    context 'for a spent variant' do
+      let(:variant) { ResultsVariant::SPENT }
+      it { expect(subject.basic).to eq(:will_not) }
+    end
+
+    context 'for a not spent variant' do
+      let(:variant) { ResultsVariant::NOT_SPENT }
+      it { expect(subject.basic).to eq(:will) }
+    end
+  end
+
+  describe '#enhanced' do
+    context 'for a caution' do
+      let(:kind) { 'caution' }
+
+      context 'for a youth caution' do
+        let(:disclosure_check) { build(:disclosure_check, :youth_simple_caution) }
+
+        context 'for a spent variant' do
+          let(:variant) { ResultsVariant::SPENT }
+          it { expect(subject.enhanced).to eq(:will_not) }
+        end
+
+        context 'for a not spent variant' do
+          let(:variant) { ResultsVariant::NOT_SPENT }
+          it { expect(subject.enhanced).to eq(:will_not) }
+        end
+      end
+
+      context 'for an adult caution' do
+        let(:disclosure_check) { build(:disclosure_check, :adult_caution) }
+
+        context 'for a spent variant' do
+          let(:variant) { ResultsVariant::SPENT }
+          it { expect(subject.enhanced).to eq(:maybe) }
+        end
+
+        context 'for a not spent variant' do
+          let(:variant) { ResultsVariant::NOT_SPENT }
+          it { expect(subject.enhanced).to eq(:will) }
+        end
+      end
+    end
+
+    context 'for a conviction' do
+      let(:kind) { 'conviction' }
+
+      context 'for a spent variant' do
+        let(:variant) { ResultsVariant::SPENT }
+        it { expect(subject.enhanced).to eq(:maybe) }
+      end
+
+      context 'for a not spent variant' do
+        let(:variant) { ResultsVariant::NOT_SPENT }
+        it { expect(subject.enhanced).to eq(:will) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://trello.com/c/urHOEzjZ

Follow-up to PR #504.

Implement the DBS informational inset block on the results page, but for now it will only show on local/staging envs until we have the green light.

Also, the rules for enhanced checks are not completely clear, so my best attempt was when in doubt, to say `may appear`.

Basic checks are correct to the best of my knowledge. Also enhanced youth cautions.

<img width="576" alt="Screenshot 2021-05-12 at 10 24 25" src="https://user-images.githubusercontent.com/687910/117951676-4dbacf80-b30c-11eb-8f34-8d03d2ac03ff.png">
