### PR TITLE
CDPT-1133 Fix multiple sentence bug

### DIFF
--- a/app/services/calculators/multiples/proceedings.rb
+++ b/app/services/calculators/multiples/proceedings.rb
@@ -10,16 +10,11 @@ module Calculators
       end
 
       def spent_date
-        return ResultsVariant::NEVER_SPENT if expiry_dates.include?(ResultsVariant::NEVER_SPENT)
-        return ResultsVariant::INDEFINITE  if expiry_dates.include?(ResultsVariant::INDEFINITE)
-
-        # Pick the latest date in the collection
-        # If there is only one sentence then it returns that date
-        expiry_dates.max
+        max_expiry(expiry_dates)
       end
 
       def spent_date_without_relevant_orders
-        non_relevant_expiry_dates.max
+        max_expiry(non_relevant_expiry_dates)
       end
 
       def spent?
@@ -43,6 +38,15 @@ module Calculators
       delegate :conviction_date, to: :first_disclosure_check
 
     private
+
+      def max_expiry(expiry_dates)
+        return ResultsVariant::NEVER_SPENT if expiry_dates.include?(ResultsVariant::NEVER_SPENT)
+        return ResultsVariant::INDEFINITE  if expiry_dates.include?(ResultsVariant::INDEFINITE)
+
+        # Pick the latest date in the collection
+        # If there is only one sentence then it returns that date
+        expiry_dates.max
+      end
 
       def disclosure_checks
         @disclosure_checks ||= check_group.disclosure_checks.completed

--- a/spec/services/calculators/multiples/proceedings_spec.rb
+++ b/spec/services/calculators/multiples/proceedings_spec.rb
@@ -143,5 +143,18 @@ RSpec.describe Calculators::Multiples::Proceedings do
         end
       end
     end
+
+    context "when there is at least one `never_spent` date" do
+      let(:disclosure_checks_scope) { instance_double("scope", completed: [disclosure_check1, disclosure_check2]) }
+
+      before do
+        allow(CheckResult).to receive(:new).with(disclosure_check: disclosure_check1).and_return(check_result1)
+        allow(CheckResult).to receive(:new).with(disclosure_check: disclosure_check2).and_return(check_never_spent)
+      end
+
+      it "returns `never_spent`" do
+        expect(calculator.spent_date_without_relevant_orders).to eq(ResultsVariant::NEVER_SPENT)
+      end
+    end
   end
 end


### PR DESCRIPTION
Handles comparison when NEVER_SPENT or INDEFINITE is present. 

`spent_date` and `spent_date_without_relevant_orders` methods now work the same way.