### PR TITLE
Disable sentry running when not in production like environment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,7 @@ module Disclosure
     # Cookies permission banner
     config.x.cookies_consent_name = 'dc_cookies_consent'.freeze
     config.x.cookies_consent_expiration = 1.year
+
+    config.sentry_dsn = "https://d82ca719a5b246bf80342c2266fe7550@o345774.ingest.sentry.io/5373163"
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Disable Sentry
+  config.sentry_dsn = ""
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,4 +52,7 @@ Rails.application.configure do
 
   # Fake for tests. Set the real value in `config/application.rb`
   config.x.surveys.feedback = 'https://example.com'.freeze
+
+  # Disable Sentry
+  config.sentry_dsn = ""
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,5 @@
-# Will use SENTRY_DSN environment variable if set
 Sentry.init do |config|
-  config.dsn = "https://d82ca719a5b246bf80342c2266fe7550@o345774.ingest.sentry.io/5373163"
+  config.dsn = Rails.application.config.sentry_dsn
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 
   # Ensure we get ActionView::MissingTemplate errors


### PR DESCRIPTION
Don't send exceptions to sentry in test and local environments