### PR TITLE
Implement DBS recency rules

### DIFF
--- a/app/decorators/conviction_decorator.rb
+++ b/app/decorators/conviction_decorator.rb
@@ -16,6 +16,14 @@ module ConvictionDecorator
     ].include?(parent)
   end
 
+  def youth?
+    ConvictionType::YOUTH_PARENT_TYPES.include?(parent)
+  end
+
+  def adult?
+    ConvictionType::ADULT_PARENT_TYPES.include?(parent)
+  end
+
   #
   # Children conviction types
   #

--- a/app/presenters/dbs_visibility.rb
+++ b/app/presenters/dbs_visibility.rb
@@ -23,15 +23,18 @@ class DbsVisibility
   # Enhanced check rules:
   #
   #   - Unspent cautions/convictions: will appear on enhanced checks.
-  #   - Spent custodial convictions: will appear on enhanced checks.
   #   - Spent youth cautions: will not appear on enhanced checks.
-  #   - TODO: other spent convictions: TBD, for now we say 'may appear'.
+  #   - Spent custodial convictions: will appear on enhanced checks.
+  #   - Recency rules, refer to `#recent_caution_or_conviction?` method.
+  #   - Any other combination: may appear on enhanced checks.
   #
   def enhanced
     return :will unless spent?
-    return :will if custodial_conviction?
 
     return :will_not if youth_caution?
+
+    return :will if custodial_conviction?
+    return :will if recent_caution_or_conviction?
 
     :maybe
   end
@@ -42,11 +45,52 @@ class DbsVisibility
 
   private
 
+  def cautions
+    @_cautions ||= completed_checks.filter_map(&:caution)
+  end
+
+  def convictions
+    @_convictions ||= completed_checks.filter_map(&:conviction)
+  end
+
   def youth_caution?
-    completed_checks.filter_map(&:caution).any?(&:youth?)
+    cautions.any?(&:youth?)
+  end
+
+  def adult_caution?
+    cautions.any?(&:adult?)
+  end
+
+  def youth_conviction?
+    convictions.any?(&:youth?)
+  end
+
+  def adult_conviction?
+    convictions.any?(&:adult?)
   end
 
   def custodial_conviction?
-    completed_checks.filter_map(&:conviction).any?(&:custodial_sentence?)
+    convictions.any?(&:custodial_sentence?)
+  end
+
+  # Recency rules for spent cautions and convictions:
+  #
+  #   - Adult cautions given within 6 years of the check: will appear.
+  #   - Youth convictions imposed within 5.5 years of the check: will appear.
+  #   - Adult convictions imposed within 11 years of the check: will appear.
+  #
+  # Note: cautions always return just 1 date (`known_date`), but convictions
+  # could contain multiple orders or sentences, and these will share the same
+  # `conviction_date`, so it is safe to pick one, the first one for example.
+  #
+  def recent_caution_or_conviction?
+    known_date = completed_checks.pluck(:known_date).first # for cautions
+    conviction_date = completed_checks.pluck(:conviction_date).first # for convictions
+
+    return true if adult_caution?    && known_date.after?(6.years.ago)
+    return true if youth_conviction? && conviction_date.after?(66.months.ago) # 5 and 1/2 years
+    return true if adult_conviction? && conviction_date.after?(11.years.ago)
+
+    false
   end
 end

--- a/app/value_objects/caution_type.rb
+++ b/app/value_objects/caution_type.rb
@@ -22,6 +22,10 @@ class CautionType < ValueObject
     YOUTH_TYPES.include?(self)
   end
 
+  def adult?
+    ADULT_TYPES.include?(self)
+  end
+
   def calculator_class
     Calculators::CautionCalculator
   end

--- a/spec/decorators/conviction_decorator_spec.rb
+++ b/spec/decorators/conviction_decorator_spec.rb
@@ -1,6 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe ConvictionDecorator do
+  context 'youth?' do
+    context 'for a youth conviction' do
+      subject { ConvictionType::YOUTH_REHABILITATION_ORDER }
+      it { expect(subject.youth?).to eq(true) }
+    end
+
+    context 'for an adult conviction' do
+      subject { ConvictionType::ADULT_ABSOLUTE_DISCHARGE }
+      it { expect(subject.youth?).to eq(false) }
+    end
+  end
+
+  context 'adult?' do
+    context 'for a youth conviction' do
+      subject { ConvictionType::YOUTH_REHABILITATION_ORDER }
+      it { expect(subject.adult?).to eq(false) }
+    end
+
+    context 'for an adult conviction' do
+      subject { ConvictionType::ADULT_ABSOLUTE_DISCHARGE }
+      it { expect(subject.adult?).to eq(true) }
+    end
+  end
+
   context 'compensation?' do
     context 'for a conviction without compensation' do
       subject { ConvictionType::HOSPITAL_ORDER }

--- a/spec/value_objects/caution_type_spec.rb
+++ b/spec/value_objects/caution_type_spec.rb
@@ -86,6 +86,30 @@ RSpec.describe CautionType do
     end
   end
 
+  describe '#adult?' do
+    subject { described_class.new(value).adult? }
+
+    context 'adult_conditional_caution' do
+      let(:value) { :adult_conditional_caution }
+      it { expect(subject).to eq(true) }
+    end
+
+    context 'youth_conditional_caution' do
+      let(:value) { :youth_conditional_caution }
+      it { expect(subject).to eq(false) }
+    end
+
+    context 'adult_simple_caution' do
+      let(:value) { :adult_simple_caution }
+      it { expect(subject).to eq(true) }
+    end
+
+    context 'youth_simple_caution' do
+      let(:value) { :youth_simple_caution }
+      it { expect(subject).to eq(false) }
+    end
+  end
+
   describe '#calculator_class' do
     subject { described_class.new(:youth_conditional_caution) }
 


### PR DESCRIPTION
Ticket: https://trello.com/c/lK5NwwEM

In addition to the rules we already have for the enhanced DBS checks, we are now introducing the recency ones too, as follows:

```
- Adult cautions given within 6 years of the check: will appear.
- Youth convictions imposed within 5.5 years of the check: will appear.
- Adult convictions imposed within 11 years of the check: will appear.
```

This only affects some **spent caution/convictions**.

We keep saying `maybe` if none of the rules are triggered, as a precaution.

**Note**: pending copy updates in the results page to indicate the results are valid as of the day of the check. Will be done in a separate PR when we have confirmation.