### PR TITLE
Add a checks report to the back office

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,10 @@
 DATABASE_URL=postgresql://postgres@db/disclosure-checker
 SESSION_EXPIRES_IN_MINUTES=60
+
+# Uncomment this line to enable http credentials site-wise.
+# HTTP_AUTH_ENABLED=1
+
+# Following are the credentials, also used in the back office.
+# Even if the `HTTP_AUTH_ENABLED` is disabled, the back office still will use them.
+HTTP_AUTH_USER=test
+HTTP_AUTH_PASSWORD=test

--- a/app/controllers/backoffice/reports_controller.rb
+++ b/app/controllers/backoffice/reports_controller.rb
@@ -1,7 +1,7 @@
 module Backoffice
   class ReportsController < ApplicationController
     def index
-      # TODO
+      @reports = DisclosureReport.completed.reorder(completed_at: :desc).limit(50)
     end
   end
 end

--- a/app/views/backoffice/reports/_report_row.html.erb
+++ b/app/views/backoffice/reports/_report_row.html.erb
@@ -1,0 +1,17 @@
+<tr class="govuk-table__row">
+  <td class="govuk-table__cell">
+    <%= I18n.l(report.completed_at, format: :short) %>
+  </td>
+  <td class="govuk-table__cell">
+    <%= distance_of_time_in_words(report.created_at, report.completed_at) %>
+  </td>
+  <td class="govuk-table__cell">
+    <%= report.caution_checks.count %>
+  </td>
+  <td class="govuk-table__cell">
+    <%= report.conviction_checks.count %>
+  </td>
+  <td class="govuk-table__cell">
+    <%= link_to 'show ›', result_url(report), class: 'govuk-link', target: '_blank' %>
+  </td>
+</tr>

--- a/app/views/backoffice/reports/index.en.html.erb
+++ b/app/views/backoffice/reports/index.en.html.erb
@@ -1,3 +1,27 @@
 <% title 'Backoffice: Reports' %>
 
-<!-- TODO -->
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      Recent completed checks
+    </h1>
+
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Completed at</th>
+          <th scope="col" class="govuk-table__header">Duration</th>
+          <th scope="col" class="govuk-table__header">Cautions</th>
+          <th scope="col" class="govuk-table__header">Convictions</th>
+          <th scope="col" class="govuk-table__header">Results page</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        <% @reports.each do |report| %>
+          <%= render partial: 'report_row', locals: { report: report } %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>


### PR DESCRIPTION
Very simple, and using what we had already in place, report page in the back office, listing the last 50 completed reports, ordered by completion date, with some basic information and a link to show the results.

This is behind http auth credentials (same credentials as usual) and also is totally anonymous as we don't ask or collect any personal information.

It is just a starting point in case we want to extend/improve it. And is just a page we can remove if we don't use it or need it anymore.

<img width="1031" alt="Screenshot 2021-06-30 at 15 16 13" src="https://user-images.githubusercontent.com/687910/123976553-24d2c480-d9b6-11eb-972f-2b731e6164c0.png">
