### PR TITLE
Enable build and deploy from PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,7 +158,7 @@ jobs:
           webapp="${{ vars.ECR_URL }}:$SHA"
 
   notify-qa:
-    needs: [build, deploy-staging]
+    needs: [build, deploy-qa]
     uses: ./.github/workflows/notification.yml
     secrets:
       webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,15 @@
 name: Deploy Workflow
 
 on:
-  workflow_dispatch:
   workflow_call:
 
 env:
   PREFIX: "dc"
   SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+  KUBE_CERT: ${{ secrets.KUBE_CERT }}
+  KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+  KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -15,6 +18,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    outputs:
+      build_tag: ${{ steps.vars.outputs.build_tag }}
 
     permissions:
       id-token: write # This is required for requesting the JWT
@@ -65,12 +71,6 @@ jobs:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
 
-    env:
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -84,14 +84,6 @@ jobs:
       - name: Login to container repository
         uses: aws-actions/amazon-ecr-login@v2
         id: login-ecr
-
-      - name: Store build tag
-        id: vars
-        run: |
-          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          short_sha=$(git rev-parse --short $SHA)
-          build_tag=$PREFIX-$branch-$short_sha
-          echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
 
       - name: Tag build and push to ECR
         run: |
@@ -113,34 +105,14 @@ jobs:
           deployment/disclosure-checker-staging \
           webapp="${{ vars.ECR_URL }}:$SHA"
 
-      - name: Send deploy notification to product Slack channel
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Staging*",
-                  "fields": [
-                    {
-                      "title": "Project",
-                      "value": "Disclosure Checker",
-                      "short": true
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "text": "Visit Job",
-                      "type": "button",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+  notify-staging:
+    needs: [build, deploy-staging]
+    uses: ./.github/workflows/notification.yml
+    secrets:
+      webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      build_tag: ${{ needs.build.outputs.build_tag }}
+      environment: Staging
 
   deploy-qa:
     runs-on: ubuntu-latest
@@ -150,12 +122,6 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
-
-    env:
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
 
     steps:
       - name: Checkout
@@ -170,14 +136,6 @@ jobs:
       - name: Login to container repository
         uses: aws-actions/amazon-ecr-login@v2
         id: login-ecr
-
-      - name: Store build tag
-        id: vars
-        run: |
-          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          short_sha=$(git rev-parse --short $SHA)
-          build_tag=$PREFIX-$branch-$short_sha
-          echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
 
       - name: Tag build and push to ECR
         run: |
@@ -199,34 +157,14 @@ jobs:
           deployment/disclosure-checker-qa \
           webapp="${{ vars.ECR_URL }}:$SHA"
 
-      - name: Send deploy notification to product Slack channel
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *QA*",
-                  "fields": [
-                    {
-                      "title": "Project",
-                      "value": "Disclosure Checker",
-                      "short": true
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "text": "Visit Job",
-                      "type": "button",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+  notify-qa:
+    needs: [build, deploy-staging]
+    uses: ./.github/workflows/notification.yml
+    secrets:
+      webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      build_tag: ${{ needs.build.outputs.build_tag }}
+      environment: QA
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -237,12 +175,6 @@ jobs:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
-
-    env:
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
 
     steps:
       - name: Checkout
@@ -257,14 +189,6 @@ jobs:
       - name: Login to container repository
         uses: aws-actions/amazon-ecr-login@v2
         id: login-ecr
-
-      - name: Store build tag
-        id: vars
-        run: |
-          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          short_sha=$(git rev-parse --short $SHA)
-          build_tag=$PREFIX-$branch-$short_sha
-          echo "build_tag=$build_tag" >> $GITHUB_OUTPUT
 
       - name: Tag build and push to ECR
         run: |
@@ -286,60 +210,20 @@ jobs:
           deployment/disclosure-checker-production \
           webapp="${{ vars.ECR_URL }}:$SHA"
 
-      - name: Send deploy notification to product Slack channel
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Production*",
-                  "fields": [
-                    {
-                      "title": "Project",
-                      "value": "Disclosure Checker",
-                      "short": true
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "text": "Visit Job",
-                      "type": "button",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+  notify-production:
+    needs: [build, deploy-production]
+    uses: ./.github/workflows/notification.yml
+    secrets:
+      webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      build_tag: ${{ needs.build.outputs.build_tag }}
+      environment: Production
 
-      - name: Send deploy notification to product Slack channel
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#1d990c",
-                  "text": "${{ github.actor }} deployed *${{ steps.vars.outputs.build_tag }}* to *Production*",
-                  "fields": [
-                    {
-                      "title": "Project",
-                      "value": "Disclosure Checker",
-                      "short": true
-                    }
-                  ],
-                  "actions": [
-                    {
-                      "text": "Visit Job",
-                      "type": "button",
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+  notify-production-2:
+    needs: [build, deploy-production]
+    uses: ./.github/workflows/notification.yml
+    secrets:
+      webhook_url: ${{ secrets.PROD_SLACK_WEBHOOK_URL }}
+    with:
+      build_tag: ${{ needs.build.outputs.build_tag }}
+      environment: Production

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -1,0 +1,43 @@
+name: Notification Workflow
+
+on:
+  workflow_call:
+    secrets:
+      webhook_url:
+        required: true
+    inputs:
+      build_tag:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    name: "notify-${{ inputs.environment }}"
+
+    steps:
+      - name: Slack notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.webhook_url }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#1d990c",
+                  "text": "${{ github.actor }} deployed *${{ inputs.build_tag }}* to *${{ inputs.environment }}*",
+                  "fields": [
+                    {
+                      "title": "Project",
+                      "value": "Disclosure Checker",
+                      "short": true
+                    }
+                  ],
+                  "footer": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                }
+              ]
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test Workflow
+name: CI Workflow
 on:
   pull_request:
   push:
@@ -59,8 +59,7 @@ jobs:
           minimum_suite_coverage: 100
           minimum_file_coverage: 100
 
-  call-build-and-deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
+  build-and-deploy:
     needs: test
     uses: ./.github/workflows/deploy.yml
     secrets: inherit


### PR DESCRIPTION
Every commit to a PR will now build the app ready to deploy. This means that a deploy can be made from the PR checks.

Also removes duplicated code to create build tag and send slack notifications.