### PR TITLE
Remove endorsement question for motoring disqualifications

### DIFF
--- a/app/decorators/conviction_decorator.rb
+++ b/app/decorators/conviction_decorator.rb
@@ -26,14 +26,11 @@ module ConvictionDecorator
     ].include?(self)
   end
 
-  def motoring_penalty_notice?
-    ConvictionType::YOUTH_PENALTY_NOTICE.eql?(self) ||
-      ConvictionType::ADULT_PENALTY_NOTICE.eql?(self)
-  end
-
-  def motoring_penalty_points?
-    ConvictionType::YOUTH_PENALTY_POINTS.eql?(self) ||
-      ConvictionType::ADULT_PENALTY_POINTS.eql?(self)
+  def motoring_fine?
+    [
+      ConvictionType::YOUTH_MOTORING_FINE,
+      ConvictionType::ADULT_MOTORING_FINE,
+    ].include?(self)
   end
 
   def bailable_offense?

--- a/app/forms/steps/conviction/conviction_subtype_form.rb
+++ b/app/forms/steps/conviction/conviction_subtype_form.rb
@@ -27,19 +27,6 @@ module Steps
         disclosure_check.conviction_subtype != conviction_subtype
       end
 
-      def motoring_endorsement
-        return GenericYesNo::YES if motoring_penalty_notice?
-
-        nil
-      end
-
-      def motoring_penalty_notice?
-        [
-          ConvictionType::ADULT_PENALTY_NOTICE,
-          ConvictionType::YOUTH_PENALTY_NOTICE,
-        ].map(&:to_s).include?(conviction_subtype)
-      end
-
       def persist!
         raise DisclosureCheckNotFound unless disclosure_check
         return true unless changed?
@@ -54,7 +41,7 @@ module Steps
           conviction_length_type: nil,
           compensation_paid: nil,
           compensation_payment_date: nil,
-          motoring_endorsement: motoring_endorsement
+          motoring_endorsement: nil
         )
       end
     end

--- a/app/services/calculators/disqualification_calculator.rb
+++ b/app/services/calculators/disqualification_calculator.rb
@@ -2,44 +2,30 @@ module Calculators
   class DisqualificationCalculator < BaseCalculator
     class Youths < DisqualificationCalculator
       #
-      # If an endorsement was received:
+      # We always assume an endorsement was received:
       #
       #   - If length is less than or equal to 2.5 years (30 months): start date + 30 months
       #   - If length is greater than 2.5 years (30 months): start date + length
       #   - If no length was given: start date + 30 months
       #   - If an indefinite ban was given: until further order
       #
-      # If an endorsement was not received:
-      #
-      #   - If length was given: start date + length
-      #   - If no length was given: start date + 24 months
-      #   - If an indefinite ban was given: until further order
-      #
       ENDORSEMENT_THRESHOLD = 30
 
       REHABILITATION_WITH_ENDORSEMENT = { months: 30 }.freeze
-      REHABILITATION_WITHOUT_ENDORSEMENT = { months: 24 }.freeze
     end
 
     class Adults < DisqualificationCalculator
       #
-      # If an endorsement was received:
+      # We always assume an endorsement was received:
       #
       #   - If length is less than or equal to 5 years (60 months): start date + 60 months
       #   - If length is greater than 5 years (60 months): start date + length
       #   - If no length was given: start date + 60 months
       #   - If an indefinite ban was given: until further order
       #
-      # If an endorsement was not received:
-      #
-      #   - If length was given: start date + length
-      #   - If no length was given: start date + 24 months
-      #   - If an indefinite ban was given: until further order
-      #
       ENDORSEMENT_THRESHOLD = 60
 
       REHABILITATION_WITH_ENDORSEMENT = { months: 60 }.freeze
-      REHABILITATION_WITHOUT_ENDORSEMENT = { months: 24 }.freeze
     end
 
     def expiry_date
@@ -55,13 +41,11 @@ module Calculators
     private
 
     def rehabilitation_without_length
