### PR TITLE
Fix the DBS youth caution rules

### DIFF
--- a/app/presenters/dbs_visibility.rb
+++ b/app/presenters/dbs_visibility.rb
@@ -22,13 +22,13 @@ class DbsVisibility
 
   # Enhanced check rules:
   #
-  #   - Youth cautions will not appear on enhanced checks regardless spent/unspent.
   #   - Unspent cautions/convictions: will appear on enhanced checks.
+  #   - Spent youth cautions: will not appear on enhanced checks.
   #   - TODO: Spent cautions/convictions: TBD, for now we say 'may appear'.
   #
   def enhanced
-    return :will_not if youth_caution?
     return :will unless spent?
+    return :will_not if youth_caution?
 
     :maybe
   end

--- a/spec/presenters/dbs_visibility_spec.rb
+++ b/spec/presenters/dbs_visibility_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe DbsVisibility do
 
         context 'for a not spent variant' do
           let(:variant) { ResultsVariant::NOT_SPENT }
-          it { expect(subject.enhanced).to eq(:will_not) }
+          it { expect(subject.enhanced).to eq(:will) }
         end
       end
 


### PR DESCRIPTION
Follow up to PR #505.

Little misunderstanding with the rules.

Youth cautions that are not spent will appear on both, standard and enhanced checks (it’s only those that are spent that will not).