### PR TITLE
CDPT-2298 Change ordering of hint text for screen readers

### DIFF
--- a/app/helpers/custom_form_helpers.rb
+++ b/app/helpers/custom_form_helpers.rb
@@ -21,6 +21,13 @@ module CustomFormHelpers
     )
   end
 
+  def i18n_date_hint(lead_text = i18n_lead_text)
+    safe_join([
+      content_tag(:p, lead_text),
+      I18n.t("helpers/dictionary.date_hint_text").html_safe,
+    ])
+  end
+
   # Used to customise hints when reusing the same view
   # Hints support markup so ensure locale keys ends with `_html`
   def i18n_hint

--- a/app/views/steps/caution/conditional_end_date/edit.html.erb
+++ b/app/views/steps/caution/conditional_end_date/edit.html.erb
@@ -6,9 +6,10 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_date_field :conditional_end_date, maxlength_enabled: true, form_group: { class: 'app-util--compact-form-group' } do
-        tag.p t('.lead_text'), class: 'govuk-body-m'
-      end %>
+      <%= f.govuk_date_field :conditional_end_date, maxlength_enabled: true,
+        form_group: { class: 'app-util--compact-form-group' },
+        hint: { text: f.i18n_date_hint(t('.lead_text')) }
+      %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_conditional_end_date

--- a/app/views/steps/conviction/compensation_payment_date/edit.html.erb
+++ b/app/views/steps/conviction/compensation_payment_date/edit.html.erb
@@ -8,9 +8,9 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_date_field :compensation_payment_date, maxlength_enabled: true,
           form_group: { class: 'app-util--compact-form-group' },
-          caption: { text: f.i18n_caption } do
-        tag.p t('.lead_text'), class: 'govuk-body-m'
-      end %>
+          caption: { text: f.i18n_caption },
+          hint: { text: f.i18n_date_hint(t('.lead_text')) }
+      %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_compensation_payment_date

--- a/app/views/steps/conviction/conviction_date/edit.html.erb
+++ b/app/views/steps/conviction/conviction_date/edit.html.erb
@@ -6,9 +6,10 @@
     <%= govuk_error_summary %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_date_field :conviction_date, maxlength_enabled: true, form_group: { class: 'app-util--compact-form-group' } do
