### PR TITLE
Modify link anchor in results page

### DIFF
--- a/app/views/steps/check/results/show.en.html.erb
+++ b/app/views/steps/check/results/show.en.html.erb
@@ -33,7 +33,7 @@
 
     <%= render @presenter.summary %>
 
-    <h2 class="govuk-heading-l">Using your results</h2>
+    <h2 class="govuk-heading-l" id="disclosure-and-barring-service">Using your results</h2>
 
     <%= content_for(:dbs_maybe_explanation) %>
 
@@ -81,7 +81,7 @@
       </p>
     <% end %>
 
-    <h3 class="govuk-heading-m" id="disclosure-and-barring-service">Disclosure and Barring Service (DBS) checks</h3>
+    <h3 class="govuk-heading-m">Disclosure and Barring Service (DBS) checks</h3>
 
     <p class="govuk-body">
       DBS checks are criminal record checks.


### PR DESCRIPTION
Ticket: https://trello.com/c/8NJm6gNh

On the back of the above ticket, it was decided a quick and immediate action we can take is to modify the DBS links to go to the paragraph "Using your results" as otherwise users, specially on mobile devices might miss it and contains important information about the DBS.

Previously links would jump to the underneath section, skipping the "Using your results" paragraph that may contain important information depending on the DBS results.