### PR TITLE
When removing a record, change the session if possible.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,14 +11,8 @@ class ApplicationController < ActionController::Base
     payload[:user_agent] = request&.user_agent
   end
 
-  # With the ability to remove disclosure_check records we now look for
-  # a disclosure_report when we can't find the last created disclosure_check.
-  # This guarantees that any other disclosure_check records added by the user,
-  # will be available to that user.
   def current_disclosure_check
-    @_current_disclosure_check ||=
-      DisclosureCheck.find_by_id(session[:disclosure_check_id]) ||
-      DisclosureReport.find_by_id(session[:disclosure_report_id])&.disclosure_checks&.last
+    @_current_disclosure_check ||= DisclosureCheck.find_by_id(session[:disclosure_check_id])
   end
   helper_method :current_disclosure_check
 
@@ -43,7 +37,6 @@ class ApplicationController < ActionController::Base
   end
 
   def reset_disclosure_check_session
-    session.delete(:disclosure_report_id)
     session.delete(:disclosure_check_id)
     session.delete(:last_seen)
 
@@ -54,7 +47,6 @@ class ApplicationController < ActionController::Base
   def initialize_disclosure_check(attributes = {})
     DisclosureCheck.create(attributes).tap do |disclosure_check|
       session[:disclosure_check_id] = disclosure_check.id
-      session[:disclosure_report_id] = disclosure_check.disclosure_report.id
     end
   end
 end

--- a/app/controllers/steps/checks_controller.rb
+++ b/app/controllers/steps/checks_controller.rb
@@ -1,5 +1,7 @@
 module Steps
   class ChecksController < CheckStepController
+    after_action :swap_current_disclosure_check_session, only: [:update]
+
     def edit
       @form_object = Steps::Check::RemoveCheckForm.build(disclosure_check)
     end
@@ -10,8 +12,16 @@ module Steps
 
     private
 
+    def disclosure_checks
+      @disclosure_checks ||= current_disclosure_report.disclosure_checks
+    end
+
     def disclosure_check
-      current_disclosure_report.disclosure_checks.find(params[:id])
+      @disclosure_check ||= disclosure_checks.find(params[:id])
+    end
+
+    def swap_current_disclosure_check_session
+      swap_disclosure_check_session(disclosure_checks.last.id) if disclosure_checks.any?
     end
   end
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe HomeController, type: :controller do
           end
 
           it 'resets the disclosure_check session data' do
-            expect(session).to receive(:delete).with(:disclosure_report_id).ordered
             expect(session).to receive(:delete).with(:disclosure_check_id).ordered
             expect(session).to receive(:delete).with(:last_seen).ordered
             expect(session).to receive(:delete) # any other deletes
@@ -60,7 +59,6 @@ RSpec.describe HomeController, type: :controller do
         end
 
         it 'resets the disclosure check session data' do
-          expect(session).to receive(:delete).with(:disclosure_report_id).ordered
           expect(session).to receive(:delete).with(:disclosure_check_id).ordered
           expect(session).to receive(:delete).with(:last_seen).ordered
           expect(session).to receive(:delete) # any other deletes
@@ -79,7 +77,6 @@ RSpec.describe HomeController, type: :controller do
       end
 
       it 'resets the disclosure_checker session data' do
-        expect(session).to receive(:delete).with(:disclosure_report_id).ordered
         expect(session).to receive(:delete).with(:disclosure_check_id).ordered
         expect(session).to receive(:delete).with(:last_seen).ordered
         expect(session).to receive(:delete) # any other deletes


### PR DESCRIPTION
Upon removing a disclosure check record, if there's other records within the same report, we swap them so that the user continues to iterate through other records.

This deprecates the second session that was introduced in 84ce9d77038c860dc0a6650e69b9db5eea7ed4f5 and uses the swap functionality introduced in 252db539d8261e8f3cab9d9bc7f822aff3df3574.