### PR TITLE
Implement cookies permission banner - Part 2

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,4 +24,10 @@
 $(document).ready(function() {
   // Initialize custom modules
   moj.init();
+
+  // Cookie banner
+  var $cookieBanner = document.querySelector('[data-module="govuk-cookie-banner"]');
+  if ($cookieBanner) {
+    new CookieBanner($cookieBanner).init();
+  }
 });

--- a/app/assets/javascripts/modules/cookie-banner.js
+++ b/app/assets/javascripts/modules/cookie-banner.js
@@ -1,0 +1,28 @@
+'use strict';
+
+function nodeListForEach(nodes, callback) {
+  if (window.NodeList.prototype.forEach) {
+    return nodes.forEach(callback)
+  }
+  for (var i = 0; i < nodes.length; i++) {
+    callback.call(window, nodes[i], i, nodes)
+  }
+}
+
+function CookieBanner($module) {
+  this.$module = $module
+}
+
+CookieBanner.prototype.init = function() {
+  this.$cookieBanner = this.$module
+  this.$cookieBannerHideButtons = this.$module.querySelectorAll('.app--js-cookie-banner-hide')
+
+  nodeListForEach(this.$cookieBannerHideButtons, function($cookieBannerHideButton) {
+    $cookieBannerHideButton.addEventListener('click', this.hideBanner.bind(this))
+  }.bind(this))
+};
+
+CookieBanner.prototype.hideBanner = function(e) {
+  this.$cookieBanner.setAttribute('hidden', true)
+  e.preventDefault()
+};

--- a/app/views/layouts/_cookie_banner.html.erb
+++ b/app/views/layouts/_cookie_banner.html.erb
@@ -1,0 +1,29 @@
+<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="<%=t '.title', service_name: service_name %>" data-module="govuk-cookie-banner">
+  <div class="govuk-cookie-banner__message govuk-width-container" role="alert">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
+          <%=t '.title', service_name: service_name %>
+        </h2>
+
+        <div class="govuk-cookie-banner__content">
+          <%=t '.content_html' %>
+        </div>
+      </div>
+    </div>
+
+    <%= form_with url: cookies_path, method: :put do %>
+      <div class="govuk-button-group">
+        <button value="accept" type="submit" name="cookies" class="govuk-button" data-module="govuk-button">
+          <%=t '.accept_button' %>
+        </button>
+
+        <button value="reject" type="submit" name="cookies" class="govuk-button" data-module="govuk-button">
+          <%=t '.reject_button' %>
+        </button>
+
+        <%= link_to t('.cookies_link'), cookies_path, class: 'govuk-link ga-pageLink', data: { ga_category: 'cookie banner', ga_label: 'view cookies' } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/_cookie_banner_confirmation.html.erb
+++ b/app/views/layouts/_cookie_banner_confirmation.html.erb
@@ -1,0 +1,20 @@
+<div class="govuk-cookie-banner" data-nosnippet role="region" aria-label="<%= t '.title', service_name: service_name %>" data-module="govuk-cookie-banner">
+  <div class="govuk-cookie-banner__message govuk-width-container" role="alert">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <div class="govuk-cookie-banner__content">
+          <p class="govuk-body">
+            <%= t ".result.#{result}" %>
+            <%= t '.content_html', cookies_link: cookies_path %>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-button-group">
+      <a href="/" role="button" draggable="false" class="app--js-cookie-banner-hide govuk-button" data-module="govuk-button">
+        <%= t '.hide_button' %>
+      </a>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,16 @@
               data: { ga_category: 'header', ga_label: 'service name' }, id: 'header-service-name' %>
 <% end %>
 
+<% content_for(:cookie_banner) do %>
+  <% unless analytics_consent_cookie.present? %>
+    <%= render partial: 'layouts/cookie_banner' %>
+  <% end %>
+
+  <% if flash['cookies_consent_updated'] %>
+    <%= render partial: 'layouts/cookie_banner_confirmation', locals: { result: flash['cookies_consent_updated'] } %>
+  <% end %>
+<% end %>
+
 <% content_for(:phase_banner) do %>
   <%= render partial: 'layouts/phase_banner' %>
 <% end %>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -29,6 +29,8 @@
   document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>
 
+<%= yield(:cookie_banner) unless controller_name == 'cookies' %>
+
 <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">
   <%= content_for?(:skip_link_message) ? yield(:skip_link_message) : 'Skip to main content' %>
 </a>

--- a/config/locales/en/layouts.yml
+++ b/config/locales/en/layouts.yml
@@ -11,3 +11,20 @@ en:
     phase_banner:
       feedback:
         banner_html: This is a new service, <a href="%{link}" class="govuk-link govuk-link--no-visited-state">your feedback</a> will help us improve.
+    cookie_banner:
+      title: Cookies on %{service_name}
+      content_html: |
+        <p class="govuk-body">We use some essential cookies to make this service work.</p>
+        <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+      accept_button: Accept analytics cookies
+      reject_button: Reject analytics cookies
+      cookies_link: View cookies
+    cookie_banner_confirmation:
+      title: Cookies on %{service_name}
+      result:
+        accept: You’ve accepted analytics cookies.
+        reject: You’ve rejected analytics cookies.
+      content_html: |
+        You can <a href="%{cookies_link}" class="govuk-link ga-pageLink" data-ga-category="cookie banner"
+        data-ga-label="change cookies">change your cookie settings</a> at any time.
+      hide_button: Hide this message


### PR DESCRIPTION
Ticket: https://trello.com/c/i5IitID9

Follow-up to PR #564.

Show the cookies permission banner on page load, and hook the accept/reject buttons to the controller.

Add a bit of javascript to allow to close the banner without reloading the page.

This follows the guidelines and design stated in the design system:
https://design-system.service.gov.uk/components/cookie-banner/

In the next PR we will implement the cookies preferences in the cookies page and add cucumber tests.

<img width="1064" alt="Screenshot 2022-01-19 at 11 20 56" src="https://user-images.githubusercontent.com/687910/150120609-eeefe7d9-d417-496d-934d-10c5bd107c92.png">
