### PR TITLE
A few more markups improvements

### DIFF
--- a/app/assets/stylesheets/local/custom.scss
+++ b/app/assets/stylesheets/local/custom.scss
@@ -16,6 +16,20 @@
   padding: govuk-spacing(3);
 }
 
+.app-proceeding-heading {
+  dt, dd {
+    border: none;
+  }
+
+  .govuk-summary-list__row {
+    border: none;
+
+    @include govuk-media-query($until: tablet) {
+      margin-bottom: govuk-spacing(5);
+    }
+  }
+}
+
 .app-tag-middle {
   vertical-align: middle;
 }
@@ -24,10 +38,8 @@ dl.multiple-checks-summary:not(:only-child) {
   &:not(:last-of-type) { padding-bottom: 0.5em; }
 }
 
-.app-link-red {
+.app-link--remove {
+  @include govuk-link-common;
   @include govuk-link-style-error;
-}
-
-.app-text-align-right {
-  text-align: right;
+  @include govuk-font(19);
 }

--- a/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
@@ -1,24 +1,17 @@
 <% translated_name = t("#{check_row.kind}.orders.#{check_row.order_type}", scope: check_row.scope) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-half">
-    <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+<dl class="govuk-summary-list govuk-!-margin-bottom-2 app-proceeding-heading">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-!-width-two-thirds govuk-heading-m">
       <%= translated_name %>
-    </h3>
+    </dt>
+    <dd class="govuk-summary-list__actions">
+      <%= link_to(edit_steps_check_path(check_row.disclosure_check), class: 'app-link--remove') do %>
+        <%= t('remove_link_html', scope: :check_your_answers, a11y_proceeding: translated_name.downcase) %>
+      <% end %>
+    </dd>
   </div>
-
-  <div class="govuk-grid-column-one-half app-text-align-right">
-
-
-    <%= link_to(edit_steps_check_path(check_row.disclosure_check), class: 'govuk-link govuk-link--no-visited-state app-link-red govuk-!-font-size-19') do %>
-      Remove
-      <span class="govuk-visually-hidden"><%= translated_name %></span>
-    <% end %>
-
-
-  </div>
-</div>
-
+</dl>
 
 <dl class="govuk-summary-list multiple-checks-summary">
   <%= render check_row.summary %>

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -150,6 +150,7 @@ en:
 
   check_your_answers:
     change_link_html: Change <span class="govuk-visually-hidden">%{a11y_question}</span>
+    remove_link_html: Remove <span class="govuk-visually-hidden">%{a11y_proceeding}</span>
     caution:
       <<: *CAUTION_ANSWERS
     conviction:


### PR DESCRIPTION
Convert the proceeding heading (caution / conviction name) to a definition list so the remove link move automatically down below the name when on small screens.

Also simplify a bit the styles of the red remove link.

Desktop:
<img width="606" alt="Screenshot 2021-05-27 at 15 34 10" src="https://user-images.githubusercontent.com/687910/119845532-42b59100-bf01-11eb-958d-7097beb0238d.png">

Mobile:
<img width="366" alt="Screenshot 2021-05-27 at 15 33 26" src="https://user-images.githubusercontent.com/687910/119845557-48ab7200-bf01-11eb-818c-bf7f1bfaae70.png">