-      return self.class::REHABILITATION_WITH_ENDORSEMENT if motoring_endorsement?
-
-      self.class::REHABILITATION_WITHOUT_ENDORSEMENT
+      self.class::REHABILITATION_WITH_ENDORSEMENT
     end
 
     def rehabilitation_with_length
-      return self.class::REHABILITATION_WITH_ENDORSEMENT if motoring_endorsement? && within_endorsement_threshold?
+      return self.class::REHABILITATION_WITH_ENDORSEMENT if within_endorsement_threshold?
 
       conviction_length
     end

--- a/app/services/calculators/motoring/adult/penalty_notice.rb
+++ b/app/services/calculators/motoring/adult/penalty_notice.rb
@@ -1,13 +1,15 @@
 module Calculators
   module Motoring
     module Adult
-      # If an endorsement was received
+      #
+      # We always assume an endorsement was received
       # start_date + 5 years
+      #
       class PenaltyNotice < BaseCalculator
-        REHABILITATION_1 = { months: 60 }.freeze
+        REHABILITATION = { months: 60 }.freeze
 
         def expiry_date
-          conviction_start_date.advance(REHABILITATION_1)
+          conviction_start_date.advance(REHABILITATION)
         end
       end
     end

--- a/app/services/calculators/motoring/adult/penalty_points.rb
+++ b/app/services/calculators/motoring/adult/penalty_points.rb
@@ -1,13 +1,15 @@
 module Calculators
   module Motoring
     module Adult
-      # An endorsement is always received when Penalty Points
+      #
+      # We always assume an endorsement was received
       # start_date + 5 years
+      #
       class PenaltyPoints < BaseCalculator
-        REHABILITATION_1 = { months: 60 }.freeze
+        REHABILITATION = { months: 60 }.freeze
 
         def expiry_date
-          conviction_start_date.advance(REHABILITATION_1)
+          conviction_start_date.advance(REHABILITATION)
         end
       end
     end

--- a/app/services/calculators/motoring/youth/penalty_notice.rb
+++ b/app/services/calculators/motoring/youth/penalty_notice.rb
@@ -1,13 +1,15 @@
 module Calculators
   module Motoring
     module Youth
-      # If an endorsement was received
+      #
+      # We always assume an endorsement was received
       # start_date + 2.5 years
+      #
       class PenaltyNotice < BaseCalculator
-        REHABILITATION_1 = { months: 30 }.freeze
+        REHABILITATION = { months: 30 }.freeze
 
         def expiry_date
-          conviction_start_date.advance(REHABILITATION_1)
+          conviction_start_date.advance(REHABILITATION)
         end
       end
     end

--- a/app/services/calculators/motoring/youth/penalty_points.rb
+++ b/app/services/calculators/motoring/youth/penalty_points.rb
@@ -1,16 +1,18 @@
 module Calculators
   module Motoring
     module Youth
-      # An endorsement is always received when Penalty Points
+      #
+      # We always assume an endorsement was received
       # start_date + 3 years
+      #
       # Because the Youth endorsement is 2.5 years and penalty points are 3 years,
-      # even if there is an endorsement, the penalty points have a longer duration
-      # hence being 3 years always
+      # the penalty points have a longer duration hence being 3 years always.
+      #
       class PenaltyPoints < BaseCalculator
-        REHABILITATION_1 = { months: 36 }.freeze
+        REHABILITATION = { months: 36 }.freeze
 
         def expiry_date
-          conviction_start_date.advance(REHABILITATION_1)
+          conviction_start_date.advance(REHABILITATION)
         end
       end
     end

--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -12,10 +12,8 @@ class ConvictionDecisionTree < BaseDecisionTree
       edit(:conviction_subtype)
     when :conviction_subtype
       after_conviction_subtype
-    when :conviction_bail_days
+    when :conviction_bail_days, :motoring_endorsement
       known_date_question
-    when :motoring_endorsement
-      after_motoring_endorsement
     when :conviction_bail
       after_conviction_bail
     when :known_date
