### PR TITLE
Add validation to caution date

### DIFF
--- a/app/forms/steps/caution/known_date_form.rb
+++ b/app/forms/steps/caution/known_date_form.rb
@@ -6,6 +6,7 @@ module Steps
 
       validates_presence_of :known_date
       validates :known_date, sensible_date: true
+      validate :before_conditional_date?
 
       private
 
@@ -16,6 +17,12 @@ module Steps
           known_date: known_date,
           approximate_known_date: approximate_known_date
         )
+      end
+
+      def before_conditional_date?
+        return if known_date.blank? || disclosure_check.conditional_end_date.blank?
+
+        errors.add(:known_date, :before_conditional_date) if known_date > disclosure_check.conditional_end_date
       end
     end
   end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -9,6 +9,7 @@ en:
               blank: Enter the date of the caution in the format dd/mm/yyyy
               invalid: The date is too far in the past. Enter a date after 01/01/1940
               future: The date of the caution can’t be in the future
+              before_conditional_date: The date of the caution can’t be after the date conditions ended
         steps/check/under_age_form:
           attributes:
             under_age:

--- a/spec/forms/steps/caution/known_date_form_spec.rb
+++ b/spec/forms/steps/caution/known_date_form_spec.rb
@@ -1,5 +1,45 @@
 require 'spec_helper'
 
 RSpec.describe Steps::Caution::KnownDateForm do
-  it_behaves_like 'a date question form', attribute_name: :known_date
+  it_behaves_like 'a date question form', attribute_name: :known_date do
+    before do
+      allow(subject).to receive(:before_conditional_date?).and_return(true)
+    end
+  end
+
+  context '#before_conditional_date? validation' do
+    let(:disclosure_check) { instance_double(DisclosureCheck, conditional_end_date: conditional_end_date) }
+    let(:known_date) { nil }
+    let(:conditional_end_date) { Date.today }
+    let(:arguments) {
+      {
+        disclosure_check: disclosure_check,
+        known_date: known_date
+      }
+    }
+
+    subject { described_class.new(arguments) }
+
+    context 'when caution date is after conditional end date' do
+      let(:known_date) { Date.tomorrow }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors.added?(:known_date, :before_conditional_date)).to eq(true)
+      end
+    end
+
+    context 'when caution date is before conditional end date' do
+      let(:known_date) { Date.yesterday }
+
+      it 'has no validation errors on the field' do
+        expect(subject).to be_valid
+        expect(subject.errors.added?(:known_date, :before_conditional_date)).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
For conditional cautions, the "known_date" (caution date) must be before the conditions end date.

This so far has been fine but with the `change` functionality in the CYA, the user might edit a conditional caution date and introduce a wrong date without noticing.

We might need to revisit other places where this can happen in convictions for the same reason, but for now I'm focusing on cautions as per PR #519.