### PR TITLE
Functionality to remove sentences in CYA

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -23,3 +23,15 @@
 dl.multiple-checks-summary:not(:only-child) {
   &:not(:last-of-type) { padding-bottom: 0.5em; }
 }
+
+.app-link-red {
+  color: $govuk-error-colour !important;
+}
+
+.app-link-red:hover {
+  color: darken($govuk-error-colour, 10%) !important;
+}
+
+.app-text-align-right {
+  text-align: right;
+}

--- a/app/controllers/steps/checks_controller.rb
+++ b/app/controllers/steps/checks_controller.rb
@@ -1,0 +1,17 @@
+module Steps
+  class ChecksController < CheckStepController
+    def edit
+      @form_object = Steps::Check::RemoveCheckForm.build(disclosure_check)
+    end
+
+    def update
+      update_and_advance(Steps::Check::RemoveCheckForm)
+    end
+
+    private
+
+    def disclosure_check
+      current_disclosure_report.disclosure_checks.find(params[:id])
+    end
+  end
+end

--- a/app/forms/steps/check/remove_check_form.rb
+++ b/app/forms/steps/check/remove_check_form.rb
@@ -1,0 +1,24 @@
+module Steps
+  module Check
+    class RemoveCheckForm < BaseForm
+      include SingleQuestionForm
+
+      validates_presence_of :remove_check
+
+      yes_no_attribute :remove_check
+
+      private
+
+      # We do not store this in the database, so when user answers "No" we return true
+      # Otherwise if the record is successfully destroyed, return true
+      def persist!
+        raise DisclosureCheckNotFound unless disclosure_check
+
+        return true if remove_check.no?
+
+        disclosure_check.destroy
+        disclosure_check.destroyed?
+      end
+    end
+  end
+end

--- a/app/services/base_decision_tree.rb
+++ b/app/services/base_decision_tree.rb
@@ -35,7 +35,7 @@ class BaseDecisionTree
   end
 
   def check_your_answers
-    disclosure_check.completed!
+    disclosure_check.completed! unless disclosure_check.completed?
 
     show('/steps/check/check_your_answers')
   end

--- a/app/services/check_decision_tree.rb
+++ b/app/services/check_decision_tree.rb
@@ -7,6 +7,8 @@ class CheckDecisionTree < BaseDecisionTree
       edit(:under_age)
     when :under_age
       after_under_age
+    when :remove_check
+      after_remove_check
     else
       raise InvalidStep, "Invalid step '#{as || step_params}'"
     end
@@ -21,5 +23,13 @@ class CheckDecisionTree < BaseDecisionTree
     when CheckKind::CONVICTION
       edit('/steps/conviction/conviction_date')
     end
+  end
+
+  def after_remove_check
+    return check_your_answers if GenericYesNo.new(step_params[:remove_check]).no?
+    return check_your_answers if disclosure_check.disclosure_report.disclosure_checks.completed.any?
+
+    # restart fresh
+    edit('/steps/check/kind', {new: 'y'})
   end
 end

--- a/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
@@ -1,6 +1,24 @@
-<h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-  <%=t "#{check_row.kind}.orders.#{check_row.order_type}", scope: check_row.scope %>
-</h3>
+<% translated_name = t("#{check_row.kind}.orders.#{check_row.order_type}", scope: check_row.scope) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+      <%= translated_name %>
+    </h3>
+  </div>
+
+  <div class="govuk-grid-column-one-half app-text-align-right">
+
+
+    <%= link_to(edit_steps_check_path(check_row.disclosure_check), class: 'govuk-link govuk-link--no-visited-state app-link-red govuk-!-font-size-19') do %>
+      Remove
+      <span class="govuk-visually-hidden"><%= translated_name %></span>
+    <% end %>
+
+
+  </div>
+</div>
+
 
 <dl class="govuk-summary-list multiple-checks-summary">
   <%= render check_row.summary %>

