### PR TITLE
CDPT-2833: Update GOV.UK header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby File.read(".ruby-version").strip
 
-gem "govuk-components", "~> 5.8"
+gem "govuk-components", "~> 5.11.1"
 gem "govuk_design_system_formbuilder"
 gem "jquery-rails"
 gem "ostruct"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,10 +165,10 @@ GEM
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    govuk-components (5.8.0)
+    govuk-components (5.11.1)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 10)
-      view_component (>= 3.18, < 3.22)
+      view_component (>= 3.18, < 3.24)
     govuk_design_system_formbuilder (5.7.1)
       actionview (>= 6.1)
       activemodel (>= 6.1)
@@ -242,7 +242,7 @@ GEM
     nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.1)
-    pagy (9.3.3)
+    pagy (9.3.5)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -417,9 +417,9 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
     useragent (0.16.11)
-    view_component (3.21.0)
+    view_component (3.23.2)
       activesupport (>= 5.2.0, < 8.1)
-      concurrent-ruby (~> 1.0)
+      concurrent-ruby (~> 1)
       method_source (~> 1.0)
     virtus (2.0.0)
       axiom-types (~> 0.1)
@@ -449,7 +449,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   factory_bot_rails
-  govuk-components (~> 5.8)
+  govuk-components (~> 5.11.1)
   govuk_design_system_formbuilder
   i18n-debug
   i18n-tasks

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -1,6 +1,6 @@
 <%= yield :top_of_page %>
 <!DOCTYPE html>
-<html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>" class="govuk-template app-html-class">
+<html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>" class="govuk-template--rebranded app-html-class">
 
 <head>
   <meta charset="utf-8"/>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "^5.8.0"
+    "govuk-frontend": "^5.11.1"
   }
 }

--- a/spec/features/feedback_link_spec.rb
+++ b/spec/features/feedback_link_spec.rb
@@ -3,9 +3,8 @@ require "rails_helper"
 RSpec.feature "feedback_link", type: :feature do
   scenario "User clicks the feedback link and sees the feedback page" do
     visit root_path
-    expect(page).to have_link("feedback", href: "https://www.smartsurvey.co.uk/s/FNZI5U/")
 
-    link = find_link("feedback")
-    expect(link[:href]).to include("https://www.smartsurvey.co.uk")
+    link = find_link(text: "feedback")
+    expect(link[:href]).to include("https://www.smartsurvey.co.uk/s/FNZI5U/")
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-govuk-frontend@^5.8.0:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.8.0.tgz#da1b03cb4f2ba1f6036be0dac3c5327c3405174c"
-  integrity sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==
+govuk-frontend@^5.11.1:
+  version "5.11.1"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.11.1.tgz#06cd64d2bbe0bfd26aa8ce393a348bff14c59f4f"
+  integrity sha512-hJJFpaer4MZLvz/2F9RZ7xZ6FqlzpxL9aw6YWOGK3F1tn419xj2WcVXwOC8Bcj/dc/LanknbWJDGkb+IdkuhTQ==


### PR DESCRIPTION
Update GOV header component with the new component. 

**Before**
<img width="1086" height="372" alt="Screenshot 2025-07-28 at 18 37 06" src="https://github.com/user-attachments/assets/7f7d20c5-aca5-4ef5-9e27-bbd86729f1d3" />


**After**
<img width="1215" height="375" alt="Screenshot 2025-07-28 at 18 31 44" src="https://github.com/user-attachments/assets/357aa43e-3ee0-473a-bde2-36dcfadbe234" />


> [!NOTE]  
> **govuk-components introduced a breaking change to update header and footer components in v5.11.0**
> https://github.com/x-govuk/govuk-components/releases/tag/v5.11.0