### PR TITLE
Add cucumber scenario for CYA change links

### DIFF
--- a/features/multiples/change_answers.feature
+++ b/features/multiples/change_answers.feature
@@ -1,0 +1,28 @@
+Feature: A person who made a mistake and wants to change their answers
+  Background:
+    When I am completing a basic 18 or over "Discharge" conviction
+     And I choose "Bind over"
+     And I enter the following date 01-06-2000
+     And I choose "Years"
+     And I fill in "Number of years" with "2"
+     And I click the "Continue" button
+
+  Scenario: Change some answers of the conviction
+    Then I should see "Check your answers"
+     And I should see "Conviction 1"
+     And I should see "1 June 2000"
+     And I should see "2 years"
+
+    When I click the "Change start date" link
+    Then I should see "When were you given the order?"
+     And I enter the following date 5-08-2001
+    Then I should see "Check your answers"
+     And I should see "5 August 2001"
+
+    When I click the "Change length of conviction" link
+    Then I should see "Was the length of the order given in weeks, months or years?"
+     And I choose "Months"
+     And I fill in "Number of months" with "15"
+     And I click the "Continue" button
+    Then I should see "Check your answers"
+     And I should see "15 months"


### PR DESCRIPTION
Ticket: https://trello.com/c/ABI0WCOR

Add a simple cucumber scenario to cover the change links functionality on the check your answers page, similar to what we did with the remove functionality.

Note how we can nicely write these by using, for example, `I click the "Change start date" link` despite on the page only the word `Change` is visible, the `start date` part is visually hidden, but still it can be used to target elements with cucumber.