### PR TITLE
CDPT-1952 Enable modsec detection mode on production

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -6,6 +6,11 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: disclosure-checker-ingress-production-disclosure-checker-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=disclosure-checker-production"
     nginx.ingress.kubernetes.io/server-snippet: |
       location ~* \.(php|cgi|xml)$ {
         deny all; access_log off;
@@ -17,7 +22,7 @@ metadata:
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
       }
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
   - hosts:
     - disclosure-checker-production.apps.live.cloud-platform.service.justice.gov.uk

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -1,10 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: disclosure-checker-ingress-production
+  name: disclosure-checker-ingress-modsec-production
   namespace: disclosure-checker-production
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: disclosure-checker-ingress-production-disclosure-checker-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: disclosure-checker-ingress-modsec-production-disclosure-checker-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |


### PR DESCRIPTION
## Description
Enables [modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) in detection mode on production so we can be aware of any issues and evaluate if more protection is required.