### PR TITLE
CDPT-2948 Switch notification banner and breadcrumb positions

### DIFF
--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -40,9 +40,9 @@
 
 <div class="govuk-width-container app-width-container--wide">
   <%= yield(:phase_banner) %>
-  <%= yield(:notification_banner) %>
   <%= yield(:back_link) %>
-
+  <%= yield(:notification_banner) %>
+  
   <main class="govuk-main-wrapper app-main-class" id="main-content" role="main">
     <%= yield(:content) %>
   </main>


### PR DESCRIPTION
### Description:

Currently the notification banner is between the Phase banner and breadcrumb area.  Visually this shows as the top of the banner butting up to the phase banner without a margin of separation.

<img width="704" height="375" alt="notification-before" src="https://github.com/user-attachments/assets/c61d22e7-0c4c-4967-84bc-ef29c61689c2" />

The notification and breadcrumb areas need to be swapped like so:

<img width="704" height="358" alt="notification-after" src="https://github.com/user-attachments/assets/9c3498c7-df3f-460f-944e-cdb64f8f8edd" />

### Jira ticket:
https://dsdmoj.atlassian.net/browse/CDPT-2948
