### PR TITLE
Minor copy amendments to results page

### DIFF
--- a/app/views/steps/check/results/show.en.html.erb
+++ b/app/views/steps/check/results/show.en.html.erb
@@ -87,7 +87,9 @@
     </p>
 
     <p class="govuk-body">
-      Criminal record checks are usually done through the Disclosure and Barring Service (DBS).
+      Criminal record checks are usually done through the
+      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/organisations/disclosure-and-barring-service">Disclosure
+        and Barring Service (DBS)</a>.
     </p>
 
     <p class="govuk-body">
@@ -97,8 +99,6 @@
     </p>
 
     <p class="govuk-body">
-      Criminal record checks are usually done through the
-      <a class="govuk-link" rel="external" target="_blank" href="https://www.gov.uk/government/publications/dbs-filtering-guidance">Disclosure and Barring Service (DBS)</a>.
       The 4 types of DBS checks are:
     </p>
 


### PR DESCRIPTION
As instructed by content designers.
There was a duplicated sentence and a wrong link.