### PR TITLE
Improve handling of session on CYA page

### DIFF
--- a/app/controllers/concerns/completion_step.rb
+++ b/app/controllers/concerns/completion_step.rb
@@ -26,6 +26,12 @@ module CompletionStep
   # remove any incomplete checks as they don't serve any purpose now
   def purge_incomplete_checks
     current_disclosure_report.disclosure_checks.in_progress.destroy_all
+
+    # It could happen the current session was one of the purged
+    # incomplete checks, so this ensures we have a valid one again.
+    swap_disclosure_check_session(
+      current_disclosure_report.disclosure_checks.last.id
+    )
   end
 
   # Because transactions can be triggered more than once for the same report,

--- a/app/services/external_url.rb
+++ b/app/services/external_url.rb
@@ -2,7 +2,7 @@ class ExternalUrl
   GOVUK_TELL_EMPLOYER_EXTERNAL_URL = 'https://www.gov.uk/tell-employer-or-college-about-criminal-record/check-your-conviction-caution'.freeze
 
   class << self
-    def govuk_check_your_conviction_caution_url
+    def govuk_service_start_page
       GOVUK_TELL_EMPLOYER_EXTERNAL_URL
     end
   end

--- a/app/views/steps/check/kind/edit.html.erb
+++ b/app/views/steps/check/kind/edit.html.erb
@@ -1,5 +1,8 @@
 <% title t('.page_title') %>
-<% step_header(path: ExternalUrl.govuk_check_your_conviction_caution_url) %>
+<%
+  back_path = any_completed_checks? ? steps_check_check_your_answers_path : ExternalUrl.govuk_service_start_page
+  step_header(path: back_path)
+%>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/services/external_url_spec.rb
+++ b/spec/services/external_url_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe ExternalUrl do
-  describe '.govuk_check_your_conviction_caution_url' do
+  describe '.govuk_service_start_page' do
     it 'has the correct url' do
-      expect(described_class.govuk_check_your_conviction_caution_url).to eq(
+      expect(described_class.govuk_service_start_page).to eq(
         'https://www.gov.uk/tell-employer-or-college-about-criminal-record/check-your-conviction-caution'
       )
     end


### PR DESCRIPTION
Ticket: https://trello.com/c/gtvCFFpA

There was a nasty edge case where the session could become invalid (as in, pointing to a non-existing DB record) if, in the CYA, a user pressed any of the buttons to add a new sentence or a new caution/conviction but didn't complete this new journey, leaving an incomplete check (record) in the DB.

When returning to the CYA and pressing the `continue to results` button, then there is code to purge any incomplete checks from DB, purging also the record currently in the session and thus failing to render the results page (with the generic error `session expired`).

Fixed this by making sure after the purge of any incomplete checks, we re-assign an existing check back to the session from those in the report (the last one, but could be any, doesn't matter).

Also, as an improvement to this, if the user in the CYA press button to add a new caution/conviction, they will start a new journey but the `back` link would have take them to the govuk start page which is not the expected behaviour.
Now this back link will take them back to the CYA as expected.

There is something else to improve: when completing a few convictions, and in the CYA, clicking the header will not give the warning as usual and will wipe the session and start from scratch, which could be very annoying to somebody having entered many convictions already. Will be fixed/improved as a separate PR as is a bit unrelated to this one.