### PR TITLE
CDPT-393 Validate current disclosure check is valid for step

### DIFF
--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -101,4 +101,10 @@ class StepController < ApplicationController
     current_disclosure_check.navigation_stack = stack_until_current_page + [request.path]
     current_disclosure_check.save!
   end
+
+  def redirect_to_root
+    current_disclosure_check.navigation_stack.pop
+    current_disclosure_check.save
+    redirect_to root_path
+  end
 end

--- a/app/controllers/steps/caution_step_controller.rb
+++ b/app/controllers/steps/caution_step_controller.rb
@@ -1,6 +1,16 @@
 module Steps
   class CautionStepController < StepController
+    before_action :check_for_caution
+
     private
+
+    def check_for_caution
+      if current_disclosure_check.kind != "caution"
+        current_disclosure_check.navigation_stack.pop
+        current_disclosure_check.save
+        redirect_to root_path
+      end
+    end
 
     def decision_tree_class
       CautionDecisionTree

--- a/app/controllers/steps/caution_step_controller.rb
+++ b/app/controllers/steps/caution_step_controller.rb
@@ -5,7 +5,7 @@ module Steps
     private
 
     def invalid_kind?
-      current_disclosure_check.kind != 'caution'
+      current_disclosure_check.kind != CheckKind::CAUTION
     end
 
     def decision_tree_class

--- a/app/controllers/steps/caution_step_controller.rb
+++ b/app/controllers/steps/caution_step_controller.rb
@@ -1,15 +1,11 @@
 module Steps
   class CautionStepController < StepController
-    before_action :check_for_caution
+    before_action :redirect_to_root, if: :invalid_kind?
 
     private
 
-    def check_for_caution
-      if current_disclosure_check.kind != "caution"
-        current_disclosure_check.navigation_stack.pop
-        current_disclosure_check.save
-        redirect_to root_path
-      end
+    def invalid_kind?
+      current_disclosure_check.kind != "caution"
     end
 
     def decision_tree_class

--- a/app/controllers/steps/caution_step_controller.rb
+++ b/app/controllers/steps/caution_step_controller.rb
@@ -5,7 +5,7 @@ module Steps
     private
 
     def invalid_kind?
-      current_disclosure_check.kind != "caution"
+      current_disclosure_check.kind != 'caution'
     end
 
     def decision_tree_class

--- a/app/controllers/steps/caution_step_controller.rb
+++ b/app/controllers/steps/caution_step_controller.rb
@@ -5,7 +5,7 @@ module Steps
     private
 
     def invalid_kind?
-      current_disclosure_check.kind != CheckKind::CAUTION
+      current_disclosure_check.kind != CheckKind::CAUTION.to_s
     end
 
     def decision_tree_class

--- a/app/controllers/steps/conviction_step_controller.rb
+++ b/app/controllers/steps/conviction_step_controller.rb
@@ -5,7 +5,7 @@ module Steps
     private
 
     def invalid_kind?
-      current_disclosure_check.kind != "conviction"
+      current_disclosure_check.kind != 'conviction'
     end
 
     def decision_tree_class

--- a/app/controllers/steps/conviction_step_controller.rb
+++ b/app/controllers/steps/conviction_step_controller.rb
@@ -5,7 +5,7 @@ module Steps
     private
 
     def invalid_kind?
-      current_disclosure_check.kind != CheckKind::CONVICTION
+      current_disclosure_check.kind != CheckKind::CONVICTION.to_s
     end
 
     def decision_tree_class

--- a/app/controllers/steps/conviction_step_controller.rb
+++ b/app/controllers/steps/conviction_step_controller.rb
@@ -1,6 +1,16 @@
 module Steps
   class ConvictionStepController < StepController
+    before_action :check_for_conviction
+
     private
+
+    def check_for_conviction
+      if current_disclosure_check.kind != "conviction"
+        current_disclosure_check.navigation_stack.pop
+        current_disclosure_check.save
+        redirect_to root_path
+      end
+    end
 
     def decision_tree_class
       ConvictionDecisionTree

--- a/app/controllers/steps/conviction_step_controller.rb
+++ b/app/controllers/steps/conviction_step_controller.rb
@@ -5,7 +5,7 @@ module Steps
     private
 
     def invalid_kind?
-      current_disclosure_check.kind != 'conviction'
+      current_disclosure_check.kind != CheckKind::CONVICTION
     end
 
     def decision_tree_class

--- a/app/controllers/steps/conviction_step_controller.rb
+++ b/app/controllers/steps/conviction_step_controller.rb
@@ -1,15 +1,11 @@
 module Steps
   class ConvictionStepController < StepController
-    before_action :check_for_conviction
+    before_action :redirect_to_root, if: :invalid_kind?
 
     private
 
-    def check_for_conviction
-      if current_disclosure_check.kind != "conviction"
-        current_disclosure_check.navigation_stack.pop
-        current_disclosure_check.save
-        redirect_to root_path
-      end
+    def invalid_kind?
+      current_disclosure_check.kind != "conviction"
     end
 
     def decision_tree_class

