### PR TITLE
Check your answers `change` functionality

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,6 +35,13 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def swap_disclosure_check_session(other_check_id)
+    session[:disclosure_check_id] = current_disclosure_report.disclosure_checks.find_by!(id: other_check_id).id
+
+    # ensure we don't have a memoized record anymore
+    @_current_disclosure_check = nil
+  end
+
   def reset_disclosure_check_session
     session.delete(:disclosure_check_id)
     session.delete(:last_seen)

--- a/app/presenters/caution_result_presenter.rb
+++ b/app/presenters/caution_result_presenter.rb
@@ -12,4 +12,11 @@ class CautionResultPresenter < ResultsItemPresenter
       :conditional_end_date,
     ].freeze
   end
+
+  def editable_attributes
+    {
+      known_date: ->(id) { edit_steps_caution_known_date_path(check_id: id) },
+      conditional_end_date: ->(id) { edit_steps_caution_conditional_end_date_path(check_id: id) },
+    }
+  end
 end

--- a/app/presenters/conviction_result_presenter.rb
+++ b/app/presenters/conviction_result_presenter.rb
@@ -17,6 +17,11 @@ class ConvictionResultPresenter < ResultsItemPresenter
     ].freeze
   end
 
+  # TODO: add attributes that makes sense to be editable
+  def editable_attributes
+    {}
+  end
+
   def i18n_conviction_length
     type = disclosure_check.conviction_length_type
     return unless type

--- a/app/presenters/question_answer_row.rb
+++ b/app/presenters/question_answer_row.rb
@@ -1,10 +1,11 @@
 class QuestionAnswerRow
-  attr_reader :question, :answer, :scope
+  attr_reader :question, :answer, :scope, :change_path
 
-  def initialize(question, answer, scope:)
+  def initialize(question, answer, scope:, change_path:)
     @question = question
     @answer = answer
     @scope = scope
+    @change_path = change_path
   end
 
   def show?

--- a/app/presenters/results_item_presenter.rb
+++ b/app/presenters/results_item_presenter.rb
@@ -1,4 +1,6 @@
 class ResultsItemPresenter
+  include Rails.application.routes.url_helpers
+
   attr_reader :disclosure_check, :kind, :scope
 
   def self.build(disclosure_check, scope:)
@@ -27,7 +29,8 @@ class ResultsItemPresenter
       QuestionAnswerRow.new(
         item,
         value || format_value(item),
-        scope: scope
+        scope: scope,
+        change_path: change_path(item)
       )
     end.select(&:show?)
   end
@@ -57,12 +60,20 @@ class ResultsItemPresenter
     )
   end
 
+  def change_path(attr)
+    editable_attributes[attr].try(:call, disclosure_check)
+  end
+
   # :nocov:
   def type_attribute
     raise NotImplementedError, 'implement in subclasses'
   end
 
   def question_attributes
+    raise NotImplementedError, 'implement in subclasses'
+  end
+
+  def editable_attributes
     raise NotImplementedError, 'implement in subclasses'
   end
   # :nocov:

--- a/app/views/steps/check/check_your_answers/shared/_change_link.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_change_link.html.erb
@@ -1,0 +1,5 @@
+<% a11y_question = t("#{row.question}.question", scope: row.scope).downcase %>
+
+<%= link_to row.change_path, class: 'govuk-link govuk-link--no-visited-state' do %>
+  <%= t('change_link_html', scope: :check_your_answers, a11y_question: a11y_question) %>
+<% end %>

--- a/app/views/steps/check/check_your_answers/shared/_row.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_row.html.erb
@@ -5,4 +5,7 @@
   <dd class="govuk-summary-list__value">
     <%=t "#{row.question}.answers.#{row.answer}", scope: row.scope, default: row.answer %>
   </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= render partial: 'steps/check/check_your_answers/shared/change_link', locals: { row: row } if row.change_path && dev_tools_enabled? %>
+  </dd>
 </div>

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -149,6 +149,7 @@ en:
     approximate: '%{date} (approximate)'
 
   check_your_answers:
+    change_link_html: Change <span class="govuk-visually-hidden">%{a11y_question}</span>
     caution:
       <<: *CAUTION_ANSWERS
     conviction:

--- a/spec/controllers/step_controller_spec.rb
+++ b/spec/controllers/step_controller_spec.rb
@@ -4,6 +4,10 @@ class DummyStepController < StepController
   def show
     head(:ok)
   end
+
+  def steps_check_check_your_answers_path
+    '/steps/cya'
+  end
 end
 
 RSpec.describe DummyStepController, type: :controller do
@@ -20,9 +24,10 @@ RSpec.describe DummyStepController, type: :controller do
 
   describe 'navigation stack' do
     let!(:disclosure_check) { DisclosureCheck.create(navigation_stack: navigation_stack) }
+    let(:params) { {} }
 
     before do
-      get :show, session: { disclosure_check_id: disclosure_check.id }
+      get :show, session: { disclosure_check_id: disclosure_check.id }, params: params
       disclosure_check.reload
     end
 
@@ -47,6 +52,16 @@ RSpec.describe DummyStepController, type: :controller do
 
       it 'adds it to the end of the stack' do
         expect(disclosure_check.navigation_stack).to eq(['/foo', '/bar', '/baz', '/dummy_step'])
