### PR TITLE
Avoid content repetition in results page

### DIFF
--- a/app/views/steps/check/results/shared/_dbs_visibility.html.erb
+++ b/app/views/steps/check/results/shared/_dbs_visibility.html.erb
@@ -3,7 +3,7 @@
   enhanced_result = dbs_visibility.enhanced
 
   content_for(
-    :dbs_maybe_explanation, t('dbs_maybe_explanation_html', scope: :results)
+    :dbs_maybe_explanation, t('dbs_maybe_explanation_html', scope: :results), flush: true
   ) if enhanced_result.eql?(:maybe)
 %>
 


### PR DESCRIPTION
Ticket: https://trello.com/c/qRnvt0Oy

The results page might repeat a whole chunk of copy if there were more than 1 caution or conviction that `may appear` on enhanced DBS.

Using `flush` fixes the problem and will only show the content once, even if `content_for` was called more than once.