### PR TITLE
Remove compensation to a victim DBS receipt kick out

### DIFF
--- a/app/services/conviction_decision_tree.rb
+++ b/app/services/conviction_decision_tree.rb
@@ -1,7 +1,6 @@
 class ConvictionDecisionTree < BaseDecisionTree
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
   def destination
     return next_step if next_step
 
@@ -22,19 +21,12 @@ class ConvictionDecisionTree < BaseDecisionTree
       after_conviction_length_type
     when :compensation_paid
       after_compensation_paid
-    when :compensation_payment_over_100
-      edit(:compensation_payment_date)
-    when :compensation_payment_date
-      after_compensation_payment_date
-    when :compensation_receipt_sent
-      after_compensation_receipt_sent
-    when :conviction_length
+    when :conviction_length, :compensation_payment_date
       check_your_answers
     else
       raise InvalidStep, "Invalid step '#{as || step_params}'"
     end
   end
-  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/CyclomaticComplexity
 
@@ -61,21 +53,9 @@ class ConvictionDecisionTree < BaseDecisionTree
   end
 
   def after_compensation_paid
-    return edit(:compensation_paid_amount) if GenericYesNo.new(disclosure_check.compensation_paid).yes?
+    return edit(:compensation_payment_date) if GenericYesNo.new(disclosure_check.compensation_paid).yes?
 
     show(:compensation_not_paid)
-  end
-
-  def after_compensation_payment_date
-    return edit(:compensation_payment_receipt) if GenericYesNo.new(disclosure_check.compensation_payment_over_100).yes?
-
-    check_your_answers
-  end
-
-  def after_compensation_receipt_sent
-    return show(:compensation_unable_to_tell) if GenericYesNo.new(disclosure_check.compensation_receipt_sent).no?
-
-    check_your_answers
   end
 
   def after_conviction_bail

--- a/features/adults/conviction_financial.feature
+++ b/features/adults/conviction_financial.feature
@@ -10,77 +10,14 @@ Feature: Conviction
     And I check my "conviction" answers and go to the results page
 
   @happy_path
-  Scenario: Conviction Financial penalty - When compensation paid in full is over £100
+  Scenario: Conviction Financial penalty - Compensation paid
     When I choose "Compensation to a victim"
     Then I should see "Have you paid the compensation in full?"
     And I choose "Yes"
-    Then I should see "Was the compensation order amount over £100?"
-    And I choose "Yes"
     Then I should see "When did you pay the compensation in full?"
     When I enter a valid date
-    Then I should see "Did you send the payment receipt to the Disclosure and Barring (DBS) service?"
-    And I choose "Yes"
-
     And I check my "conviction" answers and go to the results page
 
-  @happy_path
-  Scenario: Conviction Financial penalty - Compensation paid in full is under £100
-    When I choose "Compensation to a victim"
-    Then I should see "Have you paid the compensation in full?"
-    And I choose "Yes"
-
-    Then I should see "Was the compensation order amount over £100?"
-    And I choose "No"
-
-    Then I should see "When did you pay the compensation in full?"
-    When I enter a valid date
-
-    And I check my "conviction" answers and go to the results page
-
-  Scenario: Conviction Financial penalty - Does not select a radio button on over £100 screen
-    When I choose "Compensation to a victim"
-    Then I should see "Have you paid the compensation in full?"
-    And I choose "Yes"
-
-    Then I should see "Was the compensation order amount over £100?"
-    And I click the "Continue" button
-
-    Then I should see "Select yes or no"
-
-  @happy_path
-  Scenario: Conviction Financial penalty - Did not send payment receipt
-    When I choose "Compensation to a victim"
-    Then I should see "Have you paid the compensation in full?"
-    And I choose "Yes"
-
-    Then I should see "Was the compensation order amount over £100?"
-    And I choose "Yes"
-
-    Then I should see "When did you pay the compensation in full?"
-    When I enter a valid date
-
-    Then I should see "Did you send the payment receipt to the Disclosure and Barring (DBS) service?"
-    And I choose "No"
-
-    Then I should be on "/steps/conviction/compensation_unable_to_tell"
-
-  Scenario: Conviction Financial penalty - Does not select radio button on DBS screen
-    When I choose "Compensation to a victim"
-    Then I should see "Have you paid the compensation in full?"
-    And I choose "Yes"
-
-    Then I should see "Was the compensation order amount over £100?"
-    And I choose "Yes"
-
-    Then I should see "When did you pay the compensation in full?"
-    When I enter a valid date
-
-    Then I should see "Did you send the payment receipt to the Disclosure and Barring (DBS) service?"
-    And I click the "Continue" button
-
-    Then I should see "Select yes or no"
-
-  @happy_path
   Scenario: Conviction Financial penalty - Compensation not paid in full
     When I choose "Compensation to a victim"
     Then I should see "Have you paid the compensation in full?"

--- a/features/youth/conviction_financial.feature
+++ b/features/youth/conviction_financial.feature
@@ -10,51 +10,14 @@ Feature: Conviction
     And I check my "conviction" answers and go to the results page
 
   @happy_path
-  Scenario: Conviction Financial penalty - When compensation paid in full is over £100
+  Scenario: Conviction Financial penalty - Compensation paid
     When I choose "Compensation to a victim"
     Then I should see "Have you paid the compensation in full?"
     And I choose "Yes"
-    Then I should see "Was the compensation order amount over £100?"
-    And I choose "Yes"
     Then I should see "When did you pay the compensation in full?"
     When I enter a valid date
