### PR TITLE
Fix error page when DB is down

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
 <% end %>
 
 <% if dev_tools_enabled? %>
-  <%= render partial: 'layouts/developer_tools' if current_disclosure_report.try(:completed?) %>
+  <%= render partial: 'layouts/developer_tools' if controller_name != "errors" && current_disclosure_report.try(:completed?) %>
 <% end %>
 
 <%= render template: 'layouts/govuk_template', layout: false %>


### PR DESCRIPTION
Allow error page to work when dev_tools_enabled? is enabled and the database is not working.