### PR TITLE
Add ECR images cleaner workflow

### DIFF
--- a/.github/workflows/ecr-images-cleaner.yml
+++ b/.github/workflows/ecr-images-cleaner.yml
@@ -1,0 +1,22 @@
+name: Cleanup ECR images
+on:
+  workflow_dispatch:
+  schedule:
+    # 8am every Sunday
+    - cron: '0 8 * * 0'
+
+jobs:
+  cleanup-script:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run ECR cleanup script
+        uses: ministryofjustice/ecr-images-cleaner-action@v1.0.1
+        with:
+          aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+          kube-cert: ${{ secrets.KUBE_PROD_CERT }}
+          kube-token: ${{ secrets.KUBE_PROD_TOKEN }}
+          kube-cluster: ${{ secrets.KUBE_PROD_CLUSTER }}
+          kube-namespace: ${{ secrets.KUBE_PROD_NAMESPACE }}
+          ecr-repo-name: family-justice/disclosure-checker
+          max-old-images-to-keep: 50


### PR DESCRIPTION
We come from #572 and #573 (now closed).

This is part of the work I've been doing for DEX Uhura (CT-3300) to come up with a reusable solution to delete old ECR images without risking deleting active images.

The repo for the action is here:
https://github.com/ministryofjustice/ecr-images-cleaner-action

This workflow will run on a schedule every Sunday at 8am, as well as it is possible to run it manually (once it is merged to `main` branch).

**It will delete images older than 30 days, that are not part of the replica set history for production namespace, but keeping a buffer of 50 images no matter how old they are.**