### PR TITLE
Add permissions for each deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,10 @@ jobs:
     needs: build
     environment: staging
 
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
+
     env:
       KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
 
@@ -143,6 +147,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment: qa
+
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
 
     env:
       KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
@@ -227,6 +235,10 @@ jobs:
     needs: deploy-staging
     if: ${{ github.ref == 'refs/heads/main' }}
     environment: production
+
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
 
     env:
       KUBE_NAMESPACE: ${{ secrets.KUBE_PROD_NAMESPACE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,7 @@ jobs:
 
       - name: Tag build and push to ECR
         run: |
+          docker pull ${{ vars.ECR_URL }}:$SHA
           docker tag ${{ vars.ECR_URL }}:$SHA ${{ vars.ECR_URL }}:staging.latest
           docker push ${{ vars.ECR_URL }}:staging.latest
 
@@ -181,6 +182,7 @@ jobs:
 
       - name: Tag build and push to ECR
         run: |
+          docker pull ${{ vars.ECR_URL }}:$SHA
           docker tag ${{ vars.ECR_URL }}:$SHA ${{ vars.ECR_URL }}:qa.latest
           docker push ${{ vars.ECR_URL }}:qa.latest
 
@@ -268,6 +270,7 @@ jobs:
 
       - name: Tag build and push to ECR
         run: |
+          docker pull ${{ vars.ECR_URL }}:$SHA
           docker tag ${{ vars.ECR_URL }}:$SHA ${{ vars.ECR_URL }}:production.latest
           docker push ${{ vars.ECR_URL }}:production.latest
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,7 @@ jobs:
 
       - name: Tag build and push to ECR
         run: |
+          docker pull ${{ vars.ECR_URL }}:$SHA
           docker tag ${{ vars.ECR_URL }}:$SHA ${{ vars.ECR_URL }}:staging.latest
           docker push ${{ vars.ECR_URL }}:staging.latest
 
@@ -179,6 +180,7 @@ jobs:
 
       - name: Tag build and push to ECR
         run: |
+          docker pull ${{ vars.ECR_URL }}:$SHA
           docker tag ${{ vars.ECR_URL }}:$SHA ${{ vars.ECR_URL }}:qa.latest
           docker push ${{ vars.ECR_URL }}:qa.latest
 
@@ -267,6 +269,7 @@ jobs:
 
       - name: Tag build and push to ECR
         run: |
+          docker pull ${{ vars.ECR_URL }}:$SHA
           docker tag ${{ vars.ECR_URL }}:$SHA ${{ vars.ECR_URL }}:production.latest
           docker push ${{ vars.ECR_URL }}:production.latest
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,9 @@ jobs:
 
     env:
       KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+      KUBE_CERT: ${{ secrets.KUBE_CERT }}
+      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
 
     steps:
       - name: Checkout
@@ -92,15 +95,10 @@ jobs:
 
       - name: Tag build and push to ECR
         run: |
-          docker pull ${{ vars.ECR_URL }}:$SHA
           docker tag ${{ vars.ECR_URL }}:$SHA ${{ vars.ECR_URL }}:staging.latest
           docker push ${{ vars.ECR_URL }}:staging.latest
 
       - name: Authenticate to the cluster
-        env:
-          KUBE_CERT: ${{ secrets.KUBE_CERT }}
-          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
         run: |
           echo "${KUBE_CERT}" > ca.crt
           kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
@@ -111,7 +109,7 @@ jobs:
       - name: Rollout restart deployment
         run: |
           kubectl set image -n ${KUBE_NAMESPACE} \
-          config/kubernetes/staging \
+          deployment/disclosure-checker-staging \
           webapp="${{ vars.ECR_URL }}:$SHA"
 
       - name: Send deploy notification to product Slack channel
@@ -155,6 +153,9 @@ jobs:
 
     env:
       KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+      KUBE_CERT: ${{ secrets.KUBE_CERT }}
+      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
 
     steps:
       - name: Checkout
@@ -180,15 +181,10 @@ jobs:
 
       - name: Tag build and push to ECR
         run: |
-          docker pull ${{ vars.ECR_URL }}:$SHA
           docker tag ${{ vars.ECR_URL }}:$SHA ${{ vars.ECR_URL }}:qa.latest
           docker push ${{ vars.ECR_URL }}:qa.latest
 
       - name: Authenticate to the cluster
-        env:
-          KUBE_CERT: ${{ secrets.KUBE_CERT }}
-          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
         run: |
           echo "${KUBE_CERT}" > ca.crt
           kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
@@ -199,7 +195,7 @@ jobs:
       - name: Rollout restart deployment
         run: |
           kubectl set image -n ${KUBE_NAMESPACE} \
-          config/kubernetes/qa \
+          deployment/disclosure-checker-qa \
           webapp="${{ vars.ECR_URL }}:$SHA"
 
       - name: Send deploy notification to product Slack channel
@@ -243,7 +239,10 @@ jobs:
       contents: read  # This is required for actions/checkout
 
     env:
-      KUBE_NAMESPACE: ${{ secrets.KUBE_PROD_NAMESPACE }}
+      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+      KUBE_CERT: ${{ secrets.KUBE_CERT }}
+      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
 
     steps:
       - name: Checkout
@@ -269,15 +268,10 @@ jobs:
 
       - name: Tag build and push to ECR
         run: |
-          docker pull ${{ vars.ECR_URL }}:$SHA
           docker tag ${{ vars.ECR_URL }}:$SHA ${{ vars.ECR_URL }}:production.latest
           docker push ${{ vars.ECR_URL }}:production.latest
 
       - name: Authenticate to the cluster
-        env:
-          KUBE_CERT: ${{ secrets.KUBE_PROD_CERT }}
-          KUBE_TOKEN: ${{ secrets.KUBE_PROD_TOKEN }}
-          KUBE_CLUSTER: ${{ secrets.KUBE_PROD_CLUSTER }}
         run: |
           echo "${KUBE_CERT}" > ca.crt
           kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
@@ -288,7 +282,7 @@ jobs:
       - name: Rollout restart deployment
         run: |
           kubectl set image -n ${KUBE_NAMESPACE} \
-          config/kubernetes/production \
+          deployment/disclosure-checker-production \
           webapp="${{ vars.ECR_URL }}:$SHA"
 
       - name: Send deploy notification to product Slack channel

--- a/config/kubernetes/production/deployment.yml
+++ b/config/kubernetes/production/deployment.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: disclosure-checker-deployment-production
+  name: disclosure-checker-production
   namespace: disclosure-checker-production
 spec:
   replicas: 2

--- a/config/kubernetes/production/deployment.yml
+++ b/config/kubernetes/production/deployment.yml
@@ -4,7 +4,7 @@ metadata:
   name: disclosure-checker-production
   namespace: disclosure-checker-production
 spec:
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate

--- a/config/kubernetes/qa/deployment.yml
+++ b/config/kubernetes/qa/deployment.yml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: disclosure-checker-deployment-qa
+  name: disclosure-checker-qa
   namespace: disclosure-checker-qa
 spec:
-  replicas: 2
+  replicas: 1
   revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate
@@ -35,7 +35,7 @@ spec:
             memory: 1Gi
         readinessProbe:
           httpGet:
-            path: /ping.json
+            path: /health
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto
@@ -46,7 +46,7 @@ spec:
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /ping.json
+            path: /health
             port: 3000
             httpHeaders:
               - name: X-Forwarded-Proto

--- a/config/kubernetes/staging/deployment.yml
+++ b/config/kubernetes/staging/deployment.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: disclosure-checker-deployment-staging
+  name: disclosure-checker-staging
   namespace: disclosure-checker-staging
 spec:
   replicas: 2

--- a/config/kubernetes/staging/deployment.yml
+++ b/config/kubernetes/staging/deployment.yml
@@ -4,7 +4,7 @@ metadata:
   name: disclosure-checker-staging
   namespace: disclosure-checker-staging
 spec:
-  replicas: 2
+  replicas: 1
   revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
Add permission, and pull image before re-tagging.
Also uses per environment variables that are now been set from cloud platform and updates replica numbers per environment.