-        tag.p t('.lead_text'), class: 'govuk-body-m'
-      end %>
+      <%= f.govuk_date_field :conviction_date, maxlength_enabled: true,
+        form_group: { class: 'app-util--compact-form-group' },
+        hint: { text: f.i18n_date_hint(t('.lead_text')) }
+      %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {
         form: f, attribute: :approximate_conviction_date

--- a/app/views/steps/conviction/known_date/edit.html.erb
+++ b/app/views/steps/conviction/known_date/edit.html.erb
@@ -8,9 +8,9 @@
     <%= step_form @form_object do |f| %>
       <%= f.govuk_date_field :known_date, maxlength_enabled: true,
             form_group: { class: 'app-util--compact-form-group' },
+            hint: { text: f.i18n_date_hint },
             legend: { text: f.i18n_legend },
             caption: { text: f.i18n_caption } do
-        tag.p f.i18n_lead_text, class: 'govuk-body-m'
       end %>
 
       <%= render partial: 'steps/shared/approx_date_checkbox', locals: {

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -177,14 +177,6 @@ en:
       steps_check_under_age_form:
         caution_html: Select your age when you got the caution, not when you committed the offence
         conviction_html: Select your age when you got convicted, not when you committed the offence
-      steps_caution_conditional_end_date_form:
-        conditional_end_date_html: *date_hint_text
-      steps_conviction_conviction_date_form:
-        conviction_date_html: *date_hint_text
-      steps_conviction_known_date_form:
-        known_date_html: *date_hint_text
-      steps_conviction_compensation_payment_date_form:
-        compensation_payment_date_html: *date_hint_text
       steps_conviction_motoring_endorsement_form:
         motoring_endorsement: An endorsement means that your conviction is recorded on your driving licence. Endorsements are usually given by courts.
       steps_conviction_conviction_subtype_form:

--- a/features/fixtures/files/steps_conviction_known_date.html
+++ b/features/fixtures/files/steps_conviction_known_date.html
@@ -4,13 +4,12 @@
       <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
     </legend>
 
-    <div id="steps-conviction-known-date-form-known-date-supplemental">
-      <p class="govuk-body-m">This is usually the day you were convicted in court.</p>
-    </div>
+<div id="steps-conviction-known-date-form-known-date-supplemental"><p class="govuk-body-m">This is usually the day you were convicted in court.
+</p></div>
 
-    <div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
-      <p>For example, 23 9 2018</p>
-    </div>
+<div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
+<p>For example, 23 9 2018</p>
+</div>
 
     <div class="govuk-date-input">
       <div class="govuk-date-input__item">

--- a/features/fixtures/files/steps_conviction_known_date.html
+++ b/features/fixtures/files/steps_conviction_known_date.html
@@ -4,12 +4,13 @@
       <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
     </legend>
 
-<div id="steps-conviction-known-date-form-known-date-supplemental"><p class="govuk-body-m">This is usually the day you were convicted in court.
-</p></div>
+    <div id="steps-conviction-known-date-form-known-date-supplemental">
+      <p class="govuk-body-m">This is usually the day you were convicted in court.</p>
+    </div>
 
-<div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
-<p>For example, 23 9 2018</p>
-</div>
+    <div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
+      <p>For example, 23 9 2018</p>
+    </div>
 
     <div class="govuk-date-input">
       <div class="govuk-date-input__item">

--- a/features/fixtures/files/steps_conviction_known_date.html
+++ b/features/fixtures/files/steps_conviction_known_date.html
@@ -1,13 +1,12 @@
 <div class="govuk-form-group app-util--compact-form-group">
-  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-supplemental steps-conviction-known-date-form-known-date-hint">
+  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-hint">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
     </legend>
 
-<div id="steps-conviction-known-date-form-known-date-supplemental"><p class="govuk-body-m">This is usually the day you were convicted in court.
-</p></div>
-
-<div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
+<div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">
+<p>This is usually the day you were convicted in court.
+</p>If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
 <p>For example, 23 9 2018</p>
 </div>
 

--- a/features/fixtures/files/steps_conviction_known_date.html
+++ b/features/fixtures/files/steps_conviction_known_date.html
@@ -1,5 +1,5 @@
 <div class="govuk-form-group app-util--compact-form-group">
-  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-hint steps-conviction-known-date-form-known-date-supplemental">
+  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-supplemental steps-conviction-known-date-form-known-date-hint">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
     </legend>

--- a/features/fixtures/files/steps_conviction_known_date_with_errors.html
+++ b/features/fixtures/files/steps_conviction_known_date_with_errors.html
@@ -4,39 +4,48 @@
       <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
     </legend>
 
-<div id="steps-conviction-known-date-form-known-date-supplemental"><p class="govuk-body-m">This is usually the day you were convicted in court.
-</p></div>
+    <div id="steps-conviction-known-date-form-known-date-supplemental">
+      <p class="govuk-body-m">This is usually the day you were convicted in court.</p>
+    </div>
 
-<div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
-<p>For example, 23 9 2018</p>
+    <div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
+      <p>For example, 23 9 2018</p>
+    </div>
+
+    <p class="govuk-error-message" id="steps-conviction-known-date-form-known-date-error"><span class="govuk-visually-hidden">Error: </span>Enter the date in the format dd/mm/yyyy</p>
+    <div class="govuk-date-input">
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="steps-conviction-known-date-form-known-date-field-error">Day</label>
+          <input id="steps-conviction-known-date-form-known-date-field-error" class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" name="steps_conviction_known_date_form[known_date(3i)]" type="text" inputmode="numeric" maxlength="2">
+        </div>
+      </div>
+
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_2i">Month</label>
+          <input id="steps_conviction_known_date_form_known_date_2i" class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" name="steps_conviction_known_date_form[known_date(2i)]" type="text" inputmode="numeric" maxlength="2">
+        </div>
+      </div>
+
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_1i">Year</label>
+          <input id="steps_conviction_known_date_form_known_date_1i" class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--error" name="steps_conviction_known_date_form[known_date(1i)]" type="text" inputmode="numeric" maxlength="4">
+        </div>
+      </div>
+    </div>
+  </fieldset>
 </div>
 
-<p class="govuk-error-message" id="steps-conviction-known-date-form-known-date-error"><span class="govuk-visually-hidden">Error: </span>Enter the date in the format dd/mm/yyyy</p>
-  <div class="govuk-date-input">
-    <div class="govuk-date-input__item">
-      <div class="govuk-form-group">
-        <label class="govuk-label govuk-date-input__label" for="steps-conviction-known-date-form-known-date-field-error">Day</label>
-        <input id="steps-conviction-known-date-form-known-date-field-error" class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" name="steps_conviction_known_date_form[known_date(3i)]" type="text" inputmode="numeric" maxlength="2">
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-visually-hidden">Approximate date</legend>
+    <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+      <div class="govuk-checkboxes__item">
+        <input id="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-checkboxes__input" type="checkbox" value="true" name="steps_conviction_known_date_form[approximate_known_date]">
+        <label for="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-label govuk-checkboxes__label">This is not the exact date</label>
       </div>
     </div>
-
-    <div class="govuk-date-input__item">
-      <div class="govuk-form-group">
-        <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_2i">Month</label>
-        <input id="steps_conviction_known_date_form_known_date_2i" class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" name="steps_conviction_known_date_form[known_date(2i)]" type="text" inputmode="numeric" maxlength="2">
-      </div>
-    </div>
-
-    <div class="govuk-date-input__item">
-      <div class="govuk-form-group">
-        <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_1i">Year</label>
-        <input id="steps_conviction_known_date_form_known_date_1i" class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--error" name="steps_conviction_known_date_form[known_date(1i)]" type="text" inputmode="numeric" maxlength="4">
-      </div>
-    </div>
-  </div>
-</fieldset>
+  </fieldset>
 </div>
-
-<div class="govuk-form-group"><fieldset class="govuk-fieldset"><legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-visually-hidden">Approximate date</legend><div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
-  <div class="govuk-checkboxes__item"><input id="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-checkboxes__input" type="checkbox" value="true" name="steps_conviction_known_date_form[approximate_known_date]"><label for="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-label govuk-checkboxes__label">This is not the exact date</label></div>
-</div></fieldset></div>

--- a/features/fixtures/files/steps_conviction_known_date_with_errors.html
+++ b/features/fixtures/files/steps_conviction_known_date_with_errors.html
@@ -4,48 +4,39 @@
       <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
     </legend>
 
-    <div id="steps-conviction-known-date-form-known-date-supplemental">
-      <p class="govuk-body-m">This is usually the day you were convicted in court.</p>
-    </div>
+<div id="steps-conviction-known-date-form-known-date-supplemental"><p class="govuk-body-m">This is usually the day you were convicted in court.
+</p></div>
 
-    <div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
-      <p>For example, 23 9 2018</p>
-    </div>
-
-    <p class="govuk-error-message" id="steps-conviction-known-date-form-known-date-error"><span class="govuk-visually-hidden">Error: </span>Enter the date in the format dd/mm/yyyy</p>
-    <div class="govuk-date-input">
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="steps-conviction-known-date-form-known-date-field-error">Day</label>
-          <input id="steps-conviction-known-date-form-known-date-field-error" class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" name="steps_conviction_known_date_form[known_date(3i)]" type="text" inputmode="numeric" maxlength="2">
-        </div>
-      </div>
-
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_2i">Month</label>
-          <input id="steps_conviction_known_date_form_known_date_2i" class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" name="steps_conviction_known_date_form[known_date(2i)]" type="text" inputmode="numeric" maxlength="2">
-        </div>
-      </div>
-
-      <div class="govuk-date-input__item">
-        <div class="govuk-form-group">
-          <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_1i">Year</label>
-          <input id="steps_conviction_known_date_form_known_date_1i" class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--error" name="steps_conviction_known_date_form[known_date(1i)]" type="text" inputmode="numeric" maxlength="4">
-        </div>
-      </div>
-    </div>
-  </fieldset>
+<div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
+<p>For example, 23 9 2018</p>
 </div>
 
-<div class="govuk-form-group">
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-visually-hidden">Approximate date</legend>
-    <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
-      <div class="govuk-checkboxes__item">
-        <input id="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-checkboxes__input" type="checkbox" value="true" name="steps_conviction_known_date_form[approximate_known_date]">
-        <label for="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-label govuk-checkboxes__label">This is not the exact date</label>
+<p class="govuk-error-message" id="steps-conviction-known-date-form-known-date-error"><span class="govuk-visually-hidden">Error: </span>Enter the date in the format dd/mm/yyyy</p>
+  <div class="govuk-date-input">
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="steps-conviction-known-date-form-known-date-field-error">Day</label>
+        <input id="steps-conviction-known-date-form-known-date-field-error" class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" name="steps_conviction_known_date_form[known_date(3i)]" type="text" inputmode="numeric" maxlength="2">
       </div>
     </div>
-  </fieldset>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_2i">Month</label>
+        <input id="steps_conviction_known_date_form_known_date_2i" class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--error" name="steps_conviction_known_date_form[known_date(2i)]" type="text" inputmode="numeric" maxlength="2">
+      </div>
+    </div>
+
+    <div class="govuk-date-input__item">
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-date-input__label" for="steps_conviction_known_date_form_known_date_1i">Year</label>
+        <input id="steps_conviction_known_date_form_known_date_1i" class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--error" name="steps_conviction_known_date_form[known_date(1i)]" type="text" inputmode="numeric" maxlength="4">
+      </div>
+    </div>
+  </div>
+</fieldset>
 </div>
+
+<div class="govuk-form-group"><fieldset class="govuk-fieldset"><legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-visually-hidden">Approximate date</legend><div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+  <div class="govuk-checkboxes__item"><input id="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-checkboxes__input" type="checkbox" value="true" name="steps_conviction_known_date_form[approximate_known_date]"><label for="steps-conviction-known-date-form-approximate-known-date-true-field" class="govuk-label govuk-checkboxes__label">This is not the exact date</label></div>
+</div></fieldset></div>

--- a/features/fixtures/files/steps_conviction_known_date_with_errors.html
+++ b/features/fixtures/files/steps_conviction_known_date_with_errors.html
@@ -1,5 +1,5 @@
 <div class="govuk-form-group govuk-form-group--error app-util--compact-form-group">
-  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-error steps-conviction-known-date-form-known-date-hint steps-conviction-known-date-form-known-date-supplemental">
+  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-error steps-conviction-known-date-form-known-date-supplemental steps-conviction-known-date-form-known-date-hint">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
     </legend>

--- a/features/fixtures/files/steps_conviction_known_date_with_errors.html
+++ b/features/fixtures/files/steps_conviction_known_date_with_errors.html
@@ -1,13 +1,12 @@
 <div class="govuk-form-group govuk-form-group--error app-util--compact-form-group">
-  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-error steps-conviction-known-date-form-known-date-supplemental steps-conviction-known-date-form-known-date-hint">
+  <fieldset class="govuk-fieldset" aria-describedby="steps-conviction-known-date-form-known-date-error steps-conviction-known-date-form-known-date-hint">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
       <h1 class="govuk-fieldset__heading"><span class="govuk-caption-xl">Bind over</span>When were you given the order?</h1>
     </legend>
 
-<div id="steps-conviction-known-date-form-known-date-supplemental"><p class="govuk-body-m">This is usually the day you were convicted in court.
-</p></div>
-
-<div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
+<div class="govuk-hint" id="steps-conviction-known-date-form-known-date-hint">
+<p>This is usually the day you were convicted in court.
+</p>If you do not know the exact date, you can enter an approximate one. However, if you use an approximate date, your results will be approximate.
 <p>For example, 23 9 2018</p>
 </div>
 

--- a/spec/helpers/custom_form_helpers_spec.rb
+++ b/spec/helpers/custom_form_helpers_spec.rb
@@ -85,6 +85,36 @@ RSpec.describe CustomFormHelpers, type: :helper do
     end
   end
 
+  describe "#i18n_date_hint" do
+    let(:found_key) { "hint text about dates" }
+
+    before do
+      allow(I18n).to receive(:t).with(
+        "helpers/dictionary.date_hint_text",
+      ).and_return(found_key)
+    end
+
+    describe "with lead_text argument" do
+      it "seeks the expected key" do
+        expect(found_key).to receive(:html_safe)
+
+        builder.i18n_date_hint("lead text")
+      end
+
+      it "wraps lead text in p tags" do
+        expect(builder.i18n_date_hint("lead text")).to include "<p>lead text</p>"
+      end
+    end
+
+    describe "without lead_text argument" do
+      it "gets lead text from i18n_lead_text" do
+        allow(builder).to receive(:i18n_lead_text).and_return "i18n_lead_text"
+
+        expect(builder.i18n_date_hint).to include "<p>i18n_lead_text</p>"
+      end
+    end
+  end
+
   describe "#i18n_hint" do
     let(:found_locale) { instance_double("locale") }
 


### PR DESCRIPTION
The govuk_design_system_formbuilder gem allows for supplemental text to be added to a form element. An `aria-described-by` hint is added to the fieldset, but it is not in the same order that the text is displayed on the page which causes confusion when using a screen reader.

This change adds the supplemental text as part of the hint to avoid this confusion.