--- a/app/views/steps/checks/edit.html.erb
+++ b/app/views/steps/checks/edit.html.erb
@@ -1,0 +1,14 @@
+<% title t('.page_title') %>
+<% step_header %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary %>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.govuk_collection_radio_buttons :remove_check, GenericYesNo.values, :value, nil, inline: true %>
+
+      <%= f.continue_button %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/check.yml
+++ b/config/locales/en/check.yml
@@ -15,3 +15,6 @@ en:
       results:
         show:
           page_title: When your caution or conviction is spent
+    checks:
+      edit:
+        page_title: Are you sure you want to remove this check?

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -71,6 +71,10 @@ en:
           attributes:
             motoring_endorsement:
               inclusion: Select yes if you have received an endorsement
+        steps/check/remove_check_form:
+          attributes:
+            remove_check:
+              inclusion: Select yes if you want to remove this check
 
   errors:
     format: "%{message}"

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -248,6 +248,9 @@ en:
         under_age_options:
           'yes': Under 18
           'no': 18 or over
+      steps_check_remove_check_form:
+        remove_check_options: *YESNO
+
       steps_caution_known_date_form:
         approximate_known_date_options:
           'true': *approximate_date_checkbox
@@ -300,6 +303,8 @@ en:
     legend:
       steps_check_kind_form:
         kind: Were you cautioned or convicted?
+      steps_check_remove_check_form:
+        remove_check_html: Are you sure you want to remove this check?
       steps_caution_caution_type_form:
         caution_type: What type of caution did you get?
       steps_check_under_age_form:
@@ -387,6 +392,7 @@ en:
         weeks: Number of weeks
         months: Number of months
         years: Number of years
+
 
     lead_text:
       steps_conviction_known_date_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
   end
 
   namespace :steps do
+    resources :checks, only: [:edit, :update]
+
     namespace :check do
       edit_step :kind
       edit_step :under_age

--- a/features/multiples/remove_caution_or_convictions.feature
+++ b/features/multiples/remove_caution_or_convictions.feature
@@ -1,0 +1,27 @@
+Feature: A person who made a mistake and wants to remove a caution or conviction
+
+  Scenario: Simple Youth Caution and Adult Fine
+    And I have started a check
+    And I choose "Cautioned"
+    And I choose "Under 18"
+    And I choose "Youth caution"
+    And I enter the following date 01-01-2006
+   Then I should see "Check your answers"
+    And I click the "Add a caution or conviction" button
+
+   Then I choose "Convicted"
+    And I choose "18 or over"
+    And I enter the following date 01-06-2008
+    And I choose "Financial penalty (not including motoring fines)"
+    And I choose "A fine"
+    And I enter the following date 01-06-2008
+
+   Then I should see "Check your answers"
+    And I click to remove the first sentence
+   Then I should see "Are you sure you want to remove this check?"
+    And I choose "Yes"
+   Then I should see "Check your answers"
+    And I click to remove the first sentence
+   Then I should see "Are you sure you want to remove this check?"
+    And I choose "Yes"
+   Then I should see "Were you cautioned or convicted?"

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -30,6 +30,10 @@ When(/^I click the "([^"]*)" link$/) do |text|
   click_link(text)
 end
 
+When(/^I click to remove the first sentence$/) do
+  click_link('Remove', match: :first)
+end
+
 When(/^I click the "([^"]*)" button$/) do |text|
   click_button(text)
 end

