### PR TITLE
Ability to sort the report by number of sentences

### DIFF
--- a/app/controllers/backoffice/reports_controller.rb
+++ b/app/controllers/backoffice/reports_controller.rb
@@ -1,7 +1,27 @@
 module Backoffice
   class ReportsController < ApplicationController
+    RESULTS_LIMIT = 50
+
     def index
-      @reports = DisclosureReport.completed.reorder(completed_at: :desc).limit(50)
+      @reports = if sort_by_sentences?
+                   completed_reports.sort_by(&:disclosure_checks_count).reverse.first(limit)
+                 else
+                   completed_reports.reorder(completed_at: :desc).limit(limit)
+                 end
+    end
+
+    private
+
+    def limit
+      RESULTS_LIMIT
+    end
+
+    def completed_reports
+      DisclosureReport.completed
+    end
+
+    def sort_by_sentences?
+      params[:sentences].presence
     end
   end
 end

--- a/app/models/disclosure_report.rb
+++ b/app/models/disclosure_report.rb
@@ -15,6 +15,10 @@ class DisclosureReport < ApplicationRecord
     update!(status: :completed, completed_at: Time.current)
   end
 
+  def disclosure_checks_count
+    disclosure_checks.count
+  end
+
   # Convenience methods to return collections of just one kind
   #
   def caution_checks

--- a/app/views/backoffice/reports/_report_row.html.erb
+++ b/app/views/backoffice/reports/_report_row.html.erb
@@ -9,7 +9,10 @@
     <%= report.caution_checks.count %>
   </td>
   <td class="govuk-table__cell">
-    <%= report.conviction_checks.count %>
+    <%= report.conviction_checks.group_by(&:check_group_id).count %>
+  </td>
+  <td class="govuk-table__cell">
+    <%= report.disclosure_checks_count %>
   </td>
   <td class="govuk-table__cell">
     <%= link_to 'show ›', result_url(report), class: 'govuk-link', target: '_blank' %>

--- a/app/views/backoffice/reports/index.en.html.erb
+++ b/app/views/backoffice/reports/index.en.html.erb
@@ -6,6 +6,12 @@
       Recent completed checks
     </h1>
 
+    <p class="govuk-body govuk-!-margin-bottom-6">
+      Order by:
+        <%= link_to 'completion date', backoffice_reports_path, class: 'govuk-link govuk-link--no-visited-state' %> |
+        <%= link_to 'number of sentences', backoffice_reports_path(sentences: 1), class: 'govuk-link govuk-link--no-visited-state' %>
+    </p>
+
     <table class="govuk-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
@@ -13,6 +19,7 @@
           <th scope="col" class="govuk-table__header">Duration</th>
           <th scope="col" class="govuk-table__header">Cautions</th>
           <th scope="col" class="govuk-table__header">Convictions</th>
+          <th scope="col" class="govuk-table__header">Sentences</th>
           <th scope="col" class="govuk-table__header">Results page</th>
         </tr>
       </thead>

--- a/spec/controllers/backoffice/reports_controller_spec.rb
+++ b/spec/controllers/backoffice/reports_controller_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe Backoffice::ReportsController, type: :controller do
     expect(response).to render_template(:index)
   end
 
+  it 'sorts by sentences' do
+    get :index, params: { sentences: 1 }
+    expect(response).to render_template(:index)
+  end
+
   context 'when using credentials' do
     before do
       allow(controller).to receive(:check_http_credentials).and_call_original

--- a/spec/models/disclosure_report_spec.rb
+++ b/spec/models/disclosure_report_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe DisclosureReport, type: :model do
     end
   end
 
+  describe '#disclosure_checks_count' do
+    let(:collection_scope) { double('collection') }
+
+    before do
+      allow(subject).to receive(:disclosure_checks).and_return(collection_scope)
+    end
+
+    it 'returns the count of records' do
+      expect(collection_scope).to receive(:count)
+      subject.disclosure_checks_count
+    end
+  end
+
   context 'convenience query methods' do
     let(:collection_scope) { double('collection') }
 


### PR DESCRIPTION
Just a small improvement so it is now possible to sort the completed reports by its number of sentences

This way is easier to find at the top those that are more interesting because have many convictions/sentences.

Added a new `sentences` column to the report table, because 1 conviction, can have more than 1 sentence. It also counts as sentence the cautions, although this is probably not technically correct, but for the purpose of the report it makes more sense.