### PR TITLE
Protect against some uninitialized objects

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,7 +61,8 @@ module ApplicationHelper
   end
 
   def any_completed_checks?
-    current_disclosure_report.disclosure_checks.completed.any?
+    current_disclosure_report &&
+      current_disclosure_report.disclosure_checks.completed.any?
   end
 
   def resume_check_path

--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -19,7 +19,7 @@ class ResultsPresenter < BasketPresenter
   end
 
   def motoring?
-    conviction_checks.map(&:conviction).any?(&:motoring?)
+    conviction_checks.map(&:conviction).compact.any?(&:motoring?)
   end
 
   def time_on_bail?


### PR DESCRIPTION
Ticket: https://trello.com/c/i6m6IrA2

This is part of the investigation to fix or mitigate some (very small in number) exceptions that are captured in Sentry.

These errors happen when a user (could be even a bot scanning the website) access a page after the session has ended and thus there was no protection against a potential `nil` object.

I might raise a separate PR for other kind of errors.