+      end
+    end
+
+    context 'when coming from the check your answer page' do
+      # Note: for the sake of this test we reuse the same record ID
+      let(:params) { { check_id: disclosure_check.id } }
+      let(:navigation_stack) { ['/foo', '/bar', '/baz'] }
+
+      it 'resets the stack starting in the CYA page and append the new page' do
+        expect(disclosure_check.navigation_stack).to eq(['/steps/cya', '/dummy_step'])
       end
     end
   end

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe CautionResultPresenter do
   let(:disclosure_check) { build(:disclosure_check, :youth_simple_caution) }
   let(:scope) { 'results' }
 
+  before do
+    allow(disclosure_check).to receive(:id).and_return('12345')
+  end
+
   describe '#scope' do
     it { expect(subject.scope).to eq([scope, 'caution']) }
   end
@@ -25,9 +29,11 @@ RSpec.describe CautionResultPresenter do
 
         expect(summary[0].question).to eql(:under_age)
         expect(summary[0].answer).to eql('yes')
+        expect(summary[0].change_path).to be_nil
 
         expect(summary[1].question).to eql(:known_date)
         expect(summary[1].answer).to eq('31 October 2018')
+        expect(summary[1].change_path).to eq('/steps/caution/known_date?check_id=12345')
       end
     end
 
@@ -39,12 +45,15 @@ RSpec.describe CautionResultPresenter do
 
         expect(summary[0].question).to eql(:under_age)
         expect(summary[0].answer).to eql('yes')
+        expect(summary[0].change_path).to be_nil
 
         expect(summary[1].question).to eql(:known_date)
         expect(summary[1].answer).to eq('31 October 2018')
+        expect(summary[1].change_path).to eq('/steps/caution/known_date?check_id=12345')
 
         expect(summary[2].question).to eql(:conditional_end_date)
         expect(summary[2].answer).to eq('25 December 2018')
+        expect(summary[2].change_path).to eq('/steps/caution/conditional_end_date?check_id=12345')
       end
     end
 

--- a/spec/presenters/question_answer_row_spec.rb
+++ b/spec/presenters/question_answer_row_spec.rb
@@ -2,19 +2,28 @@ RSpec.describe QuestionAnswerRow do
   let(:question) { 'question' }
   let(:answer) { 'answer' }
   let(:scope) { %w(check_your_answers caution) }
+  let(:change_path) { '/foo/bar' }
 
-  subject { described_class.new(question, answer, scope: scope) }
+  subject { described_class.new(question, answer, scope: scope, change_path: change_path) }
 
   describe '#to_partial_path' do
     it { expect(subject.to_partial_path).to eq('check_your_answers/shared/row') }
   end
 
   describe '#question' do
-    it { expect(subject.question).to eq('question') }
+    it { expect(subject.question).to eq(question) }
   end
 
   describe '#answer' do
-    it { expect(subject.answer).to eq('answer') }
+    it { expect(subject.answer).to eq(answer) }
+  end
+
+  describe '#scope' do
+    it { expect(subject.scope).to eq(scope) }
+  end
+
+  describe '#change_path' do
+    it { expect(subject.change_path).to eq(change_path) }
   end
 
   describe '#show?' do

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -139,6 +139,29 @@ RSpec.shared_examples 'an intermediate step controller' do |form_class, decision
         get :edit, session: { disclosure_check_id: existing_case.id }
         expect(response).to be_successful
       end
+
+      context 'when editing a different disclosure_check record' do
+        context 'and the other record belongs to this same report' do
+          let!(:another_case) { DisclosureCheck.create(status: :completed, check_group_id: existing_case.check_group_id) }
+
+          it 'swaps the session with the new record and responds with HTTP success' do
+            get :edit, session: { disclosure_check_id: existing_case.id }, params: { check_id: another_case.id }
+
+            expect(response).to be_successful
+            expect(session[:disclosure_check_id]).to eq(another_case.id)
+          end
+        end
+
+        context 'and the other record belongs to a different report' do
+          let!(:another_case) { DisclosureCheck.create(status: :completed) }
+
+          it 'raises a not found exception' do
+            expect {
+              get :edit, session: { disclosure_check_id: existing_case.id }, params: { check_id: another_case.id }
+            }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Ticket: https://trello.com/c/lrx02rsR

First attempt and kind of Proof of Concept of the ability to `change` answers to previous questions in cautions or convictions.

Right now this PR only implements Cautions as these are much simpler (only 2 questions can be edited).

Some questions will not be editable because in doing so, the caution (or conviction) change fundamentally, for example the under age question. If a user answered over 18 and then they change it to under 18, the whole caution or conviction will become wrong as the "type" is linked to the age (for example, youth cautions vs. adult cautions).

The implementation is simple: all of the "change" links will have as a query param the ID of the `disclosure_check` record being edited (because when in the basket there are more than 1, we need to differentiate).
This ID allows to "swap" the session from whatever was before to this new disclosure check record and perform the edit/navigation normally on it.

There is no possibility of tampering with the ID because it does the lookup over the records owned by the current disclosure report anyways, just in case.

More refinements, cukes, and convictions, in follow-up PRs...

<img width="703" alt="Screenshot 2021-05-25 at 10 54 25" src="https://user-images.githubusercontent.com/687910/119478306-9d0af200-bd47-11eb-8540-5fbe7db4904c.png">
