### PR TITLE
Delete disclosure report session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,6 +43,7 @@ class ApplicationController < ActionController::Base
   end
 
   def reset_disclosure_check_session
+    session.delete(:disclosure_report_id)
     session.delete(:disclosure_check_id)
     session.delete(:last_seen)
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe HomeController, type: :controller do
           end
 
           it 'resets the disclosure_check session data' do
+            expect(session).to receive(:delete).with(:disclosure_report_id).ordered
             expect(session).to receive(:delete).with(:disclosure_check_id).ordered
             expect(session).to receive(:delete).with(:last_seen).ordered
             expect(session).to receive(:delete) # any other deletes
@@ -59,6 +60,7 @@ RSpec.describe HomeController, type: :controller do
         end
 
         it 'resets the disclosure check session data' do
+          expect(session).to receive(:delete).with(:disclosure_report_id).ordered
           expect(session).to receive(:delete).with(:disclosure_check_id).ordered
           expect(session).to receive(:delete).with(:last_seen).ordered
           expect(session).to receive(:delete) # any other deletes
@@ -77,6 +79,7 @@ RSpec.describe HomeController, type: :controller do
       end
 
       it 'resets the disclosure_checker session data' do
+        expect(session).to receive(:delete).with(:disclosure_report_id).ordered
         expect(session).to receive(:delete).with(:disclosure_check_id).ordered
         expect(session).to receive(:delete).with(:last_seen).ordered
         expect(session).to receive(:delete) # any other deletes


### PR DESCRIPTION
Introduced in PR #518, I forgot to  delete the `disclosure_report` session so that the user can start a new check. Without  deleting the session the user would be prevented from starting a new check without deleting the service session cookies manually.