### PR TITLE
Re-introduce text in the results page

### DIFF
--- a/app/forms/value_object_methods.rb
+++ b/app/forms/value_object_methods.rb
@@ -1,11 +1,4 @@
 module ValueObjectMethods
-  APPROXIMATE_DATE_ATTRS = [
-    :approximate_known_date,
-    :approximate_conviction_date,
-    :approximate_conditional_end_date,
-    :approximate_compensation_payment_date,
-  ].freeze
-
   def self.included(base)
     base.send :include, InstanceMethods
   end
@@ -36,10 +29,6 @@ module ValueObjectMethods
       return conviction_subtype if conviction?
 
       raise 'Unknown or nil check kind'
-    end
-
-    def approximate_dates?
-      APPROXIMATE_DATE_ATTRS.any? { |attr| disclosure_check.try(attr) }
     end
   end
 end

--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -1,4 +1,36 @@
 class ResultsPresenter < BasketPresenter
+  APPROXIMATE_DATE_ATTRS = [
+    :approximate_known_date,
+    :approximate_conviction_date,
+    :approximate_conditional_end_date,
+    :approximate_compensation_payment_date,
+  ].freeze
+
+  MOTORING_CONVICTION_TYPES = [
+    ConvictionType::YOUTH_MOTORING,
+    ConvictionType::ADULT_MOTORING
+  ].map(&:to_s).freeze
+
+  def approximate_dates?
+    APPROXIMATE_DATE_ATTRS.any? do |attr|
+      disclosure_report.disclosure_checks.any? do |disclosure_check|
+        disclosure_check.try(attr)
+      end
+    end
+  end
+
+  def motoring?
+    disclosure_report.disclosure_checks.any? do |disclosure_check|
+      MOTORING_CONVICTION_TYPES.include?(disclosure_check.conviction_type)
+    end
+  end
+
+  def time_on_bail?
+    disclosure_report.disclosure_checks.any? do |disclosure_check|
+      disclosure_check.conviction_bail_days.to_i.positive?
+    end
+  end
+
   def scope
     :results
   end

--- a/app/views/steps/check/results/show.en.html.erb
+++ b/app/views/steps/check/results/show.en.html.erb
@@ -17,6 +17,12 @@
       <% end %>
     </h1>
 
+    <% if @presenter.approximate_dates? %>
+      <p class="govuk-body">
+        You entered an approximate date so your results will be approximate.
+      </p>
+    <% end %>
+
     <p class="govuk-body">
       Your results are calculated using the information you have given and the current law.
       Read more about
@@ -40,6 +46,36 @@
       <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/tell-employer-or-college-about-criminal-record/what-information-you-need-to-give">
         Read more about this on GOV.UK</a>.
     </p>
+
+    <% if @presenter.motoring? %>
+      <h3 class="govuk-heading-m">Your driving record</h3>
+
+      <p class="govuk-body">
+        This checker tells you whether cautions or convictions are spent.
+        However, some motoring endorsements stay on your driving record after the caution or conviction is spent.
+      </p>
+
+      <p class="govuk-body">
+        Your driving record is maintained by the Driver and Vehicle Licensing Agency (DVLA).
+        You can <a href="https://www.gov.uk/view-driving-licence" class="govuk-link" rel="external" target="_blank">view your driving licence information</a>, including your driving record, on GOV.UK.
+      </p>
+
+      <p class="govuk-body">
+        You can find out more about <a href="https://www.gov.uk/penalty-points-endorsements" class="govuk-link" rel="external" target="_blank">penalty points</a> on GOV.UK.
+      </p>
+    <% end %>
+
+    <% if @presenter.time_on_bail? %>
+      <h3 class="govuk-heading-m">
+        Time spent on bail with an electronic tag
+      </h3>
+
+      <p class="govuk-body">
+        Your result and spent date include the number of days you said you spent
+        on bail with an electronic tag that counted towards your sentence.
+        Each full day offsets a day from the total length of your sentence.
+      </p>
+    <% end %>
 
     <h3 class="govuk-heading-m" id="disclosure-and-barring-service">Disclosure and Barring Service (DBS) checks</h3>
 

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -65,46 +65,4 @@ RSpec.describe BaseForm do
       end
     end
   end