@@ -43,19 +41,11 @@ class ConvictionDecisionTree < BaseDecisionTree
   private
 
   def after_conviction_subtype
-    return edit(:conviction_bail)    if conviction.bailable_offense?
-    return edit(:compensation_paid)  if conviction.compensation?
-    return after_motoring_conviction if conviction.motoring?
+    return edit(:conviction_bail)      if conviction.bailable_offense?
+    return edit(:compensation_paid)    if conviction.compensation?
+    return edit(:motoring_endorsement) if conviction.motoring_fine?
 
     known_date_question
-  end
-
-  def after_motoring_conviction
-    if conviction.motoring_penalty_points? || conviction.motoring_penalty_notice?
-      known_date_question
-    else
-      edit(:motoring_endorsement)
-    end
   end
 
   def after_known_date
@@ -88,20 +78,10 @@ class ConvictionDecisionTree < BaseDecisionTree
     check_your_answers
   end
 
-  def after_motoring_endorsement
-    return check_your_answers if penalty_notice_without_endorsement?
-
-    known_date_question
-  end
-
   def after_conviction_bail
     return edit(:conviction_bail_days) if step_value(:conviction_bail).inquiry.yes?
 
     known_date_question
-  end
-
-  def penalty_notice_without_endorsement?
-    conviction.motoring_penalty_notice? && GenericYesNo.new(disclosure_check.motoring_endorsement).no?
   end
 
   def known_date_question

--- a/features/adults/conviction_motoring.feature
+++ b/features/adults/conviction_motoring.feature
@@ -8,9 +8,6 @@ Feature: Adult Conviction
     Given The current date is 03-07-2020
     When I choose "<subtype>"
 
-    Then I should see "Did you get an endorsement?"
-    And I choose "<endorsement>"
-
     Then I should see "<known_date_header>"
     And I enter the following date 01-01-2020
 
@@ -25,19 +22,14 @@ Feature: Adult Conviction
     And I should see "<spent_date>"
 
     Examples:
-      | subtype          | endorsement | known_date_header       | length_type_header                                                      | length_header                                | length_months | spent_date                                       |
-      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | This conviction will be spent on 1 January 2025  |
-      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | This conviction was spent on 1 July 2020         |
-      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 70            | This conviction will be spent on 1 November 2025 |
-      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 70            | This conviction will be spent on 1 November 2025 |
+      | subtype          | known_date_header       | length_type_header                                                      | length_header                                | length_months | spent_date                                       |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | This conviction will be spent on 1 January 2025  |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 70            | This conviction will be spent on 1 November 2025 |
 
   @happy_path @date_travel
   Scenario Outline: Motoring disqualification without length or indefinite
     Given The current date is 03-07-2020
     When I choose "<subtype>"
-
-    Then I should see "Did you get an endorsement?"
-    And I choose "<endorsement>"
 
     Then I should see "<known_date_header>"
     And I enter the following date 01-01-2020
@@ -49,11 +41,9 @@ Feature: Adult Conviction
     And I should see "<spent_date>"
 
     Examples:
-      | subtype          | endorsement | known_date_header       | length_type_header                                                      | length_option       | spent_date                                                                                          |
-      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | This conviction will be spent on 1 January 2025                                                     |
-      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | This conviction will be spent on 1 January 2022                                                     |
-      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
-      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
+      | subtype          | known_date_header       | length_type_header                                                      | length_option       | spent_date                                                                                          |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | This conviction will be spent on 1 January 2025                                                     |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
 
   @happy_path  @date_travel
   Scenario Outline: Motoring fine
@@ -80,30 +70,17 @@ Feature: Adult Conviction
 
     Then I should see "When was the endorsement given?"
     And I enter the following date 01-01-2020
-    And I check my "conviction" answers and go to the results page
-    And I should see "This conviction will be spent on 1 January 2025"
 
