### PR TITLE
Tweak DBS recency rules for older adult cautions

### DIFF
--- a/features/adults/caution.feature
+++ b/features/adults/caution.feature
@@ -18,7 +18,7 @@ Feature: Caution
     Then I should see "This caution is spent on the day you receive it"
 
      And I should see "This caution will not appear on a basic DBS check."
-     And I should see "This caution may appear on a standard or enhanced DBS check."
+     And I should see "This caution will not appear on a standard or enhanced DBS check."
 
   @happy_path
   Scenario: Over 18, conditional caution
@@ -34,4 +34,4 @@ Feature: Caution
     Then I should see "This caution was spent on 1 January 1999"
 
      And I should see "This caution will not appear on a basic DBS check."
-     And I should see "This caution may appear on a standard or enhanced DBS check."
+     And I should see "This caution will not appear on a standard or enhanced DBS check."

--- a/spec/presenters/dbs_visibility_spec.rb
+++ b/spec/presenters/dbs_visibility_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe DbsVisibility do
 
           context 'given more than 6 years ago' do
             let(:known_date) { 7.years.ago }
-            it { expect(subject.enhanced).to eq(:maybe) }
+            it { expect(subject.enhanced).to eq(:will_not) }
           end
         end
 


### PR DESCRIPTION
Follow-up to PR #547.

We are still awaiting confirmation but it is quite possible spent adult cautions given more than 6 years ago will not show in the standard or enhanced DBS check.

If given within 6 years they will appear.

More context in the slack convo: https://mojdt.slack.com/archives/CKZT0MY1G/p1627375025048900

As a consequence of this I had to do some refactor of the code but now it should be even more easier to read and follow and also easier to make changes in the future if needed.