### PR TITLE
Change heading from h2 to h3 in results page

### DIFF
--- a/app/views/steps/check/results/shared/_feedback.en.html.erb
+++ b/app/views/steps/check/results/shared/_feedback.en.html.erb
@@ -1,8 +1,8 @@
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 
-<h2 class="govuk-heading-m govuk-!-margin-top-5">
+<h3 class="govuk-heading-m govuk-!-margin-top-5">
   We’d like your feedback
-</h2>
+</h3>
 
 <p class="govuk-body">
   This will help us to improve the service.


### PR DESCRIPTION
Ticket: https://trello.com/c/8oxpSW1n

Very minor tweak, as raised by a recent accessibility report, to change the survey heading from an h2 to an h3 so it is consistent with the rest of headings.