-
-  describe 'APPROXIMATE_DATE_ATTRS' do
-    it 'returns the expected attributes' do
-      expect(described_class::APPROXIMATE_DATE_ATTRS).to eq([
-        :approximate_known_date,
-        :approximate_conviction_date,
-        :approximate_conditional_end_date,
-        :approximate_compensation_payment_date,
-      ])
-    end
-  end
-
-  describe '#approximate_dates?' do
-    let(:disclosure_check) {
-      instance_double(
-        DisclosureCheck,
-        approximate_conviction_date: approximate_conviction_date,
-        approximate_known_date: approximate_known_date
-      )
-    }
-
-    let(:approximate_conviction_date) { false }
-    let(:approximate_known_date) { false }
-
-    before do
-      allow(subject).to receive(:disclosure_check).and_return(disclosure_check)
-    end
-
-    context 'there is at least one approximate date' do
-      let(:approximate_known_date) { true }
-      it { expect(subject.approximate_dates?).to eq(true) }
-    end
-
-    context 'there are no approximate dates' do
-      it { expect(subject.approximate_dates?).to eq(false) }
-    end
-
-    context 'there are nil values' do
-      let(:approximate_known_date) { nil }
-      it { expect(subject.approximate_dates?).to eq(false) }
-    end
-  end
 end

--- a/spec/presenters/results_presenter_spec.rb
+++ b/spec/presenters/results_presenter_spec.rb
@@ -47,6 +47,55 @@ RSpec.describe ResultsPresenter do
     end
   end
 
+  describe 'APPROXIMATE_DATE_ATTRS' do
+    it 'returns the expected attributes' do
+      expect(described_class::APPROXIMATE_DATE_ATTRS).to eq([
+        :approximate_known_date,
+        :approximate_conviction_date,
+        :approximate_conditional_end_date,
+        :approximate_compensation_payment_date,
+      ])
+    end
+  end
+
+  describe '#approximate_dates?' do
+    it { expect(subject.approximate_dates?).to be(false) }
+
+    context 'when there is an approximate date' do
+      described_class::APPROXIMATE_DATE_ATTRS.each do |approximate_date_attr|
+        before { disclosure_check.update(approximate_date_attr => true) }
+
+        it { expect(subject.approximate_dates?).to be(true) }
+      end
+    end
+  end
+
+  describe '#motoring?' do
+    it { expect(subject.motoring?).to be(false) }
+
+    context 'when conviction type is adult motoring' do
+      before { disclosure_check.update(conviction_type: ConvictionType::ADULT_MOTORING) }
+
+      it { expect(subject.motoring?).to be(true) }
+    end
+
+    context 'when conviction type is youth motoring' do
+      before { disclosure_check.update(conviction_type: ConvictionType::YOUTH_MOTORING) }
+
+      it { expect(subject.motoring?).to be(true) }
+    end
+  end
+
+  describe '#time_on_bail?' do
+    it { expect(subject.time_on_bail?).to be(false) }
+
+    context 'when conviction_bail_days is a positive number' do
+      before { disclosure_check.update(conviction_bail_days: 1) }
+
+      it { expect(subject.time_on_bail?).to be(true) }
+    end
+  end
+
   describe '#proceedings_size' do
     it 'returns the calculator proceedings size' do
       expect(subject.proceedings_size).to eq(1)


### PR DESCRIPTION
The following text had been removed in PR #492 as part of
moving towards the service being capable of dealing with multiple cautions and convictions.

The added code now checks for any disclosure check that has:
- approximate dates selected
- bail time
- motoring conviction

Story: https://trello.com/c/ONHg9IzX/278-dc-results-page-missing-copy



----


### Screenshot with all text visible

![Pasted_Image_12_05_2021__13_40](https://user-images.githubusercontent.com/136777/118102941-4b6e7900-b3d1-11eb-9573-63da209a1385.png)