-  @happy_path  @date_travel
-  Scenario: Motoring endorsed FPN
-    Given The current date is 03-07-2020
-    When I choose "Fixed Penalty notice (FPN) with penalty points (endorsement)"
-
-    Then I should see "When was the endorsement given?"
-    And I enter the following date 01-01-2020
     And I check my "conviction" answers and go to the results page
     And I should see "This conviction will be spent on 1 January 2025"
 
   @happy_path @date_travel
-  Scenario Outline: Motoring penalty points
+  Scenario: Motoring penalty points
     Given The current date is 03-07-2020
-    When I choose "<subtype>"
+    When I choose "Penalty points"
 
-    Then I should see "<known_date_header>"
+    Then I should see "When were you given the penalty points?"
     And I enter the following date 01-01-2020
 
     And I check my "conviction" answers and go to the results page
-    And I should see "This conviction <spent_date>"
-
-    Examples:
-      | subtype        | known_date_header                       | spent_date                      |
-      | Penalty points | When were you given the penalty points? | will be spent on 1 January 2025 |
+    And I should see "This conviction will be spent on 1 January 2025"

--- a/features/youth/conviction_motoring.feature
+++ b/features/youth/conviction_motoring.feature
@@ -8,9 +8,6 @@ Feature: Youth Conviction
     Given The current date is 03-07-2020
     When I choose "<subtype>"
 
-    Then I should see "Did you get an endorsement?"
-    And I choose "<endorsement>"
-
     Then I should see "<known_date_header>"
     And I enter the following date 01-01-2020
 
@@ -25,19 +22,14 @@ Feature: Youth Conviction
     And I should see "<spent_date>"
 
     Examples:
-      | subtype          | endorsement | known_date_header       | length_type_header                                                      | length_header                                | length_months | spent_date                                   |
-      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | This conviction will be spent on 1 July 2022 |
-      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | This conviction was spent on 1 July 2020     |
-      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 40            | This conviction will be spent on 1 May 2023  |
-      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 40            | This conviction will be spent on 1 May 2023  |
+      | subtype          | known_date_header       | length_type_header                                                      | length_header                                | length_months | spent_date                                   |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | This conviction will be spent on 1 July 2022 |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 40            | This conviction will be spent on 1 May 2023  |
 
   @happy_path @date_travel
   Scenario Outline: Motoring disqualification without length or indefinite
     Given The current date is 03-07-2020
     When I choose "<subtype>"
-
-    Then I should see "Did you get an endorsement?"
-    And I choose "<endorsement>"
 
     Then I should see "<known_date_header>"
     And I enter the following date 01-01-2020
@@ -49,11 +41,9 @@ Feature: Youth Conviction
     And I should see "<spent_date>"
 
     Examples:
-      | subtype          | endorsement | known_date_header       | length_type_header                                                      | length_option       | spent_date                                                                         |
-      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | This conviction will be spent on 1 July 2022                                       |
-      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | This conviction will be spent on 1 January 2022                                    |
-      | Disqualification | Yes         | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
-      | Disqualification | No          | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
+      | subtype          | known_date_header       | length_type_header                                                      | length_option       | spent_date                                                                         |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | This conviction will be spent on 1 July 2022                                       |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
 
   @happy_path @date_travel
   Scenario Outline: Motoring fine
@@ -85,18 +75,13 @@ Feature: Youth Conviction
     And I check my "conviction" answers and go to the results page
     And I should see "This conviction will be spent on 1 July 2022"
 
-
   @happy_path @date_travel
-  Scenario Outline: Motoring penalty points
+  Scenario: Motoring penalty points
     Given The current date is 03-07-2020
-    When I choose "<subtype>"
+    When I choose "Penalty points"
 
-    Then I should see "<known_date_header>"
+    Then I should see "When were you given the penalty points?"
     And I enter the following date 01-01-2020
 