--- a/spec/forms/steps/check/remove_check_form_spec.rb
+++ b/spec/forms/steps/check/remove_check_form_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Check::RemoveCheckForm do
+  # NOTE: not using the shared examples for 'a yes-no question form' because
+  # we are performing a custom override of the `#persist!` method.
+
+  let(:question_attribute) { :remove_check }
+  let(:answer_value) { 'yes' }
+
+  let(:arguments) do
+    {
+      disclosure_check: disclosure_check,
+      question_attribute => answer_value
+    }
+  end
+
+  let(:disclosure_check) { instance_double(DisclosureCheck) }
+
+  subject { described_class.new(arguments) }
+
+  describe 'validations on field presence' do
+    it { should validate_presence_of(question_attribute, :inclusion) }
+  end
+
+  describe '#save' do
+    context 'when no disclosure_check is associated with the form' do
+      let(:disclosure_check) { nil }
+
+      it 'raises an error' do
+        expect { described_class.new(arguments).save }.to raise_error(BaseForm::DisclosureCheckNotFound)
+      end
+    end
+
+    context 'when answer is `yes`' do
+      let(:answer_value) { 'yes' }
+
+      it 'deletes the record' do
+        expect(disclosure_check).to receive(:destroy)
+        expect(disclosure_check).to receive(:destroyed?).and_return(true)
+
+        expect(described_class.new(arguments).save).to be(true)
+      end
+    end
+
+    context 'when answer is `no`' do
+      let(:answer_value) { 'no' }
+
+      it 'saves the record' do
+        expect(disclosure_check).not_to receive(:update)
+        expect(disclosure_check).not_to receive(:destroy)
+        expect(disclosure_check).not_to receive(:destroyed?)
+
+        expect(described_class.new(arguments).save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/check_decision_tree_spec.rb
+++ b/spec/services/check_decision_tree_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe CheckDecisionTree do
+  let(:disclosure_report) { DisclosureReport.new }
+
   let(:disclosure_check) do
-    instance_double(
-      DisclosureCheck,
-      kind: kind,
-      under_age: under_age,
-    )
+    build(:disclosure_check, kind: kind, under_age: under_age, disclosure_report: disclosure_report)
   end
 
   let(:step_params)      { double('Step') }
@@ -14,6 +12,7 @@ RSpec.describe CheckDecisionTree do
   let(:as)               { nil }
   let(:kind)             { nil }
   let(:under_age)        { nil }
+  let(:remove_check)     { nil }
 
   subject {
     described_class.new(
@@ -28,7 +27,7 @@ RSpec.describe CheckDecisionTree do
     it { is_expected.to have_destination(:under_age, :edit) }
   end
 
-  describe 'when the step is `under_age`' do
+  context 'when the step is `under_age`' do
     let(:step_params) { { under_age: under_age } }
 
     context 'and answer is `no`' do
@@ -57,6 +56,35 @@ RSpec.describe CheckDecisionTree do
         let(:kind) { 'conviction' }
         it { is_expected.to have_destination('/steps/conviction/conviction_date', :edit) }
       end
+    end
+  end
+
+  context 'when the step is `remove_check`' do
+    let(:step_params) { { remove_check: remove_check } }
+
+    context 'and the answer is `yes`' do
+      let(:remove_check) { GenericYesNo::YES }
+
+      it { is_expected.to have_destination('/steps/check/kind', :edit) }
+    end
+
+    context 'and whe answer is `no`' do
+      let(:remove_check) { GenericYesNo::NO }
+
+      it { is_expected.to have_destination('/steps/check/check_your_answers', :show) }
+    end
+
+    context 'and there are other disclosure checks in the same disclosure report' do
+      let(:remove_check) { GenericYesNo::YES }
+
+      before do
+        group = disclosure_report.check_groups.build
+        group.disclosure_checks << build(:disclosure_check, :suspended_prison_sentence, :completed)
+
+        group.save
+      end
+
+      it { is_expected.to have_destination('/steps/check/check_your_answers', :show) }
     end
   end
 end


### PR DESCRIPTION
This adds functionality for the user to be able to remove sentences in the Check Your Answers page.

When a sentence is deleted, it's crucial to know wether there was other sentences
in the same report. Specially when the deleted sentence was the last one to be created,
since, until now, the session relied purely on the last `disclosure_check`, if that is deleted
we must find the Report id in order to know if there was other sentences present in order to send
the user to CYA or to the first page of the service (and restart their journey).

![image](https://user-images.githubusercontent.com/136777/119323614-cf98ea00-bc76-11eb-82fd-b0e59e7ac84a.png)


Story: https://trello.com/c/D6Goc7YV