### PR TITLE
CDPT-948 Add "Until further order" options

### DIFF
--- a/app/value_objects/conviction_type.rb
+++ b/app/value_objects/conviction_type.rb
@@ -48,7 +48,7 @@ class ConvictionType < ValueObject
     #
     REFERRAL_ORDER                     = new(:referral_order,                   parent: REFERRAL_SUPERVISION_YRO, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     SUPERVISION_ORDER                  = new(:supervision_order,                parent: REFERRAL_SUPERVISION_YRO, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
-    YOUTH_REHABILITATION_ORDER         = new(:youth_rehabilitation_order,       parent: REFERRAL_SUPERVISION_YRO, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
+    YOUTH_REHABILITATION_ORDER         = new(:youth_rehabilitation_order,       parent: REFERRAL_SUPERVISION_YRO, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusSixMonths),
 
     DETENTION_TRAINING_ORDER           = new(:detention_training_order,         parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::DetentionTraining),
     DETENTION                          = new(:detention,                        parent: CUSTODIAL_SENTENCE, calculator_class: Calculators::SentenceCalculator::Detention),
@@ -81,7 +81,7 @@ class ConvictionType < ValueObject
     ######################
 
     ADULT_ATTENDANCE_CENTRE_ORDER       = new(:adult_attendance_centre_order,      parent: ADULT_COMMUNITY_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
-    ADULT_COMMUNITY_ORDER               = new(:adult_community_order,              parent: ADULT_COMMUNITY_REPARATION, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
+    ADULT_COMMUNITY_ORDER               = new(:adult_community_order,              parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, calculator_class: Calculators::AdditionCalculator::PlusTwelveMonths),
     ADULT_CRIMINAL_BEHAVIOUR            = new(:adult_criminal_behaviour,           parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),
     ADULT_REPARATION_ORDER              = new(:adult_reparation_order,             parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, skip_length: true, calculator_class: Calculators::ImmediatelyCalculator),
     ADULT_RESTRAINING_ORDER             = new(:adult_restraining_order,            parent: ADULT_COMMUNITY_REPARATION, relevant_order: true, drag_through: true, calculator_class: Calculators::AdditionCalculator::PlusZeroMonths),

--- a/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
+++ b/spec/forms/steps/conviction/conviction_length_type_form_spec.rb
@@ -25,10 +25,12 @@ RSpec.describe Steps::Conviction::ConvictionLengthTypeForm do
   # the spec `spec/services/conviction_length_choices_spec.rb`
   #
   describe "#values" do
-    context "when a `Youth rehabilitation order`" do
+    context "when a `Youth supervision order`" do
+      let(:conviction_subtype) { ConvictionType::SUPERVISION_ORDER.to_s }
+
       it "includes `no_length` in the values" do
         expect(ConvictionLengthChoices).to receive(:choices).with(
-          conviction_subtype: ConvictionType::YOUTH_REHABILITATION_ORDER,
+          conviction_subtype: ConvictionType::SUPERVISION_ORDER,
         ).and_call_original
 
         expect(form.values).to eq(

--- a/spec/value_objects/conviction_type_spec.rb
+++ b/spec/value_objects/conviction_type_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe ConvictionType do
       let(:subtype) { "youth_rehabilitation_order" }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.relevant_order?).to eq(false) }
+      it { expect(conviction_type.relevant_order?).to eq(true) }
       it { expect(conviction_type.drag_through?).to eq(false) }
       it { expect(conviction_type.schedule_18_offence?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusSixMonths) }
@@ -404,7 +404,7 @@ RSpec.describe ConvictionType do
       let(:subtype) { "adult_community_order" }
 
       it { expect(conviction_type.skip_length?).to eq(false) }
-      it { expect(conviction_type.relevant_order?).to eq(false) }
+      it { expect(conviction_type.relevant_order?).to eq(true) }
       it { expect(conviction_type.drag_through?).to eq(false) }
       it { expect(conviction_type.schedule_18_offence?).to eq(false) }
       it { expect(conviction_type.calculator_class).to eq(Calculators::AdditionCalculator::PlusTwelveMonths) }


### PR DESCRIPTION
Makes Youth Community Order and Adult Community Orders relevant orders which "until further order" option to appear.
<img width="679" alt="Screenshot 2023-09-22 at 16 39 47" src="https://github.com/ministryofjustice/disclosure-checker/assets/1190196/9dd6e240-a59e-4411-8eed-e970b13f6338">
