### PR TITLE
CDPT-2458 Fix prison and suspended sentence rehabilitation dates

### DIFF
--- a/app/services/calculators/sentence_calculator.rb
+++ b/app/services/calculators/sentence_calculator.rb
@@ -42,7 +42,7 @@ module Calculators
       if disclosure_check.schedule18_over_4_years?
         ResultsVariant::NEVER_SPENT
       else
-        conviction_end_date.advance(rehabilitation_period)
+        conviction_end_date
       end
     end
 
@@ -55,9 +55,9 @@ module Calculators
 
   private
 
-    # The day before the end date, thus we subtract 1 day.
+    #   # The day before the end date, thus we subtract 1 day.
     def conviction_end_date
-      super.advance(days: -1)
+      super.advance(rehabilitation_period)
     end
   end
 end

--- a/app/services/calculators/sentence_calculator.rb
+++ b/app/services/calculators/sentence_calculator.rb
@@ -42,7 +42,7 @@ module Calculators
       if disclosure_check.schedule18_over_4_years?
         ResultsVariant::NEVER_SPENT
       else
-        conviction_end_date
+        conviction_end_date.advance(rehabilitation_period)
       end
     end
 
@@ -51,13 +51,6 @@ module Calculators
     #
     def valid?
       conviction_length_in_months <= self.class::UPPER_LIMIT_MONTHS
-    end
-
-  private
-
-    #   # The day before the end date, thus we subtract 1 day.
-    def conviction_end_date
-      super.advance(rehabilitation_period)
     end
   end
 end

--- a/features/adults/conviction_custodial_sentence.feature
+++ b/features/adults/conviction_custodial_sentence.feature
@@ -23,8 +23,8 @@ Feature: Conviction
 
     Examples:
       | subtype                   | known_date_header            | length_type_header                                                    | length_header                        | result                                           |
-      | Prison sentence           | When did the sentence start? | Was the length of the sentence given in days, weeks, months or years? | What was the length of the sentence? | This conviction will be spent on 31 October 2025 |
-      | Suspended prison sentence | When did the sentence start? | Was the length of the sentence given in days, weeks, months or years? | What was the length of the sentence? | This conviction will be spent on 31 October 2025 |
+      | Prison sentence           | When did the sentence start? | Was the length of the sentence given in days, weeks, months or years? | What was the length of the sentence? | This conviction will be spent on 1 November 2025 |
+      | Suspended prison sentence | When did the sentence start? | Was the length of the sentence given in days, weeks, months or years? | What was the length of the sentence? | This conviction will be spent on 1 November 2025 |
 
 
   @happy_path

--- a/features/youth/conviction_custodial_sentence.feature
+++ b/features/youth/conviction_custodial_sentence.feature
@@ -23,8 +23,8 @@ Feature: Conviction
 
     Examples:
       | subtype                            | known_date_header             | length_type_header                                                     | length_header                         | result                                             |
-      | Detention and training order (DTO) | When did the DTO start?       | Was the length of the DTO given in days, weeks, months or years?       | What was the length of the DTO?       | This conviction will be spent on 11 September 2023 |
-      | Detention                          | When did the detention start? | Was the length of the detention given in days, weeks, months or years? | What was the length of the detention? | This conviction will be spent on 11 September 2023 |
+      | Detention and training order (DTO) | When did the DTO start?       | Was the length of the DTO given in days, weeks, months or years?       | What was the length of the DTO?       | This conviction will be spent on 12 September 2023 |
+      | Detention                          | When did the detention start? | Was the length of the detention given in days, weeks, months or years? | What was the length of the detention? | This conviction will be spent on 12 September 2023 |
 
   @happy_path
   Scenario Outline: Hospital orders

--- a/spec/presenters/check_answers_presenter_spec.rb
+++ b/spec/presenters/check_answers_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CheckAnswersPresenter do
         expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
         expect(summary[0].number).to be(1)
         expect(summary[0].check_group).to eql(disclosure_check.check_group)
-        expect(summary[0].spent_date).to eq(Date.new(2019, 7, 1))
+        expect(summary[0].spent_date).to eq(Date.new(2019, 7, 2))
       end
     end
 