-    Then I should see "Did you send the payment receipt to the Disclosure and Barring (DBS) service?"
-    And I choose "Yes"
-
     And I check my "conviction" answers and go to the results page
 
-  @happy_path
-  Scenario: Conviction Financial penalty - Compensation paid in full is under £100
-    When I choose "Compensation to a victim"
-    Then I should see "Have you paid the compensation in full?"
-    And I choose "Yes"
-
-    Then I should see "Was the compensation order amount over £100?"
-    And I choose "No"
-
-    Then I should see "When did you pay the compensation in full?"
-    When I enter a valid date
-
-    And I check my "conviction" answers and go to the results page
-
-  @happy_path
-  Scenario: Conviction Financial penalty - Did not send payment receipt
-    When I choose "Compensation to a victim"
-    Then I should see "Have you paid the compensation in full?"
-    And I choose "Yes"
-
-    Then I should see "Was the compensation order amount over £100?"
-    And I choose "Yes"
-
-    Then I should see "When did you pay the compensation in full?"
-    When I enter a valid date
-
-    Then I should see "Did you send the payment receipt to the Disclosure and Barring (DBS) service?"
-    And I choose "No"
-
-    Then I should be on "/steps/conviction/compensation_unable_to_tell"
-
-  @happy_path
   Scenario: Conviction Financial penalty - Compensation not paid in full
     When I choose "Compensation to a victim"
     Then I should see "Have you paid the compensation in full?"

--- a/spec/services/conviction_decision_tree_spec.rb
+++ b/spec/services/conviction_decision_tree_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe ConvictionDecisionTree do
       conviction_subtype: conviction_subtype,
       compensation_paid: compensation_paid,
       motoring_endorsement: motoring_endorsement,
-      compensation_payment_over_100: compensation_payment_over_100,
-      compensation_receipt_sent: compensation_receipt_sent,
     )
   end
 
@@ -19,8 +17,6 @@ RSpec.describe ConvictionDecisionTree do
   let(:conviction_subtype) { nil }
   let(:compensation_paid)  { nil }
   let(:motoring_endorsement) { nil }
-  let(:compensation_payment_over_100) { nil }
-  let(:compensation_receipt_sent) { nil }
 
   subject { described_class.new(disclosure_check: disclosure_check, step_params: step_params, as: as, next_step: next_step) }
 
@@ -136,7 +132,7 @@ RSpec.describe ConvictionDecisionTree do
     context 'when the step is `compensation_paid` equal yes' do
       let(:compensation_paid)  { GenericYesNo::YES }
       let(:step_params) { { compensation_paid:  compensation_paid } }
-      it { is_expected.to have_destination(:compensation_paid_amount, :edit) }
+      it { is_expected.to have_destination(:compensation_payment_date, :edit) }
     end
 
     context 'when the step is `compensation_paid` equal no' do
@@ -146,50 +142,9 @@ RSpec.describe ConvictionDecisionTree do
     end
   end
 
-  context 'when the step is `compensation_paid_amount`' do
-    context 'when the step is `compensation_payment_over_100` equal yes' do
-      let(:compensation_payment_over_100)  { GenericYesNo::YES }
-      let(:step_params) { { compensation_payment_over_100:  compensation_payment_over_100 } }
-
-      it { is_expected.to have_destination(:compensation_payment_date, :edit) }
-    end
-
-    context 'when the step is `compensation_payment_over_100` equal no' do
-      let(:compensation_payment_over_100)  { GenericYesNo::NO }
-      let(:step_params) { { compensation_payment_over_100:  compensation_payment_over_100 } }
-
-      it { is_expected.to have_destination(:compensation_payment_date, :edit) }
-    end
-  end
-
   context 'when the step is `compensation_payment_date`' do
     let(:step_params) { { compensation_payment_date: 'anything' } }
-
-    context 'and the compensation payment was over £100' do
-      let(:compensation_payment_over_100) { GenericYesNo::YES }
-
-      it { is_expected.to have_destination(:compensation_payment_receipt, :edit) }
-    end
-
-    context 'and the compensation payment was under £100' do
-      let(:compensation_payment_over_100) { GenericYesNo::NO }
-
-      it { is_expected.to show_check_your_answers_page }
-    end
-  end
-
-  context 'when the step is `compensation_receipt_sent`' do
-    let(:step_params) { { compensation_receipt_sent: 'anything' } }
-
-    context 'and the receipt was sent' do
-      let(:compensation_receipt_sent) { GenericYesNo::YES }
-      it { is_expected.to show_check_your_answers_page }
-    end
-
-    context 'and the receipt was not sent' do
-      let(:compensation_receipt_sent) { GenericYesNo::NO }
-      it { is_expected.to have_destination(:compensation_unable_to_tell, :show) }
-    end
+    it { is_expected.to show_check_your_answers_page }
   end
 
   context 'when the step is `motoring_endorsement`' do


### PR DESCRIPTION
Ticket: https://trello.com/c/cETYcVq3

This is work in progress. We are awaiting for copy changes (maybe) to be
introduced in the journey.

For now I've just reorganised the journey to get rid of the kick out
page and the amount question, as it was only used to trigger the
kick out when the amount was over 100 but does not affect any of the
calculations.

Pending things: removal of form objects, controllers, views, locales,
etc. and even the unused DB fields. once we are clear on the copy
changes and where we have to apply them.