### PR TITLE
Enable CYA change links

### DIFF
--- a/app/views/steps/check/check_your_answers/shared/_change_link.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_change_link.html.erb
@@ -1,5 +1,7 @@
 <% a11y_question = t("#{row.question}.question", scope: row.scope).downcase %>
 
-<%= link_to row.change_path, class: 'govuk-link govuk-link--no-visited-state' do %>
+<%= link_to row.change_path,
+            class: 'govuk-link govuk-link--no-visited-state ga-pageLink',
+            data: { ga_category: 'check your answers', ga_label: "change #{row.question}" } do %>
   <%= t('change_link_html', scope: :check_your_answers, a11y_question: a11y_question) %>
 <% end %>

--- a/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_check_row.html.erb
@@ -6,7 +6,9 @@
       <%= translated_name %>
     </dt>
     <dd class="govuk-summary-list__actions">
-      <%= link_to(edit_steps_check_path(check_row.disclosure_check), class: 'app-link--remove') do %>
+      <%= link_to edit_steps_check_path(check_row.disclosure_check),
+                  class: 'app-link--remove ga-pageLink',
+                  data: { ga_category: 'check your answers', ga_label: "remove #{check_row.kind}" } do %>
         <%= t('remove_link_html', scope: :check_your_answers, a11y_proceeding: translated_name.downcase) %>
       <% end %>
     </dd>

--- a/app/views/steps/check/check_your_answers/shared/_row.html.erb
+++ b/app/views/steps/check/check_your_answers/shared/_row.html.erb
@@ -6,6 +6,6 @@
     <%=t "#{row.question}.answers.#{row.answer}", scope: row.scope, default: row.answer %>
   </dd>
   <dd class="govuk-summary-list__actions">
-    <%= render partial: 'steps/check/check_your_answers/shared/change_link', locals: { row: row } if row.change_path && dev_tools_enabled? %>
+    <%= render partial: 'steps/check/check_your_answers/shared/change_link', locals: { row: row } if row.change_path %>
   </dd>
 </div>


### PR DESCRIPTION
Ticket: https://trello.com/c/lrx02rsR

This was hidden behind a feature flag and only visible on staging but now we have the green light to release to production.

Also added GA tracking (including the remove links for parity).