### PR TITLE
Introduce days to sentence length

### DIFF
--- a/app/forms/steps/conviction/conviction_length_form.rb
+++ b/app/forms/steps/conviction/conviction_length_form.rb
@@ -4,7 +4,9 @@ module Steps
       attribute :conviction_length, String
       delegate :conviction_length_type, to: :disclosure_check
 
-      validates_numericality_of :conviction_length, greater_than: 0, only_integer: true
+      HUNDRED_YEARS_IN_DAYS = 36_524
+
+      validates_numericality_of :conviction_length, greater_than: 0, less_than: HUNDRED_YEARS_IN_DAYS, only_integer: true
       validates :conviction_length, sentence_length: true, if: :disclosure_check
 
       def i18n_attribute

--- a/app/services/base_calculator.rb
+++ b/app/services/base_calculator.rb
@@ -1,10 +1,6 @@
 class BaseCalculator
   class InvalidCalculation < RuntimeError; end
 
-  SECONDS_IN_A_MONTH = ActiveSupport::Duration::SECONDS_PER_MONTH
-  WEEKS_IN_A_MONTH = 52 / 12.0
-  MONTHS_IN_A_YEAR = 12
-
   attr_reader :disclosure_check
 
   def initialize(disclosure_check)
@@ -46,10 +42,12 @@ class BaseCalculator
 
   def sentence_length_in_months(length, length_unit)
     case length_unit
+    when 'days'
+      length.days.in_months
     when 'weeks'
-      length / WEEKS_IN_A_MONTH
+      length.weeks.in_months
     when 'years'
-      length * MONTHS_IN_A_YEAR
+      length.years.in_months
     when 'months'
       length
     end