--- a/spec/presenters/results_presenter_spec.rb
+++ b/spec/presenters/results_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ResultsPresenter do
         expect(summary[0]).to be_an_instance_of(CheckGroupPresenter)
         expect(summary[0].number).to be(1)
         expect(summary[0].check_group).to eql(disclosure_check.check_group)
-        expect(summary[0].spent_date).to eq(Date.new(2019, 7, 1))
+        expect(summary[0].spent_date).to eq(Date.new(2019, 7, 2))
       end
     end
 

--- a/spec/services/calculators/multiples/multiple_offenses_calculator_scenarios_spec.rb
+++ b/spec/services/calculators/multiples/multiple_offenses_calculator_scenarios_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
     end
 
     it "returns the date for the first proceeeding" do
-      expect(calculator.spent_date_for(first_proceedings)).to eq(Date.new(2011, 12, 9))
+      expect(calculator.spent_date_for(first_proceedings)).to eq(Date.new(2011, 12, 10))
     end
 
     it "returns indefinite for the second proceeding" do
@@ -195,11 +195,11 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
     end
 
     it "returns the date for the first proceeeding" do
-      expect(calculator.spent_date_for(first_proceedings)).to eq(Date.new(2017, 4, 30))
+      expect(calculator.spent_date_for(first_proceedings)).to eq(Date.new(2017, 5, 1))
     end
 
     it "returns indefinite for the second proceeding" do
-      expect(calculator.spent_date_for(second_proceedings)).to eq(Date.new(2017, 4, 30))
+      expect(calculator.spent_date_for(second_proceedings)).to eq(Date.new(2017, 5, 1))
     end
   end
 
@@ -247,7 +247,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
     end
 
     it "returns the date for the first proceeeding" do
-      expect(calculator.spent_date_for(first_proceedings)).to eq(Date.new(2016, 8, 19))
+      expect(calculator.spent_date_for(first_proceedings)).to eq(Date.new(2016, 8, 20))
     end
 
     it "returns indefinite for the second proceeding" do
@@ -453,7 +453,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
 
       # This becomes spent on 7 August 2013 as long as he is not convicted of a further offence during this time.
       it "returns the date for the forth proceeding" do
-        expect(calculator.spent_date_for(forth_proceedings)).to eq(Date.new(2013, 8, 6))
+        expect(calculator.spent_date_for(forth_proceedings)).to eq(Date.new(2013, 8, 7))
       end
     end
   end
@@ -520,9 +520,9 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
     end
 
     it "dates" do
-      expect(calculator.spent_date_for(first_proceedings)).to eq(Date.new(2009, 2, 28))
-      expect(calculator.spent_date_for(second_proceedings)).to eq(Date.new(2009, 2, 28))
-      expect(calculator.spent_date_for(third_proceedings)).to eq(Date.new(2009, 2, 28))
+      expect(calculator.spent_date_for(first_proceedings)).to eq(Date.new(2009, 3, 1))
+      expect(calculator.spent_date_for(second_proceedings)).to eq(Date.new(2009, 3, 1))
+      expect(calculator.spent_date_for(third_proceedings)).to eq(Date.new(2009, 3, 1))
     end
   end
 
@@ -592,7 +592,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
     end
 
     it "returns the date for the second proceeding" do
-      expect(calculator.spent_date_for(second_proceedings)).to eq(Date.new(2019, 12, 31))
+      expect(calculator.spent_date_for(second_proceedings)).to eq(Date.new(2020, 1, 1))
     end
   end
 
@@ -607,7 +607,7 @@ RSpec.describe Calculators::Multiples::MultipleOffensesCalculator do
     let(:third_conviction_date) { Date.new(2014, 7, 1) }
     let(:fourth_conviction_date) { Date.new(2016, 6, 30) }
 
-    let(:spent_date) { Date.new(2018, 6, 29) }
+    let(:spent_date) { Date.new(2018, 6, 30) }
 
     let(:third_proceeding_group) { disclosure_report.check_groups.build }
     let(:fourth_proceeding_group) { disclosure_report.check_groups.build }


### PR DESCRIPTION
**Description**

  Prison sentence & Suspended Prison sentence rehabilitation date end is incorrect. 
  For both these sentences an extra day needs to be added so for example instead of ending on 31st will end on the 1st.

**Jira ticket**

  https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1152?selectedIssue=CDPT-2458