### PR TITLE
Show check in progress warning when on CYA

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,8 +8,8 @@ class HomeController < ApplicationController
   private
 
   def in_progress_enough?
-    current_disclosure_check&.in_progress? &&
-      current_disclosure_check.navigation_stack.size > 1
+    current_disclosure_report&.in_progress? &&
+      (current_disclosure_check.navigation_stack.size > 1 || helpers.any_completed_checks?)
   end
 
   def existing_disclosure_check_warning

--- a/app/controllers/warning_controller.rb
+++ b/app/controllers/warning_controller.rb
@@ -1,3 +1,5 @@
 class WarningController < ApplicationController
+  before_action :check_disclosure_check_presence
+
   def reset_session; end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,6 +64,10 @@ module ApplicationHelper
     current_disclosure_report.disclosure_checks.completed.any?
   end
 
+  def resume_check_path
+    current_disclosure_check.navigation_stack.last || root_path
+  end
+
   # Use this to feature-flag code that should only run/show on test environments
   def dev_tools_enabled?
     Rails.env.development? || ENV.key?('DEV_TOOLS_ENABLED')

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,9 @@
 <% end %>
 
 <% content_for(:service_name) do %>
-  <%= link_to service_name, root_path, class: 'govuk-header__link govuk-header__link--service-name ga-pageLink', data: {ga_category: 'header', ga_label: 'service name'} %>
+  <%= link_to service_name, root_path,
+              class: 'govuk-header__link govuk-header__link--service-name ga-pageLink',
+              data: { ga_category: 'header', ga_label: 'service name' }, id: 'header-service-name' %>
 <% end %>
 
 <% content_for(:phase_banner) do %>

--- a/app/views/warning/reset_session.html.erb
+++ b/app/views/warning/reset_session.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%=t '.heading' %></h1>
 
-    <%= link_button :resume_check, previous_step_path, class: 'govuk-button govuk-!-margin-right-3 ga-pageLink',
+    <%= link_button :resume_check, resume_check_path, class: 'govuk-button govuk-!-margin-right-3 ga-pageLink',
                     data: { module: 'govuk-button', ga_category: 'in progress warning', ga_label: 'resume check' } %>
 
     <%= link_button :restart_check, root_path(new: 'y'), class: 'govuk-button govuk-button--secondary ga-pageLink',

--- a/features/multiples/cautions_and_convictions.feature
+++ b/features/multiples/cautions_and_convictions.feature
@@ -50,8 +50,16 @@ Feature: A person with cautions and convictions
       And I choose "Months"
       And I fill in "Number of months" with "12"
      Then I click the "Continue" button
-
       And I should see "Check your answers"
+
+     # Check in progress warning quick smoke test
+     When I click the "header-service-name" link
+     Then I should see "It looks like you already have a check in progress"
+      And I should see a "Resume check" link to "/steps/check/check_your_answers"
+      And I should see a "Start a new check" link to "/?new=y"
+     When I click the "Resume check" link
+     Then I should see "Check your answers"
+
      Then I click the "Continue to your results" button
 
       And I should see "Caution 1"

--- a/spec/controllers/warning_controller_spec.rb
+++ b/spec/controllers/warning_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe WarningController, type: :controller do
+  before do
+    allow(controller).to receive(:current_disclosure_check).and_return(existing_disclosure_check)
+  end
+
+  describe '#reset_session' do
+    context 'when an existing check exists in session' do
+      let(:existing_disclosure_check) { DisclosureCheck.create(navigation_stack: []) }
+
+      it 'responds with HTTP success' do
+        get :reset_session, session: { disclosure_check_id: existing_disclosure_check.id }
+        expect(response).to render_template(:reset_session)
+      end
+    end
+
+    context 'when no check exists in session' do
+      let(:existing_disclosure_check) { nil }
+
+      it 'redirects to the invalid session error page' do
+        get :reset_session
+        expect(response).to redirect_to(invalid_session_errors_path)
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -168,6 +168,30 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#resume_check_path' do
+    let(:current_disclosure_check) { instance_double(DisclosureCheck, navigation_stack: navigation_stack) }
+
+    before do
+      allow(helper).to receive(:current_disclosure_check).and_return(current_disclosure_check)
+    end
+
+    context 'when the stack is empty' do
+      let(:navigation_stack) { [] }
+
+      it 'returns the root path' do
+        expect(helper.resume_check_path).to eq('/')
+      end
+    end
+
+    context 'when the stack has elements' do
+      let(:navigation_stack) { ['/somewhere', '/over', '/the', '/rainbow'] }
+
+      it 'returns the last element' do
+        expect(helper.resume_check_path).to eq('/rainbow')
+      end
+    end
+  end
+
   describe 'dev_tools_enabled?' do
     before do
       allow(Rails).to receive_message_chain(:env, :development?).and_return(development_env)


### PR DESCRIPTION
Ticket: https://trello.com/c/gtvCFFpA

Follow-up to PR #539 to fix/improve another issue, where the CYA didn't have the "check in progress" protection, so if a user had added let's say a few cautions/convictions in the basket and for some reason they click the header, it will just start a journey from the beginning, wiping from the session all previous entered cautions/convictions, which can be very frustrating.

This has been improved by not only checking for a "disclosure_check" record `in_progress` but also a disclosure_report, because when the user reach the CYA, the current disclosure_check is marked as completed and thus this is why the in progress warning wasn't showing.