--- a/app/value_objects/conviction_length_type.rb
+++ b/app/value_objects/conviction_length_type.rb
@@ -1,5 +1,6 @@
 class ConvictionLengthType < ValueObject
   VALUES = [
+    DAYS = new(:days),
     WEEKS = new(:weeks),
     MONTHS = new(:months),
     YEARS = new(:years),

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -49,6 +49,7 @@ en:
           attributes:
             conviction_length:
               greater_than: The length must be greater than zero
+              less_than: The length seems to be too long
               not_a_number: The length must be a number, like 3
               not_an_integer: The length must be a whole number, like 4
               invalid_sentence: The length of the sentence is invalid for this conviction

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -272,12 +272,14 @@ en:
           adult_other_requirement_order: Any other order with a requirement
       steps_conviction_conviction_length_type_form:
         conviction_length_type_options:
+          days: Days
           weeks: Weeks
           months: Months
           years: Years
           no_length: No length was given
           indefinite: Until further order
       steps_conviction_conviction_length_form:
+        days: Number of days
         weeks: Number of weeks
         months: Number of months
         years: Number of years
@@ -365,19 +367,20 @@ en:
         conviction_bail: Did you spend any time on bail with an electronic tag?
       steps_conviction_conviction_length_type_form:
         # default key
-        default: Was the length of the order given in weeks, months or years?
+        default: Was the length of the order given in days, weeks, months or years?
         # alternative keys defined with `i18_attribute`
-        detention_training_order: Was the length of the DTO given in weeks, months or years?
-        detention: Was the length of the detention given in weeks, months or years?
-        conditional_discharge: Was the length of the conditions given in weeks, months or years?
-        adult_conditional_discharge: Was the length of the conditions given in weeks, months or years?
-        adult_suspended_prison_sentence: Was the length of the sentence given in weeks, months or years?
-        adult_prison_sentence: Was the length of the sentence given in weeks, months or years?
-        adult_disqualification: Was the length of the disqualification given in weeks, months or years?
-        youth_disqualification: Was the length of the disqualification given in weeks, months or years?
-        adult_service_detention: Was the length of the detention given in weeks, months or years?
-        service_detention: Was the length of the detention given in weeks, months or years?
+        detention_training_order: Was the length of the DTO given in days, weeks, months or years?
+        detention: Was the length of the detention given in days, weeks, months or years?
+        conditional_discharge: Was the length of the conditions given in days, weeks, months or years?
+        adult_conditional_discharge: Was the length of the conditions given in days, weeks, months or years?
+        adult_suspended_prison_sentence: Was the length of the sentence given in days, weeks, months or years?
+        adult_prison_sentence: Was the length of the sentence given in days, weeks, months or years?
+        adult_disqualification: Was the length of the disqualification given in days, weeks, months or years?
+        youth_disqualification: Was the length of the disqualification given in days, weeks, months or years?
+        adult_service_detention: Was the length of the detention given in days, weeks, months or years?
+        service_detention: Was the length of the detention given in days, weeks, months or years?
       steps_conviction_conviction_length_form:
+        days: Number of days
         weeks: Number of weeks
         months: Number of months
         years: Number of years

--- a/config/locales/en/results.yml
+++ b/config/locales/en/results.yml
@@ -100,6 +100,7 @@ en:
     conviction_length:
       question: Length of sentence
       answers:
+        days: '%{length} days'
         weeks: '%{length} weeks'
         months: '%{length} months'
         years: '%{length} years'

--- a/features/adults/conviction_community_prevention_reparation.feature
+++ b/features/adults/conviction_community_prevention_reparation.feature
@@ -19,13 +19,13 @@ Feature: Conviction
 
     Examples:
       | subtype                        | known_date_header              | length_type_header                                           | length_header                     |
-      | Attendance centre order        | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
-      | Community order                | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
-      | Criminal behaviour order       | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
-      | Restraining order              | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
-      | Serious crime prevention order | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
-      | Sexual harm prevention order   | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
-      | Any other order with a requirement | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
+      | Attendance centre order        | When were you given the order? | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
+      | Community order                | When were you given the order? | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
+      | Criminal behaviour order       | When were you given the order? | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
+      | Restraining order              | When were you given the order? | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
+      | Serious crime prevention order | When were you given the order? | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
+      | Sexual harm prevention order   | When were you given the order? | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
+      | Any other order with a requirement | When were you given the order? | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
 
   Scenario: Adult community, reparation or other order with requirements - Reparation order
     Given I am completing a basic 18 or over "Community, reparation or other order with requirements" conviction

--- a/features/adults/conviction_custodial_sentence.feature
+++ b/features/adults/conviction_custodial_sentence.feature
@@ -30,8 +30,8 @@ Feature: Conviction
 
     Examples:
       | subtype                   | known_date_header            | length_type_header                                              | length_header                        | result                                           |
-      | Prison sentence           | When did the sentence start? | Was the length of the sentence given in weeks, months or years? | What was the length of the sentence? | This conviction will be spent on 21 October 2025 |
-      | Suspended prison sentence | When did the sentence start? | Was the length of the sentence given in weeks, months or years? | What was the length of the sentence? | This conviction will be spent on 21 October 2025 |
+      | Prison sentence           | When did the sentence start? | Was the length of the sentence given in days, weeks, months or years? | What was the length of the sentence? | This conviction will be spent on 21 October 2025 |
+      | Suspended prison sentence | When did the sentence start? | Was the length of the sentence given in days, weeks, months or years? | What was the length of the sentence? | This conviction will be spent on 21 October 2025 |
 
 
   @happy_path
@@ -55,7 +55,7 @@ Feature: Conviction
 
     Examples:
       | subtype        | known_date_header              | length_type_header                                           | length_header                     |
-      | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
+      | Hospital order | When were you given the order? | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
 
   @happy_path @date_travel
   Scenario Outline: Hospital orders (with no length or indefinite length)
@@ -76,5 +76,5 @@ Feature: Conviction
 
     Examples:
       | subtype        | known_date_header              | length_type_header                                           | length_type         | result                                                                             |
-      | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | No length was given | This conviction will be spent on 1 January 2022                                    |
-      | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
+      | Hospital order | When were you given the order? | Was the length of the order given in days, weeks, months or years? | No length was given | This conviction will be spent on 1 January 2022                                    |
+      | Hospital order | When were you given the order? | Was the length of the order given in days, weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |

--- a/features/adults/conviction_discharge.feature
+++ b/features/adults/conviction_discharge.feature
@@ -18,8 +18,8 @@ Feature: Conviction
 
   Examples:
     | subtype                | known_date_header                   | length_type_header                                                | length_header                         |
-    | Conditional discharge  | When were you given the discharge?  | Was the length of the conditions given in weeks, months or years? | What was the length of the discharge? |
-    | Bind over              | When were you given the order?      | Was the length of the order given in weeks, months or years?      | What was the length of the order?     |
+    | Conditional discharge  | When were you given the discharge?  | Was the length of the conditions given in days, weeks, months or years? | What was the length of the discharge? |
+    | Bind over              | When were you given the order?      | Was the length of the order given in days, weeks, months or years?      | What was the length of the order?     |
 
 
   @happy_path

--- a/features/adults/conviction_military.feature
+++ b/features/adults/conviction_military.feature
@@ -20,9 +20,9 @@ Feature: Conviction
 
     Examples:
     | subtype                  | length_type_header                                               | known_date_header                  | length_header                         |
-    | Overseas community order | Was the length of the order given in weeks, months or years?     | When were you given the order?     | What was the length of the order?     |
-    | Service community order  | Was the length of the order given in weeks, months or years?     | When were you given the order?     | What was the length of the order?     |
-    | Service detention        | Was the length of the detention given in weeks, months or years? | When were you given the detention? | What was the length of the detention? |
+    | Overseas community order | Was the length of the order given in days, weeks, months or years?     | When were you given the order?     | What was the length of the order?     |
+    | Service community order  | Was the length of the order given in days, weeks, months or years?     | When were you given the order?     | What was the length of the order?     |
+    | Service detention        | Was the length of the detention given in days, weeks, months or years? | When were you given the detention? | What was the length of the detention? |
 
   @happy_path
   Scenario Outline: Adult military convictions without length

--- a/features/adults/conviction_motoring.feature
+++ b/features/adults/conviction_motoring.feature
@@ -23,8 +23,8 @@ Feature: Adult Conviction
 
     Examples:
       | subtype          | known_date_header       | length_type_header                                                      | length_header                                | length_months | spent_date                                       |
-      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | This conviction will be spent on 1 January 2025  |
-      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 70            | This conviction will be spent on 1 November 2025 |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in days, weeks, months or years? | What was the length of the disqualification? | 6             | This conviction will be spent on 1 January 2025  |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in days, weeks, months or years? | What was the length of the disqualification? | 70            | This conviction will be spent on 1 November 2025 |
 
   @happy_path @date_travel
   Scenario Outline: Motoring disqualification without length or indefinite
@@ -42,8 +42,8 @@ Feature: Adult Conviction
 
     Examples:
       | subtype          | known_date_header       | length_type_header                                                      | length_option       | spent_date                                                                                          |
-      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | This conviction will be spent on 1 January 2025                                                     |
-      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in days, weeks, months or years? | No length was given | This conviction will be spent on 1 January 2025                                                     |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in days, weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
 
   @happy_path  @date_travel
   Scenario Outline: Motoring fine

--- a/features/multiples/change_answers.feature
+++ b/features/multiples/change_answers.feature
@@ -20,7 +20,7 @@ Feature: A person who made a mistake and wants to change their answers
      And I should see "5 August 2001"
 
     When I click the "Change length of sentence" link
-    Then I should see "Was the length of the order given in weeks, months or years?"
+    Then I should see "Was the length of the order given in days, weeks, months or years?"
      And I choose "Months"
      And I fill in "Number of months" with "15"
      And I click the "Continue" button

--- a/features/youth/conviction_custodial_sentence.feature
+++ b/features/youth/conviction_custodial_sentence.feature
@@ -30,8 +30,8 @@ Feature: Conviction
 
     Examples:
       | subtype                            | known_date_header             | length_type_header                                               | length_header                         | result                                        |
-      | Detention and training order (DTO) | When did the DTO start?       | Was the length of the DTO given in weeks, months or years?       | What was the length of the DTO?       | This conviction will be spent on 27 July 2023 |
-      | Detention                          | When did the detention start? | Was the length of the detention given in weeks, months or years? | What was the length of the detention? | This conviction will be spent on 27 July 2023 |
+      | Detention and training order (DTO) | When did the DTO start?       | Was the length of the DTO given in days, weeks, months or years?       | What was the length of the DTO?       | This conviction will be spent on 27 July 2023 |
+      | Detention                          | When did the detention start? | Was the length of the detention given in days, weeks, months or years? | What was the length of the detention? | This conviction will be spent on 27 July 2023 |
 
   @happy_path
   Scenario Outline: Hospital orders (non-bailable)
@@ -54,7 +54,7 @@ Feature: Conviction
 
     Examples:
       | subtype        | known_date_header              | length_type_header                                           | length_header                     |
-      | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
+      | Hospital order | When were you given the order? | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
 
   @happy_path @date_travel
   Scenario Outline: Hospital orders (with no length or indefinite length)
@@ -75,5 +75,5 @@ Feature: Conviction
 
     Examples:
       | subtype        | known_date_header              | length_type_header                                           | length_type         | result                                                                             |
-      | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | No length was given | This conviction will be spent on 1 January 2022                                    |
-      | Hospital order | When were you given the order? | Was the length of the order given in weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
+      | Hospital order | When were you given the order? | Was the length of the order given in days, weeks, months or years? | No length was given | This conviction will be spent on 1 January 2022                                    |
+      | Hospital order | When were you given the order? | Was the length of the order given in days, weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |

--- a/features/youth/conviction_discharge.feature
+++ b/features/youth/conviction_discharge.feature
@@ -10,7 +10,7 @@ Feature: Conviction
     And I should see "When were you given the order?"
 
     When I enter a valid date
-    Then I should see "Was the length of the order given in weeks, months or years?"
+    Then I should see "Was the length of the order given in days, weeks, months or years?"
     And I choose "Years"
 
     Then I should see "What was the length of the order?"
@@ -35,7 +35,7 @@ Feature: Conviction
     And I should see "When were you given the discharge?"
 
     When I enter a valid date
-    Then I should see "Was the length of the conditions given in weeks, months or years?"
+    Then I should see "Was the length of the conditions given in days, weeks, months or years?"
     And I choose "Years"
 
     Then I should see "What was the length of the discharge?"

--- a/features/youth/conviction_military.feature
+++ b/features/youth/conviction_military.feature
@@ -20,9 +20,9 @@ Feature: Conviction
 
     Examples:
       | subtype                  | length_type_header                                               | known_date_header                  | length_header                         |
-      | Overseas community order | Was the length of the order given in weeks, months or years?     | When were you given the order?     | What was the length of the order?     |
-      | Service community order  | Was the length of the order given in weeks, months or years?     | When were you given the order?     | What was the length of the order?     |
-      | Service detention        | Was the length of the detention given in weeks, months or years? | When were you given the detention? | What was the length of the detention? |
+      | Overseas community order | Was the length of the order given in days, weeks, months or years?     | When were you given the order?     | What was the length of the order?     |
+      | Service community order  | Was the length of the order given in days, weeks, months or years?     | When were you given the order?     | What was the length of the order?     |
+      | Service detention        | Was the length of the detention given in days, weeks, months or years? | When were you given the detention? | What was the length of the detention? |
 
   @happy_path
   Scenario Outline: Military convictions without length

--- a/features/youth/conviction_motoring.feature
+++ b/features/youth/conviction_motoring.feature
@@ -23,8 +23,8 @@ Feature: Youth Conviction
 
     Examples:
       | subtype          | known_date_header       | length_type_header                                                      | length_header                                | length_months | spent_date                                   |
-      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 6             | This conviction will be spent on 1 July 2022 |
-      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | What was the length of the disqualification? | 40            | This conviction will be spent on 1 May 2023  |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in days, weeks, months or years? | What was the length of the disqualification? | 6             | This conviction will be spent on 1 July 2022 |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in days, weeks, months or years? | What was the length of the disqualification? | 40            | This conviction will be spent on 1 May 2023  |
 
   @happy_path @date_travel
   Scenario Outline: Motoring disqualification without length or indefinite
@@ -42,8 +42,8 @@ Feature: Youth Conviction
 
     Examples:
       | subtype          | known_date_header       | length_type_header                                                      | length_option       | spent_date                                                                         |
-      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | No length was given | This conviction will be spent on 1 July 2022                                       |
-      | Disqualification | When did the ban start? | Was the length of the disqualification given in weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in days, weeks, months or years? | No length was given | This conviction will be spent on 1 July 2022                                       |
+      | Disqualification | When did the ban start? | Was the length of the disqualification given in days, weeks, months or years? | Until further order | This conviction is not spent and will stay in place until another order is made to change or end it |
 
   @happy_path @date_travel
   Scenario Outline: Motoring fine

--- a/features/youth/conviction_prevention_reparation.feature
+++ b/features/youth/conviction_prevention_reparation.feature
@@ -19,8 +19,8 @@ Feature: Conviction
 
     Examples:
       | subtype                 | known_date_header              | length_type_header                                           | length_header                          |
-      | Restraining order       | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order?      |
-      | Sexual harm prevention order | When were you given the order? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
+      | Restraining order       | When were you given the order? | Was the length of the order given in days, weeks, months or years? | What was the length of the order?      |
+      | Sexual harm prevention order | When were you given the order? | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
 
 
   Scenario: Prevention or reparation order - Reparation order

--- a/features/youth/conviction_referral_supervision_yro.feature
+++ b/features/youth/conviction_referral_supervision_yro.feature
@@ -18,6 +18,6 @@ Feature: Conviction
 
   Examples:
     | subtype                    | known_date_header                              | length_type_header                                           | length_header                     |
-    | Referral order             | What was the date of your first panel meeting? | Was the length of the order given in weeks, months or years? | What was the length of the order? |
-    | Supervision order          | When were you given the order?                 | Was the length of the order given in weeks, months or years? | What was the length of the order? |
-    | Youth rehabilitation order | When were you given the order?                 | Was the length of the order given in weeks, months or years? | What was the length of the order? |
+    | Referral order             | What was the date of your first panel meeting? | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
+    | Supervision order          | When were you given the order?                 | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |
+    | Youth rehabilitation order | When were you given the order?                 | Was the length of the order given in days, weeks, months or years? | What was the length of the order? |

--- a/spec/forms/steps/conviction/conviction_length_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_form_spec.rb
@@ -70,6 +70,19 @@ RSpec.describe Steps::Conviction::ConvictionLengthForm do
           end
         end
 
+        context 'when length is too long' do
+          let(:conviction_length) { described_class::HUNDRED_YEARS_IN_DAYS + 1 }
+
+          it 'returns false' do
+            expect(subject.save).to be(false)
+          end
+
+          it 'has a validation error on the field' do
+            expect(subject).to_not be_valid
+            expect(subject.errors.details[:conviction_length][0][:error]).to eq(:less_than)
+          end
+        end
+
         context 'length is not an whole number' do
           let(:conviction_length) { 1.5 }
 

--- a/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Steps::Conviction::ConvictionLengthTypeForm do
 
         expect(subject.values).to eq(
           [
+            ConvictionLengthType.new(:days),
             ConvictionLengthType.new(:weeks),
             ConvictionLengthType.new(:months),
             ConvictionLengthType.new(:years),
@@ -50,6 +51,8 @@ RSpec.describe Steps::Conviction::ConvictionLengthTypeForm do
 
         expect(subject.values).to eq(
           [
+
+            ConvictionLengthType.new(:days),
             ConvictionLengthType.new(:weeks),
             ConvictionLengthType.new(:months),
             ConvictionLengthType.new(:years),

--- a/spec/services/base_calculator_spec.rb
+++ b/spec/services/base_calculator_spec.rb
@@ -41,27 +41,54 @@ RSpec.describe BaseCalculator do
   end
 
   context '#sentence_distance_in_months' do
+    it 'in days' do
+      expect(subject.sentence_length_in_months(30, 'days')).to be < 1
+      expect(subject.sentence_length_in_months(31, 'days')).to be >= 1
+
+      # 2 months
+      expect(subject.sentence_length_in_months(60, 'days')).to be < 2
+      expect(subject.sentence_length_in_months(61, 'days')).to be >= 2
+
+      # 3 months
+      expect(subject.sentence_length_in_months(91, 'days')).to be < 3
+      expect(subject.sentence_length_in_months(92, 'days')).to be >= 3
+
+      # 6 months
+      expect(subject.sentence_length_in_months(182, 'days')).to be < 6
+      expect(subject.sentence_length_in_months(183, 'days')).to be >= 6
+
+      # 25 months
+      expect(subject.sentence_length_in_months(760, 'days')).to be < 25
+      expect(subject.sentence_length_in_months(761, 'days')).to be >= 25
+
+      # 30 months
+      expect(subject.sentence_length_in_months(913, 'days')).to be < 30
+      expect(subject.sentence_length_in_months(914, 'days')).to be >= 30
+    end
+
     it 'in weeks' do
       expect(subject.sentence_length_in_months(4, 'weeks')).to be < 1
       expect(subject.sentence_length_in_months(5, 'weeks')).to be >= 1
+
+      # 2 months
       expect(subject.sentence_length_in_months(8, 'weeks')).to be < 2
       expect(subject.sentence_length_in_months(9, 'weeks')).to be >= 2
 
       # 3 months
-      expect(subject.sentence_length_in_months(12, 'weeks')).to be < 3
-      expect(subject.sentence_length_in_months(13, 'weeks')).to be >= 3
+      expect(subject.sentence_length_in_months(13, 'weeks')).to be < 3
+      expect(subject.sentence_length_in_months(14, 'weeks')).to be >= 3
 
       # 6 months
-      expect(subject.sentence_length_in_months(25, 'weeks')).to be < 6
-      expect(subject.sentence_length_in_months(26, 'weeks')).to be >= 6
+      expect(subject.sentence_length_in_months(26, 'weeks')).to be < 6
+      expect(subject.sentence_length_in_months(27, 'weeks')).to be >= 6
 
       # 25 months
       expect(subject.sentence_length_in_months(108, 'weeks')).to be < 25
       expect(subject.sentence_length_in_months(109, 'weeks')).to be >= 25
 
       # 30 months
-      expect(subject.sentence_length_in_months(129, 'weeks')).to be < 30
-      expect(subject.sentence_length_in_months(130, 'weeks')).to be >= 30
+      expect(subject.sentence_length_in_months(130, 'weeks')).to be < 30
+      expect(subject.sentence_length_in_months(131, 'weeks')).to be >= 30
     end
 
     it 'in months' do

--- a/spec/services/conviction_length_choices_spec.rb
+++ b/spec/services/conviction_length_choices_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ConvictionLengthChoices do
 
   let(:all_choices) {
     [
+      ConvictionLengthType::DAYS,
       ConvictionLengthType::WEEKS,
       ConvictionLengthType::MONTHS,
       ConvictionLengthType::YEARS,
@@ -15,6 +16,7 @@ RSpec.describe ConvictionLengthChoices do
 
   let(:all_choices_except_no_length) {
     [
+      ConvictionLengthType::DAYS,
       ConvictionLengthType::WEEKS,
       ConvictionLengthType::MONTHS,
       ConvictionLengthType::YEARS,

--- a/spec/value_objects/conviction_length_type_spec.rb
+++ b/spec/value_objects/conviction_length_type_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe ConvictionLengthType do
   describe '#without_length?' do
     subject { described_class.new(value).without_length? }
 
+    context 'days' do
+      let(:value) { :days }
+
+      it { expect(subject).to eq(false) }
+    end
+
     context 'weeks' do
       let(:value) { :weeks }
       it { expect(subject).to eq(false) }
@@ -33,6 +39,7 @@ RSpec.describe ConvictionLengthType do
   describe '.values' do
     it 'returns all possible values' do
       expect(described_class.values.map(&:to_s)).to eq(%w(
+        days
         weeks
         months
         years


### PR DESCRIPTION
We have received feedback that sometimes courts give the sentence in days,
which means that users would have to convert those days into one of our options,
this is not ideal as it could prone users to introduce decimal numbers (which are not allowed).

So this commit allows users to introduce days, and internally we convert those days into months.

I've removed the conversion constants and replaced the calculations with ActiveSupport own methods.

The reason the specs have been changeds is that ActiveSupport calculates seconds per month,
so there's was a tiny discrepancy with the previous implementation, but nothing drastic (at least not in short periods of time)

```ruby
ActiveSupport::Duration::SECONDS_PER_MONTH

1.month.in_seconds
=> 2629746
```

## Question Page

![image](https://user-images.githubusercontent.com/136777/123289499-6f60c680-d508-11eb-9aa0-4af76fac0451.png)



## Results Page

![image](https://user-images.githubusercontent.com/136777/123289356-50facb00-d508-11eb-8743-3c3c3140224d.png)


Story: https://trello.com/c/DqoWLnHu