### PR TITLE
CDPT-967 Fix calculation bug

### DIFF
--- a/app/services/calculators/sentence_calculator.rb
+++ b/app/services/calculators/sentence_calculator.rb
@@ -74,7 +74,7 @@ module Calculators
       case conviction_length_in_months
       when 0..6
         self.class::REHABILITATION_1
-      when 7..30
+      when 6..30
         self.class::REHABILITATION_2
       else
         self.class::REHABILITATION_3


### PR DESCRIPTION
Sentence lengths over 6 months and below 7 months are not being caught correctly by the case statement.

NB: I have not added any tests for this fix as this code is changing anyway as part of the upcoming CDPT-954 changes.