-     And I check my "conviction" answers and go to the results page
-     And I should see "<spent_date>"
-
-    Examples:
-      | subtype        | known_date_header                        | spent_date                                      |
-      | Penalty points | When were you given the penalty points?  | This conviction will be spent on 1 January 2023 |
+    And I check my "conviction" answers and go to the results page
+    And I should see "This conviction will be spent on 1 January 2023"

--- a/spec/decorators/conviction_decorator_spec.rb
+++ b/spec/decorators/conviction_decorator_spec.rb
@@ -47,15 +47,15 @@ RSpec.describe ConvictionDecorator do
     end
   end
 
-  describe '#motoring_penalty_notice?' do
-    context 'for an adult `ADULT_PENALTY_NOTICE` conviction type' do
-      subject { ConvictionType::ADULT_PENALTY_NOTICE }
-      it { expect(subject.motoring_penalty_notice?).to eq(true) }
+  describe '#motoring_fine?' do
+    context 'for an adult `ADULT_MOTORING_FINE` conviction type' do
+      subject { ConvictionType::ADULT_MOTORING_FINE }
+      it { expect(subject.motoring_fine?).to eq(true) }
     end
 
-    context 'for a youth `YOUTH_PENALTY_NOTICE` conviction type' do
-      subject { ConvictionType::YOUTH_PENALTY_NOTICE }
-      it { expect(subject.motoring_penalty_notice?).to eq(true) }
+    context 'for a youth `YOUTH_MOTORING_FINE` conviction type' do
+      subject { ConvictionType::YOUTH_MOTORING_FINE }
+      it { expect(subject.motoring_fine?).to eq(true) }
     end
   end
 

--- a/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_subtype_form_spec.rb
@@ -27,84 +27,16 @@ RSpec.describe Steps::Conviction::ConvictionSubtypeForm do
   # in the value-object spec `spec/value_objects/conviction_type_spec.rb`
   describe '#values' do
     it 'returns the relevant values (children of the conviction type)' do
-      expect(subject.values).to include(
+      expect(subject.values).to match_array([
         ConvictionType.new(:referral_order),
         ConvictionType.new(:supervision_order),
         ConvictionType.new(:youth_rehabilitation_order)
-      )
+      ])
     end
   end
 
   describe '#save' do
     it_behaves_like 'a value object form', attribute_name: :conviction_subtype, example_value: 'referral_order'
-
-    context 'when conviction type is motoring' do
-      context 'and conviction subtype is youth_penalty_notice' do
-        let(:conviction_type) { 'youth_motoring' }
-        let(:conviction_subtype) { 'youth_penalty_notice' }
-
-        it 'saves the record with motoring endorsement saved with `yes` value' do
-          expect(disclosure_check).to receive(:update).with(
-            conviction_subtype: conviction_subtype,
-            # Dependent attributes to be reset
-            known_date: nil,
-            conviction_bail: nil,
-            conviction_bail_days: nil,
-            conviction_length: nil,
-            conviction_length_type: nil,
-            compensation_paid: nil,
-            compensation_payment_date: nil,
-            motoring_endorsement: GenericYesNo::YES,
-          ).and_return(true)
-
-          expect(subject.save).to be(true)
-        end
-
-        context 'when conviction_subtype is already the same on the model' do
-          let(:disclosure_check) {
-            instance_double(DisclosureCheck, conviction_type: conviction_type, conviction_subtype: conviction_subtype)
-          }
-
-          it 'does not save the record but returns true' do
-            expect(disclosure_check).to_not receive(:update)
-            expect(subject.save).to be(true)
-          end
-        end
-      end
-
-      context 'and conviction subtype is adult_penalty_notice' do
-        let(:conviction_type) { 'adult_motoring' }
-        let(:conviction_subtype) { 'adult_penalty_notice' }
-
-        it 'saves the record with motoring endorsement saved with `yes` value' do
-          expect(disclosure_check).to receive(:update).with(
-            conviction_subtype: conviction_subtype,
-            # Dependent attributes to be reset
-            known_date: nil,
-            conviction_bail: nil,
-            conviction_bail_days: nil,
-            conviction_length: nil,
-            conviction_length_type: nil,
-            compensation_paid: nil,
-            compensation_payment_date: nil,
-            motoring_endorsement: GenericYesNo::YES,
-          ).and_return(true)
-
-          expect(subject.save).to be(true)
-        end
-
-        context 'when conviction_subtype is already the same on the model' do
-          let(:disclosure_check) {
-            instance_double(DisclosureCheck, conviction_type: conviction_type, conviction_subtype: conviction_subtype)
-          }
-
-          it 'does not save the record but returns true' do
-            expect(disclosure_check).to_not receive(:update)
-            expect(subject.save).to be(true)
-          end
-        end
-      end
-    end
 
     context 'when form is valid' do
       let(:conviction_subtype) { 'referral_order' }

