### PR TITLE
Use short lived credentials for ECR

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -104,7 +104,7 @@ jobs:
             -t app .
 
       - name: Push to ECR
-      - run: |
+        run: |
           docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG, $REGISTRY/$REPOSITORY:staging.latest
         env:

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -107,8 +107,10 @@ jobs:
       - name: Push to ECR
         run: |
           docker tag ${{ vars.ECR_URL }}:${{ github.sha }} ${{ vars.ECR_URL }}:staging.latest
+          docker tag ${{ vars.ECR_URL }}:${{ github.sha }} ${{ vars.ECR_URL }}:production.latest
           docker push ${{ vars.ECR_URL }}:${{ github.sha }}
           docker push ${{ vars.ECR_URL }}:staging.latest
+          docker push ${{ vars.ECR_URL }}:production.latest
 
   deploy-staging:
     runs-on: ubuntu-latest
@@ -145,15 +147,6 @@ jobs:
       KUBE_NAMESPACE: ${{ secrets.KUBE_PROD_NAMESPACE }}
 
     steps:
-      - name: Pull from ECR
-        run: |
-          docker pull ${{ vars.ECR_URL }}:${{ github.sha }}
-
-      - name: Push to ECR
-        run: |
-          docker tag ${{ vars.ECR_URL }}:${{ github.sha }} ${{ vars.ECR_URL }}:production.latest
-          docker push ${{ vars.ECR_URL }}:production.latest
-
       - name: Authenticate to the cluster
         env:
           KUBE_CERT: ${{ secrets.KUBE_PROD_CERT }}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -105,8 +105,9 @@ jobs:
 
       - name: Push to ECR
         run: |
-          docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG $REGISTRY/$REPOSITORY:staging.latest
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker tag app $REGISTRY/$REPOSITORY:staging.latest
+          docker push app
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -101,18 +101,13 @@ jobs:
             --build-arg APP_BUILD_DATE=${{ env.BUILD_DATE }} \
             --build-arg APP_BUILD_TAG=${{ github.ref }} \
             --build-arg APP_GIT_COMMIT=${{ github.sha }} \
-            -t app .
+            -t ${{ vars.ECR_URL }}:${{ github.sha }} .
 
       - name: Push to ECR
         run: |
-          docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
-          docker tag app $REGISTRY/$REPOSITORY:staging.latest
-          docker push $REGISTRY/$REPOSITORY:staging.latest
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
-          IMAGE_TAG: ${{ github.sha }}
+          docker tag ${{ vars.ECR_URL }}:${{ github.sha }} ${{ vars.ECR_URL }}:staging.latest
+          docker push ${{ vars.ECR_URL }}:${{ github.sha }}
+          docker push ${{ vars.ECR_URL }}:staging.latest
 
   deploy-staging:
     runs-on: ubuntu-latest
@@ -138,7 +133,7 @@ jobs:
         run: |
           kubectl set image -n ${KUBE_NAMESPACE} \
           deployment/disclosure-checker-deployment-staging \
-          webapp="${{ secrets.ECR_URL }}:${{ github.sha }}"
+          webapp="${{ vars.ECR_URL }}:${{ github.sha }}"
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -151,25 +146,13 @@ jobs:
 
     steps:
       - name: Pull from ECR
-        id: ecr-pull
-        uses: jwalton/gh-ecr-push@v1.3.6
-        with:
-          access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
-          region: eu-west-2
-          direction: pull
-          local-image: app
-          image: ${{ secrets.ECR_NAME }}:${{ github.sha }}
+        run: |
+          docker pull ${{ vars.ECR_URL }}:${{ github.sha }}
 
       - name: Push to ECR
-        id: ecr-push
-        uses: jwalton/gh-ecr-push@v1.3.6
-        with:
-          access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
-          region: eu-west-2
-          local-image: app
-          image: ${{ secrets.ECR_NAME }}:production.latest
+        run: |
+          docker tag ${{ vars.ECR_URL }}:${{ github.sha }} ${{ vars.ECR_URL }}:production.latest
+          docker push ${{ vars.ECR_URL }}:production.latest
 
       - name: Authenticate to the cluster
         env:
@@ -187,4 +170,4 @@ jobs:
         run: |
           kubectl set image -n ${KUBE_NAMESPACE} \
           deployment/disclosure-checker-deployment-production \
-          webapp="${{ secrets.ECR_URL }}:${{ github.sha }}"
+          webapp="${{ vars.ECR_URL }}:${{ github.sha }}"

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag app $REGISTRY/$REPOSITORY:staging.latest
-          docker push -a $REGISTRY/$REPOSITORY:staging.latest
+          docker push $REGISTRY/$REPOSITORY:staging.latest
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -105,8 +105,8 @@ jobs:
 
       - name: Push to ECR
         run: |
-          docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG, $REGISTRY/$REPOSITORY:staging.latest
+          docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG $REGISTRY/$REPOSITORY:staging.latest
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag app $REGISTRY/$REPOSITORY:staging.latest
-          docker push app
+          docker push -a $REGISTRY/$REPOSITORY:staging.latest
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Push to ECR
         run: |
           docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker tag app $REGISTRY/$REPOSITORY:staging.latest
           docker push $REGISTRY/$REPOSITORY:staging.latest
         env:
@@ -136,7 +137,8 @@ jobs:
       - name: Rollout restart deployment
         run: |
           kubectl set image -n ${KUBE_NAMESPACE} \
-          deployment/disclosure-checker-deployment-staging
+          deployment/disclosure-checker-deployment-staging \
+          webapp="${{ secrets.ECR_URL }}:${{ github.sha }}"
 
   deploy-production:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -70,11 +70,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/main'
+
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Assume role in Cloud Platform
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.ECR_REGION }}
+
+      - name: Login to container repository
+        uses: aws-actions/amazon-ecr-login@v1
+        id: login-ecr
 
       - name: Store current date
         run: echo "BUILD_DATE=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
@@ -91,14 +104,13 @@ jobs:
             -t app .
 
       - name: Push to ECR
-        id: ecr
-        uses: jwalton/gh-ecr-push@v1.3.6
-        with:
-          access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
-          region: eu-west-2
-          local-image: app
-          image: ${{ secrets.ECR_NAME }}:${{ github.sha }}, ${{ secrets.ECR_NAME }}:staging.latest
+      - run: |
+          docker tag app $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG, $REGISTRY/$REPOSITORY:staging.latest
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
 
   deploy-staging:
     runs-on: ubuntu-latest
@@ -123,12 +135,12 @@ jobs:
       - name: Rollout restart deployment
         run: |
           kubectl set image -n ${KUBE_NAMESPACE} \
-          deployment/disclosure-checker-deployment-staging \
-          webapp="${{ secrets.ECR_URL }}:${{ github.sha }}"
+          deployment/disclosure-checker-deployment-staging
 
   deploy-production:
     runs-on: ubuntu-latest
     needs: deploy-staging
+    if: github.ref == 'refs/heads/main'
     environment: production
 
     env:

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -70,6 +70,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: test
+    if: github.ref == 'refs/heads/main'
 
     permissions:
       id-token: write # This is required for requesting the JWT
@@ -138,7 +139,6 @@ jobs:
   deploy-production:
     runs-on: ubuntu-latest
     needs: deploy-staging
-    if: github.ref == 'refs/heads/main'
     environment: production
 
     env:


### PR DESCRIPTION
The ECR_URL secret value has been deprecated and will go away at some point. I've created the repository variable `ECR_URL` to replace it (https://github.com/ministryofjustice/disclosure-checker/settings/variables/actions).