### PR TITLE
Change conviction attributes in CYA

### DIFF
--- a/app/presenters/conviction_result_presenter.rb
+++ b/app/presenters/conviction_result_presenter.rb
@@ -8,18 +8,23 @@ class ConvictionResultPresenter < ResultsItemPresenter
   def question_attributes
     [
       :under_age,
-      :conviction_bail_days,
       :conviction_date,
       :known_date,
       [:conviction_length, i18n_conviction_length],
+      :conviction_bail_days,
       :compensation_payment_date,
       :motoring_endorsement,
     ].freeze
   end
 
-  # TODO: add attributes that makes sense to be editable
   def editable_attributes
-    {}
+    {
+      known_date: ->(id) { edit_steps_conviction_known_date_path(check_id: id, next_step: :cya) },
+      conviction_length: ->(id) { edit_steps_conviction_conviction_length_type_path(check_id: id) },
+      conviction_bail_days: ->(id) { edit_steps_conviction_conviction_bail_days_path(check_id: id, next_step: :cya) },
+      compensation_payment_date: ->(id) { edit_steps_conviction_compensation_payment_date_path(check_id: id, next_step: :cya) },
+      motoring_endorsement: ->(id) { edit_steps_conviction_motoring_endorsement_path(check_id: id, next_step: :cya) },
+    }
   end
 
   def i18n_conviction_length

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -56,7 +56,7 @@ en:
       absolute_discharge: Absolute discharge
       conditional_discharge: Conditional discharge
       # financial
-      fine: A fine
+      fine: Fine
       compensation_to_a_victim: Compensation to a victim
       # military
       dismissal: Dismissal
@@ -77,7 +77,7 @@ en:
       adult_sexual_harm_prevention_order: Sexual harm prevention order
       adult_other_requirement_order: Order with a requirement
       # adult_financial
-      adult_fine: A fine
+      adult_fine: Fine
       adult_compensation_to_a_victim: Compensation to a victim
       # adult_military
       adult_dismissal: Dismissal
@@ -272,6 +272,9 @@ en:
       steps_conviction_conviction_subtype_form:
         conviction_subtype_options:
           <<: *CONVICTION_SUBTYPES
+          # Following convictions have minor variations between the radio options and the results page
+          fine: A fine
+          adult_fine: A fine
           adult_other_requirement_order: Any other order with a requirement
       steps_conviction_conviction_length_type_form:
         conviction_length_type_options:

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -21,7 +21,7 @@ en:
       absolute_discharge: Absolute discharge
       conditional_discharge: Conditional discharge
       # financial
-      fine: A fine
+      fine: Fine
       compensation_to_a_victim: Compensation to a victim
       # military
       dismissal: Dismissal
@@ -42,7 +42,7 @@ en:
       adult_sexual_harm_prevention_order: Sexual harm prevention order
       adult_other_requirement_order: Order with a requirement
       # adult_financial
-      adult_fine: A fine
+      adult_fine: Fine
       adult_compensation_to_a_victim: Compensation to a victim
       # adult_military
       adult_dismissal: Dismissal
@@ -106,7 +106,7 @@ en:
         no_length: No length was given
         indefinite: Until further order
     compensation_payment_date:
-      question: Compensation payment date
+      question: Payment date
     motoring_endorsement:
       question: Motoring endorsement
       answers:

--- a/spec/presenters/conviction_result_presenter_spec.rb
+++ b/spec/presenters/conviction_result_presenter_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe ConvictionResultPresenter do
   let(:disclosure_check) { build(:disclosure_check, :dto_conviction) }
   let(:scope) { 'results' }
 
+  before do
+    allow(disclosure_check).to receive(:id).and_return('12345')
+  end
+
   describe '#scope' do
     it { expect(subject.scope).to eq([scope, 'conviction']) }
   end
@@ -24,15 +28,19 @@ RSpec.describe ConvictionResultPresenter do
 
       expect(summary[0].question).to eql(:under_age)
       expect(summary[0].answer).to eql('yes')
+      expect(summary[0].change_path).to be_nil
 
       expect(summary[1].question).to eql(:conviction_date)
       expect(summary[1].answer).to eq('1 January 2018')
+      expect(summary[1].change_path).to be_nil
 
       expect(summary[2].question).to eql(:known_date)
       expect(summary[2].answer).to eq('31 October 2018')
+      expect(summary[2].change_path).to eq('/steps/conviction/known_date?check_id=12345&next_step=cya')
 
       expect(summary[3].question).to eql(:conviction_length)
       expect(summary[3].answer).to eq('9 weeks')
+      expect(summary[3].change_path).to eq('/steps/conviction/conviction_length_type?check_id=12345')
     end
 
     context 'when no length given' do
@@ -45,6 +53,7 @@ RSpec.describe ConvictionResultPresenter do
 
         expect(summary[3].question).to eql(:conviction_length)
         expect(summary[3].answer).to eq('No length was given')
+        expect(summary[3].change_path).to eq('/steps/conviction/conviction_length_type?check_id=12345')
       end
     end
 
@@ -54,17 +63,9 @@ RSpec.describe ConvictionResultPresenter do
       it 'returns the correct question-answer pairs' do
         expect(summary.size).to eq(4)
 
-        expect(summary[0].question).to eql(:under_age)
-        expect(summary[0].answer).to eql('yes')
-
-        expect(summary[1].question).to eql(:conviction_date)
-        expect(summary[1].answer).to eq('1 January 2018')
-
-        expect(summary[2].question).to eql(:known_date)
-        expect(summary[2].answer).to eq('31 October 2018')
-
         expect(summary[3].question).to eql(:compensation_payment_date)
         expect(summary[3].answer).to eq('31 October 2019')
+        expect(summary[3].change_path).to eq('/steps/conviction/compensation_payment_date?check_id=12345&next_step=cya')
       end
     end
 
@@ -86,19 +87,9 @@ RSpec.describe ConvictionResultPresenter do
       it 'returns the correct question-answer pairs' do
         expect(summary.size).to eq(5)
 
-        expect(summary[0].question).to eql(:under_age)
-        expect(summary[0].answer).to eql('yes')
-
-        expect(summary[1].question).to eql(:conviction_bail_days)
-        expect(summary[1].answer).to eq(15)
-
-        expect(summary[2].question).to eql(:conviction_date)
-        expect(summary[2].answer).to eq('1 January 2018')
-
-        expect(summary[3].question).to eql(:known_date)
-        expect(summary[3].answer).to eq('31 October 2018')
-
-        # ignoring following rows as they are the same as in other tests
+        expect(summary[4].question).to eql(:conviction_bail_days)
+        expect(summary[4].answer).to eq(15)
+        expect(summary[4].change_path).to eq('/steps/conviction/conviction_bail_days?check_id=12345&next_step=cya')
       end
     end
   end


### PR DESCRIPTION
Ticket: https://trello.com/c/lrx02rsR

Follow-up to PR #519.

This PR adds the "change" functionality to the convictions, similar to cautions.

There is one without the change link for now (`conviction_date`) because it is the top level conviction date, so changing it would affect all the disposals/orders that are part of the conviction (we would have to iterate through all of them changing the attribute in their corresponding DB records).

Will investigate some alternatives in another PR if possible. But it is best probably to not allow this to be changed.

<img width="691" alt="Screenshot 2021-05-26 at 12 50 24" src="https://user-images.githubusercontent.com/687910/119655017-fc890080-be20-11eb-98ec-efebfac75f1e.png">