--- a/spec/services/calculators/disqualification_calculator_spec.rb
+++ b/spec/services/calculators/disqualification_calculator_spec.rb
@@ -5,12 +5,10 @@ RSpec.describe Calculators::DisqualificationCalculator do
 
   let(:disclosure_check) { build(:disclosure_check,
                                  under_age: under_age,
-                                 motoring_endorsement: motoring_endorsement,
                                  known_date: known_date,
                                  conviction_length: conviction_length,
                                  conviction_length_type: conviction_length_type) }
 
-  let(:motoring_endorsement) { GenericYesNo::NO }
   let(:known_date) { Date.new(2018, 10, 31) }
   let(:conviction_length) { nil }
   let(:conviction_length_type) { nil }
@@ -20,25 +18,14 @@ RSpec.describe Calculators::DisqualificationCalculator do
 
     context '#expiry_date' do
       context 'with a length' do
-        context 'with a motoring endorsement' do
-          let(:motoring_endorsement) { GenericYesNo::YES }
+        context 'less than or equal to 2.5 years' do
+          let(:conviction_length) { 2 }
+          let(:conviction_length_type) { 'years' }
 
-          context 'less than or equal to 2.5 years' do
-            let(:conviction_length) { 2 }
-            let(:conviction_length_type) { 'years' }
-
-            it { expect(subject.expiry_date.to_s).to eq((known_date + 30.months).to_s) }
-          end
-
-          context 'greater than 2.5 years' do
-            let(:conviction_length) { 3 }
-            let(:conviction_length_type) { 'years' }
-
-            it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
-          end
+          it { expect(subject.expiry_date.to_s).to eq((known_date + 30.months).to_s) }
         end
 
-        context 'without a motoring endorsement' do
+        context 'greater than 2.5 years' do
           let(:conviction_length) { 3 }
           let(:conviction_length_type) { 'years' }
 
@@ -48,15 +35,7 @@ RSpec.describe Calculators::DisqualificationCalculator do
 
       context 'without a length' do
         let(:conviction_length) { 'no_length' }
-
-        context 'with a motoring endorsement' do
-          let(:motoring_endorsement) { GenericYesNo::YES }
-          it { expect(subject.expiry_date.to_s).to eq('2021-04-30') }
-        end
-
-        context 'without a motoring endorsement' do
-          it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
-        end
+        it { expect(subject.expiry_date.to_s).to eq('2021-04-30') }
       end
 
       context 'with an indefinite length' do
@@ -71,43 +50,24 @@ RSpec.describe Calculators::DisqualificationCalculator do
 
     context '#expiry_date' do
       context 'with a length' do
-        context 'with a motoring endorsement' do
-          let(:motoring_endorsement) { GenericYesNo::YES }
-
-          context 'less than or equal to 5 years' do
-            let(:conviction_length) { 4 }
-            let(:conviction_length_type) { 'years' }
-
-            it { expect(subject.expiry_date.to_s).to eq((known_date + 60.months).to_s) }
-          end
-
-          context 'greater than 5 years' do
-            let(:conviction_length) { 6 }
-            let(:conviction_length_type) { 'years' }
-
-            it { expect(subject.expiry_date.to_s).to eq((known_date + 72.months).to_s) }
-          end
-        end
-
-        context 'without a motoring endorsement' do
-          let(:conviction_length) { 3 }
+        context 'less than or equal to 5 years' do
+          let(:conviction_length) { 4 }
           let(:conviction_length_type) { 'years' }
 
