### PR TITLE
Some attributes can jump back to CYA

### DIFF
--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -1,4 +1,6 @@
 module CustomFormHelpers
+  delegate :params, :hidden_field_tag, to: :template
+
   def continue_button(continue: :continue)
     submit_button(continue)
   end
@@ -35,10 +37,32 @@ module CustomFormHelpers
   private
 
   def submit_button(i18n_key, opts = {}, &block)
-    govuk_submit I18n.t("helpers.buttons.#{i18n_key}"), **opts, &block
+    safe_join(
+      [
+        next_step_if_present,
+        govuk_submit(I18n.t("helpers.buttons.#{i18n_key}"), **opts, &block)
+      ]
+    )
+  end
+
+  # Do not blindly trust the param, always whitelist
+  def next_step_if_present
+    next_step = case params[:next_step]
+                when 'cya'
+                  '/steps/check/check_your_answers'
+                end
+
+    hidden_field_tag(:next_step, next_step) if next_step
   end
 
   def scope_for_locale(context)
     [:helpers, context, object_name]
   end
+
+  # This method is just to aid with testing
+  # :nocov:
+  def template
+    @template
+  end
+  # :nocov:
 end

--- a/app/presenters/caution_result_presenter.rb
+++ b/app/presenters/caution_result_presenter.rb
@@ -15,7 +15,7 @@ class CautionResultPresenter < ResultsItemPresenter
 
   def editable_attributes
     {
-      known_date: ->(id) { edit_steps_caution_known_date_path(check_id: id) },
+      known_date: ->(id) { edit_steps_caution_known_date_path(check_id: id, next_step: :cya) },
       conditional_end_date: ->(id) { edit_steps_caution_conditional_end_date_path(check_id: id) },
     }
   end

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -13,10 +13,47 @@ RSpec.describe CustomFormHelpers, type: :helper do
   end
 
   describe '#continue_button' do
-    it 'outputs the govuk continue button' do
-      expect(
-        builder.continue_button
-      ).to eq('<input type="submit" name="commit" value="Continue" formnovalidate="formnovalidate" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" />')
+    let(:expected_markup) { '<input type="submit" name="commit" value="Continue" formnovalidate="formnovalidate" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-disable-with="Continue" />' }
+    let(:template) { double('template', params: params) }
+
+    before do
+      allow(builder).to receive(:template).and_return(template)
+    end
+
+    context 'when there is no next step param' do
+      let(:params) { {} }
+
+      it 'outputs the govuk continue button without the next step hidden tag' do
+        expect(
+          builder.continue_button
+        ).to eq(expected_markup)
+      end
+    end
+
+    context 'when the next step param is not recognised' do
+      let(:params) { {next_step: 'foobar'} }
+
+      it 'outputs the govuk continue button without the next step hidden tag' do
+        expect(
+          builder.continue_button
+        ).to eq(expected_markup)
+      end
+    end
+
+    context 'where there is a valid next step param' do
+      let(:params) { {next_step: 'cya'} }
+
+      it 'outputs the govuk continue button with the next step hidden tag' do
+        expect(
+          template
+        ).to receive(:hidden_field_tag).with(
+          :next_step, '/steps/check/check_your_answers'
+        ).and_return('<hidden_tag_here>'.html_safe)
+
+        expect(
+          builder.continue_button
+        ).to eq('<hidden_tag_here>' + expected_markup)
+      end
     end
   end
 

--- a/spec/presenters/caution_result_presenter_spec.rb
+++ b/spec/presenters/caution_result_presenter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CautionResultPresenter do
 
         expect(summary[1].question).to eql(:known_date)
         expect(summary[1].answer).to eq('31 October 2018')
-        expect(summary[1].change_path).to eq('/steps/caution/known_date?check_id=12345')
+        expect(summary[1].change_path).to eq('/steps/caution/known_date?check_id=12345&next_step=cya')
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe CautionResultPresenter do
 
         expect(summary[1].question).to eql(:known_date)
         expect(summary[1].answer).to eq('31 October 2018')
-        expect(summary[1].change_path).to eq('/steps/caution/known_date?check_id=12345')
+        expect(summary[1].change_path).to eq('/steps/caution/known_date?check_id=12345&next_step=cya')
 
         expect(summary[2].question).to eql(:conditional_end_date)
         expect(summary[2].answer).to eq('25 December 2018')


### PR DESCRIPTION
Some attributes can be edited without having to go through the following steps. This way after changing something, we can take the user back to the CYA page quickly.

This is done by marking these attributes with the `?next_step=cya` query param.

After editing something and clicking the `continue` button, if the `next_step` was set, the decision tree logic will be skipped and jump straight to the path specified in the next step (it is a hidden tag in the form).

If the attribute is the last one in a journey, there is no need to add this query param as it is redundant because the next step is always the CYA in these cases.
For example for cautions, `conditional_end_date` is the last attribute in the journey and the next step is always the CYA anyways.