### PR TITLE
Copy change `Length of conviction` to `Length of sentence`

### DIFF
--- a/config/locales/en/conviction.yml
+++ b/config/locales/en/conviction.yml
@@ -20,7 +20,7 @@ en:
           page_title: Weeks, months or years
       conviction_length:
         edit:
-          page_title: Length of conviction
+          page_title: Length of sentence
           heading:
             default: What was the length of the order?
             detention_training_order: What was the length of the DTO?

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -98,7 +98,7 @@ en:
     known_date:
       question: Start date
     conviction_length:
-      question: Length of conviction
+      question: Length of sentence
       answers:
         weeks: '%{length} weeks'
         months: '%{length} months'

--- a/features/multiples/change_answers.feature
+++ b/features/multiples/change_answers.feature
@@ -19,7 +19,7 @@ Feature: A person who made a mistake and wants to change their answers
     Then I should see "Check your answers"
      And I should see "5 August 2001"
 
-    When I click the "Change length of conviction" link
+    When I click the "Change length of sentence" link
     Then I should see "Was the length of the order given in weeks, months or years?"
      And I choose "Months"
      And I fill in "Number of months" with "15"


### PR DESCRIPTION
Ticket: https://trello.com/c/DTKQQcwt

This was raised by policy and suggested we could use `Length of sentence` instead of previously `Length of conviction`.

This affects the Check your answers page and the Results page.