--- a/spec/factories/disclosure_check.rb
+++ b/spec/factories/disclosure_check.rb
@@ -193,5 +193,9 @@ FactoryBot.define do
     trait :completed do
       status { :completed }
     end
+
+    trait :in_progress do
+      status { :in_progress }
+    end
   end
 end

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -163,6 +163,22 @@ RSpec.shared_examples 'an intermediate step controller' do |form_class, decision
           end
         end
       end
+
+      if decision_tree_class != CheckDecisionTree
+        context 'when disclosure_check record is the wrong type' do
+          let(:type) { decision_tree_class == CautionDecisionTree ? :conviction : :caution }
+
+          it 'removes visit from navigation stack' do
+            get :edit, session: { disclosure_check_id: existing_case.id }
+            expect(existing_case.navigation_stack).to be_empty
+          end
+
+          it 'responds with redirect' do
+            get :edit, session: { disclosure_check_id: existing_case.id }
+            expect(response).to redirect_to(root_path)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -133,7 +133,7 @@ RSpec.shared_examples 'an intermediate step controller' do |form_class, decision
     end
 
     context 'when a case exists in the session' do
-      let!(:existing_case) { DisclosureCheck.create(status: :in_progress) }
+      let!(:existing_case) { create(:disclosure_check, :caution, :in_progress) }
 
       it 'responds with HTTP success' do
         get :edit, session: { disclosure_check_id: existing_case.id }
@@ -153,7 +153,7 @@ RSpec.shared_examples 'an intermediate step controller' do |form_class, decision
         end
 
         context 'and the other record belongs to a different report' do
-          let!(:another_case) { DisclosureCheck.create(status: :completed) }
+          let!(:another_case) { create(:disclosure_check, :caution, :completed) }
 
           it 'raises a not found exception' do
             expect {
@@ -181,7 +181,7 @@ RSpec.shared_examples 'an intermediate step controller without update' do
     end
 
     context 'when a case exists in the session' do
-      let!(:existing_case) { DisclosureCheck.create(status: :in_progress) }
+      let!(:existing_case) { create(:disclosure_check, :caution, :in_progress) }
 
       it 'responds with HTTP success' do
         get :edit, session: { disclosure_check_id: existing_case.id }
@@ -207,7 +207,7 @@ RSpec.shared_examples 'a show step controller' do
     end
 
     context 'when a case exists in the session' do
-      let!(:existing_case) { DisclosureCheck.create }
+      let!(:existing_case) { create(:disclosure_check, :caution, :in_progress) }
 
       it 'responds with HTTP success' do
         get :show, session: { disclosure_check_id: existing_case.id }

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -88,7 +88,7 @@ RSpec.shared_examples 'a starting point step controller' do
     end
 
     context 'when a case exists in the session' do
-      let!(:existing_case) { create(:disclosure_check, type, navigation_stack: ['/not', '/empty']) }
+      let!(:existing_case) { create(:disclosure_check, :conviction, navigation_stack: ['/not', '/empty']) }
 
       it 'does not create a new case' do
         expect {

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -208,7 +208,7 @@ RSpec.shared_examples 'a show step controller' do
     end
 
     context 'when a case exists in the session' do
-      let!(:existing_case) { create(:disclosure_check, type, :in_progress) }
+      let!(:existing_case) { create(:disclosure_check, :conviction, :in_progress) }
 
       it 'responds with HTTP success' do
         get :show, session: { disclosure_check_id: existing_case.id }

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_class|
-  let(:type) { decision_tree_class.is_a?(CautionDecisionTree) ? :caution : :conviction }
+  let(:type) { decision_tree_class == CautionDecisionTree ? :caution : :conviction }
   describe '#update' do
     let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
     let(:form_class_params_name) { form_class.name.underscore }
@@ -88,7 +88,7 @@ RSpec.shared_examples 'a starting point step controller' do
     end
 
     context 'when a case exists in the session' do
-      let!(:existing_case) { create(:disclosure_check, navigation_stack: ['/not', '/empty']) }
+      let!(:existing_case) { create(:disclosure_check, type, navigation_stack: ['/not', '/empty']) }
 
       it 'does not create a new case' do
         expect {
@@ -117,7 +117,6 @@ RSpec.shared_examples 'a starting point step controller' do
 end
 
 RSpec.shared_examples 'an intermediate step controller' do |form_class, decision_tree_class|
-  let(:type) { decision_tree_class.is_a?(CautionDecisionTree) ? :caution : :conviction }
   include_examples 'a generic step controller', form_class, decision_tree_class
 
   describe '#edit' do


### PR DESCRIPTION
An exception can occur when a user reaches an invalid step for the current check. e.g. they reach a conviction step when it should be checking a caution. They are also not able to resume the previous check because the navigation stack is invalid.

To recreate:
1. Select "Cautioned" as the check type
2. Change the URL to `/steps/conviction/conviction_subtype`

The additional validation added means that if this occurs, the user will be redirected to the reset_session page which will allow them to start a new check, or resume the previous one. The invalid step is removed from the navigation stack so that they can continue.