### PR TITLE
Add DBS rule for custodial convictions

### DIFF
--- a/app/models/disclosure_report.rb
+++ b/app/models/disclosure_report.rb
@@ -1,6 +1,6 @@
 class DisclosureReport < ApplicationRecord
   has_many :check_groups, dependent: :destroy
-  has_many :disclosure_checks, through: :check_groups, source: :disclosure_checks
+  has_many :disclosure_checks, through: :check_groups
 
   enum status: {
     in_progress: 0,
@@ -13,5 +13,15 @@ class DisclosureReport < ApplicationRecord
 
   def completed!
     update!(status: :completed, completed_at: Time.current)
+  end
+
+  # Convenience methods to return collections of just one kind
+  #
+  def caution_checks
+    disclosure_checks.where(kind: CheckKind::CAUTION.to_s)
+  end
+
+  def conviction_checks
+    disclosure_checks.where(kind: CheckKind::CONVICTION.to_s)
   end
 end

--- a/spec/models/disclosure_report_spec.rb
+++ b/spec/models/disclosure_report_spec.rb
@@ -43,4 +43,26 @@ RSpec.describe DisclosureReport, type: :model do
       subject.completed!
     end
   end
+
+  context 'convenience query methods' do
+    let(:collection_scope) { double('collection') }
+
+    before do
+      allow(subject).to receive(:disclosure_checks).and_return(collection_scope)
+    end
+
+    describe '#caution_checks' do
+      it 'filters by kind caution' do
+        expect(collection_scope).to receive(:where).with(kind: 'caution')
+        subject.caution_checks
+      end
+    end
+
+    describe '#conviction_checks' do
+      it 'filters by kind conviction' do
+        expect(collection_scope).to receive(:where).with(kind: 'conviction')
+        subject.conviction_checks
+      end
+    end
+  end
 end

--- a/spec/presenters/check_group_presenter_spec.rb
+++ b/spec/presenters/check_group_presenter_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe CheckGroupPresenter do
       expect(panel).to be_an_instance_of(DbsVisibility)
       expect(panel.kind).to eq('caution')
       expect(panel.variant).to eq(ResultsVariant::SPENT)
+      expect(panel.completed_checks).to eq([disclosure_check])
     end
   end
 

--- a/spec/presenters/dbs_visibility_spec.rb
+++ b/spec/presenters/dbs_visibility_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe DbsVisibility do
   subject { described_class.new(kind: kind, variant: variant, completed_checks: [disclosure_check]) }
 
-  let(:kind) { nil }
+  let(:kind) { 'foobar' } # only used in the view partial
   let(:variant) { nil }
   let(:disclosure_check) { nil }
 
@@ -9,10 +9,7 @@ RSpec.describe DbsVisibility do
     it { expect(subject.to_partial_path).to eq('results/shared/dbs_visibility') }
   end
 
-  # Note: for basic checks it does not matter if it is a caution or a conviction
   describe '#basic' do
-    let(:kind) { 'foobar' }
-
     context 'for a spent variant' do
       let(:variant) { ResultsVariant::SPENT }
       it { expect(subject.basic).to eq(:will_not) }
@@ -26,8 +23,6 @@ RSpec.describe DbsVisibility do
 
   describe '#enhanced' do
     context 'for a caution' do
-      let(:kind) { 'caution' }
-
       context 'for a youth caution' do
         let(:disclosure_check) { build(:disclosure_check, :youth_simple_caution) }
 
@@ -58,11 +53,20 @@ RSpec.describe DbsVisibility do
     end
 
     context 'for a conviction' do
-      let(:kind) { 'conviction' }
+      let(:disclosure_check) { build(:disclosure_check, :compensation) }
 
       context 'for a spent variant' do
-        let(:variant) { ResultsVariant::SPENT }
-        it { expect(subject.enhanced).to eq(:maybe) }
+        context 'for custodial convictions' do
+          let(:disclosure_check) { build(:disclosure_check, :dto_conviction) }
+          let(:variant) { ResultsVariant::SPENT }
+
+          it { expect(subject.enhanced).to eq(:will) }
+        end
+
+        context 'for non-custodial convictions' do
+          let(:variant) { ResultsVariant::SPENT }
+          it { expect(subject.enhanced).to eq(:maybe) }
+        end
       end
 
       context 'for a not spent variant' do

--- a/spec/presenters/results_presenter_spec.rb
+++ b/spec/presenters/results_presenter_spec.rb
@@ -84,13 +84,13 @@ RSpec.describe ResultsPresenter do
     it { expect(subject.motoring?).to be(false) }
 
     context 'when conviction type is adult motoring' do
-      before { disclosure_check.update(conviction_type: ConvictionType::ADULT_MOTORING) }
+      before { disclosure_check.update(conviction_subtype: ConvictionType::ADULT_MOTORING_FINE) }
 
       it { expect(subject.motoring?).to be(true) }
     end
 
     context 'when conviction type is youth motoring' do
-      before { disclosure_check.update(conviction_type: ConvictionType::YOUTH_MOTORING) }
+      before { disclosure_check.update(conviction_subtype: ConvictionType::YOUTH_MOTORING_FINE) }
 
       it { expect(subject.motoring?).to be(true) }
     end


### PR DESCRIPTION
Ticket: https://trello.com/c/urHOEzjZ

Add the rule for custodial convictions (these are always shown on the enhanced DBS check).

Simplified/refactored some more code to make use of a more declarative syntax, easier to read, introduce in previous PRs.