### PR TITLE
Fix color contrast in CYA remove link

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -25,11 +25,7 @@ dl.multiple-checks-summary:not(:only-child) {
 }
 
 .app-link-red {
-  color: $govuk-error-colour !important;
-}
-
-.app-link-red:hover {
-  color: darken($govuk-error-colour, 10%) !important;
+  @include govuk-link-style-error;
 }
 
 .app-text-align-right {


### PR DESCRIPTION
Before:
<img width="139" alt="Screenshot 2021-05-26 at 14 41 13" src="https://user-images.githubusercontent.com/687910/119675109-aaea7100-be34-11eb-9d59-8d814dc6df03.png">

After:
<img width="112" alt="Screenshot 2021-05-26 at 15 11 03" src="https://user-images.githubusercontent.com/687910/119675123-ad4ccb00-be34-11eb-8826-89d768c07cd1.png">
