### PR TITLE
Copy amendments and introduction of convictions logic

### DIFF
--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -11,6 +11,10 @@ class ResultsPresenter < BasketPresenter
     ConvictionType::ADULT_MOTORING
   ].map(&:to_s).freeze
 
+  def convictions?
+    calculator.proceedings.any?(&:conviction?)
+  end
+
   def approximate_dates?
     APPROXIMATE_DATE_ATTRS.any? do |attr|
       disclosure_report.disclosure_checks.any? do |disclosure_check|

--- a/app/views/steps/check/results/show.en.html.erb
+++ b/app/views/steps/check/results/show.en.html.erb
@@ -17,12 +17,6 @@
       <% end %>
     </h1>
 
-    <% if @presenter.approximate_dates? %>
-      <p class="govuk-body">
-        You entered an approximate date so your results will be approximate.
-      </p>
-    <% end %>
-
     <p class="govuk-body">
       Your results are calculated using the information you have given and the current law.
       Read more about
@@ -31,14 +25,21 @@
       on GOV.UK.
     </p>
 
+    <% if @presenter.approximate_dates? %>
+      <p class="govuk-body">As you entered an approximate date, your results will be approximate.
+      </p>
+    <% end %>
+
     <%= render @presenter.summary %>
 
     <h2 class="govuk-heading-l">Using your results</h2>
 
-    <p class="govuk-body">
-      Your results are correct if you served your sentence in full as the court ordered you to.
-      The conviction might not be spent if you did not stick to the terms of your sentence.
-    </p>
+    <% if @presenter.convictions? %>
+      <p class="govuk-body">
+        Your results are correct if you served your sentence in full as the court ordered you to.
+        The conviction might not be spent if you did not stick to the terms of your sentence.
+      </p>
+    <% end %>
 
     <p class="govuk-body">
       You do not have to tell anyone about spent cautions or convictions unless you are asked.

--- a/spec/presenters/results_presenter_spec.rb
+++ b/spec/presenters/results_presenter_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe ResultsPresenter do
     end
   end
 
+  describe '#convictions?' do
+    it { expect(subject.convictions?).to be(true) }
+
+    context 'when there are no convictions' do
+      let(:disclosure_check) { create(:disclosure_check, :adult_caution, :completed) }
+
+      it { expect(subject.convictions?).to be(false) }
+    end
+  end
+
   describe '#approximate_dates?' do
     it { expect(subject.approximate_dates?).to be(false) }
 


### PR DESCRIPTION
Update from Leigh:

1. The line for approximate dates should appear under the opening line beginning: “Your results are calculated using…”
2. The line for approximate dates should read: As you entered an approximate date, your results will be approximate.
3. This paragraph is conditional to be shown only when it’s a conviction: [CONDITIONAL FOR CONVICTIONS] Your results are correct if you served your sentence in full as the court ordered you to. The conviction might not be spent if you did not stick to the terms of your sentence.

Story: https://trello.com/c/ONHg9IzX/278-dc-results-page-missing-copy

### Screenshot with a conviction

![image](https://user-images.githubusercontent.com/136777/118136839-7621f700-b3fc-11eb-84b6-f793d80e37a2.png)

### Screenshot with a caution

![image](https://user-images.githubusercontent.com/136777/118136994-98b41000-b3fc-11eb-826b-50e96c2ab96a.png)
