### PR TITLE
Install capybara-lockstep gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ end
 group :test do
   gem "brakeman"
   gem "capybara"
+  gem "capybara-lockstep"
   gem "cucumber", "< 10.0.0"
   gem "cucumber-rails", require: false
   gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-lockstep (2.2.3)
+      activesupport (>= 4.2)
+      capybara (>= 3.0)
+      ruby2_keywords
+      selenium-webdriver (>= 4.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.4)
@@ -356,6 +361,7 @@ GEM
     rubocop-rspec (3.3.0)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -437,6 +443,7 @@ DEPENDENCIES
   binding_of_caller
   brakeman
   capybara
+  capybara-lockstep
   cucumber (< 10.0.0)
   cucumber-rails
   debug

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -19,6 +19,8 @@
 
   <meta property="og:image" content="<%= asset_path '/assets/govuk-frontend/govuk/assets/images/govuk-opengraph-image.png' %>">
 
+  <%= capybara_lockstep if defined?(Capybara::Lockstep) %>
+
   <%= yield :head %>
 </head>
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,7 +12,7 @@ Capybara.register_driver(:chrome_headless) do |app|
   args = %w[disable-gpu no-sandbox]
   args << "headless" unless ENV["SHOW_BROWSER"]
 
-  options = Selenium::WebDriver::Chrome::Options.new(args:)
+  options = Selenium::WebDriver::Chrome::Options.new(unhandled_prompt_behavior: "ignore", args:)
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
 end


### PR DESCRIPTION
Added the capybara-lockstep gem to fix failing cucumber tests due to a chromedriver behavioural change.