-          it { expect(subject.expiry_date.to_s).to eq((known_date + 36.months).to_s) }
+          it { expect(subject.expiry_date.to_s).to eq((known_date + 60.months).to_s) }
+        end
+
+        context 'greater than 5 years' do
+          let(:conviction_length) { 6 }
+          let(:conviction_length_type) { 'years' }
+
+          it { expect(subject.expiry_date.to_s).to eq((known_date + 72.months).to_s) }
         end
       end
 
       context 'without a length' do
         let(:conviction_length) { 'no_length' }
-
-        context 'with a motoring endorsement' do
-          let(:motoring_endorsement) { GenericYesNo::YES }
-          it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
-        end
-
-        context 'without a motoring endorsement' do
-          it { expect(subject.expiry_date.to_s).to eq('2020-10-31') }
-        end
+        it { expect(subject.expiry_date.to_s).to eq('2023-10-31') }
       end
 
       context 'with an indefinite length' do

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -73,13 +73,13 @@ RSpec.describe ConvictionDecisionTree do
         it { is_expected.to have_destination(:motoring_endorsement, :edit) }
       end
 
-      context 'when subtype equal adult_penalty_notice' do
-        let(:conviction_subtype) { :adult_penalty_notice }
-        it { is_expected.to have_destination(:known_date, :edit) }
+      context 'when subtype equal youth_motoring_fine' do
+        let(:conviction_subtype) { :youth_motoring_fine }
+        it { is_expected.to have_destination(:motoring_endorsement, :edit) }
       end
 
-      context 'when subtype equal adult_penalty_points' do
-        let(:conviction_subtype) { :adult_penalty_points }
+      context 'when subtype is any other motoring conviction' do
+        let(:conviction_subtype) { :adult_disqualification }
         it { is_expected.to have_destination(:known_date, :edit) }
       end
     end
@@ -193,33 +193,8 @@ RSpec.describe ConvictionDecisionTree do
   end
 
   context 'when the step is `motoring_endorsement`' do
-    let(:motoring_endorsement) {GenericYesNo::YES }
-    let(:step_params) { { motoring_endorsement:  motoring_endorsement } }
-
-    context 'when subtype is equal adult_penalty_notice' do
-      let(:conviction_subtype) { :adult_penalty_notice }
-      context 'with a endorsement' do
-        it { is_expected.to have_destination(:known_date, :edit) }
-      end
-
-      context ' without a endorsement' do
-        let(:motoring_endorsement) {GenericYesNo::NO }
-        it { is_expected.to show_check_your_answers_page }
-      end
-    end
-
-    context 'when subtype is not equal to adult_penalty_notice sub types' do
-      let(:conviction_subtype) { :adult_disqualification }
-
-      context 'with a endorsement' do
-        it { is_expected.to have_destination(:known_date, :edit) }
-      end
-
-      context 'without a endorsement' do
-        let(:motoring_endorsement) {GenericYesNo::NO }
-        it { is_expected.to have_destination(:known_date, :edit) }
-      end
-    end
+    let(:step_params) { { motoring_endorsement:  GenericYesNo::YES } }
+    it { is_expected.to have_destination(:known_date, :edit) }
   end
 
   context 'when the step is `conviction_bail`' do


### PR DESCRIPTION
Ticket: https://trello.com/c/1RtNkemH

During DC demos, feedback was given that it is unnecessary to ask users who enter that they have a driving disqualification whether they have an endorsement, as all disqualifications are endorsed.

Legal confirmed that we should remove the question for the service.

Refactor the code around the disqualification logic because we now only have 1 motoring conviction where we need to still ask this question (fines). The others can be simplified.

Individual commits for more context.